### PR TITLE
feat(wsl): WSL development support (line-ending guard · preflight · install guide)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,31 @@
+# =============================================================================
+# BATHOS — line-ending policy
+# -----------------------------------------------------------------------------
+# The repo is Linux/macOS-primary and also runs under **WSL** (Windows Subsystem
+# for Linux). Shell scripts MUST stay LF: a CRLF inside a `#!/usr/bin/env bash`
+# shebang makes WSL/Linux fail with `bad interpreter: /usr/bin/env bash^M`.
+# Windows git (core.autocrlf=true) would otherwise rewrite them to CRLF on
+# checkout — these rules prevent that so a Windows clone still runs in WSL.
+# =============================================================================
+
+# Normalize text by default and commit as LF.
+* text=auto eol=lf
+
+# Shell scripts — always LF (critical for WSL / Linux / macOS execution).
+*.sh   text eol=lf
+*.bash text eol=lf
+
+# PowerShell scripts — UTF-8 (with BOM); keep LF (PowerShell 5.1+/7 read either
+# EOL, and the BOM is what 5.1 needs to decode UTF-8 correctly, not the EOL).
+*.ps1  text eol=lf
+
+# Binary assets — never apply EOL conversion.
+*.png    binary
+*.jpg    binary
+*.jpeg   binary
+*.gif    binary
+*.ico    binary
+*.pdf    binary
+*.bundle binary
+*.woff   binary
+*.woff2  binary

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ BATHOS turns a **single Claude Code session into a disciplined product team** �
 | **Use case** — build a new service step by step | [`docs/USECASE-en.md`](docs/USECASE-en.md) | [`docs/USECASE-kr.md`](docs/USECASE-kr.md) | [`docs/USECASE-es.md`](docs/USECASE-es.md) | Start here: a hands-on walkthrough (adopt into your own project, build "ReadShelf" end-to-end) |
 | **Features & operating principles** | [`docs/FEATURES-en.md`](docs/FEATURES-en.md) | [`docs/FEATURES-kr.md`](docs/FEATURES-kr.md) | [`docs/FEATURES-es.md`](docs/FEATURES-es.md) | What makes BATHOS distinctive and how the engine works under the hood |
 | **Usage guide** | [`docs/USAGE-en.md`](docs/USAGE-en.md) | [`docs/USAGE-kr.md`](docs/USAGE-kr.md) | [`docs/USAGE-es.md`](docs/USAGE-es.md) | Reference: install, CLI, waves, gates, hooks, troubleshooting |
+| **Install guides** — per platform | *(see USAGE-en §1)* | [`macOS/Linux`](docs/macos-linux-install-kr.md) · [`Windows (PowerShell)`](docs/windows-install-kr.md) · [`Windows (WSL)`](docs/wsl-install-kr.md) | *(see USAGE-es §1)* | Platform-specific setup: prerequisites, engine build, `install.sh`/`install.ps1`, verification, troubleshooting |
 | **Token & quota management** | [`docs/QUOTA-en.md`](docs/QUOTA-en.md) | [`docs/QUOTA-kr.md`](docs/QUOTA-kr.md) | [`docs/QUOTA-es.md`](docs/QUOTA-es.md) | Control cost, sequence waves, recover from usage limits |
 | **Custom module authoring** | [`docs/MODULE-GUIDE-en.md`](docs/MODULE-GUIDE-en.md) | [`docs/MODULE-GUIDE-kr.md`](docs/MODULE-GUIDE-kr.md) | [`docs/MODULE-GUIDE-es.md`](docs/MODULE-GUIDE-es.md) | Write your own plugin (module.yaml, trigger DSL, W4) without touching the core |
 | **Role customization** | [`docs/ROLE-GUIDE-en.md`](docs/ROLE-GUIDE-en.md) | [`docs/ROLE-GUIDE-kr.md`](docs/ROLE-GUIDE-kr.md) | [`docs/ROLE-GUIDE-es.md`](docs/ROLE-GUIDE-es.md) | Adapt the 17 roles via the 3-layer override (base → team → user) |
@@ -109,7 +110,7 @@ You mostly type **slash commands** (e.g. `/wave1-discovery`). The `bathos` binar
 
 ### 1. Get the code & build the engine
 
-Dedicated install guides per platform: **macOS / Linux → [`docs/macos-linux-install-kr.md`](docs/macos-linux-install-kr.md)** · **Windows → [`docs/windows-install-kr.md`](docs/windows-install-kr.md)** (both Korean). The quick paths for each are below.
+Dedicated install guides per platform: **macOS / Linux → [`docs/macos-linux-install-kr.md`](docs/macos-linux-install-kr.md)** · **Windows (native PowerShell) → [`docs/windows-install-kr.md`](docs/windows-install-kr.md)** · **Windows (WSL) → [`docs/wsl-install-kr.md`](docs/wsl-install-kr.md)** (Korean). The quick paths for each are below.
 
 #### On macOS / Linux
 
@@ -151,6 +152,23 @@ $env:BATHOS_BIN = "$PWD\core\target\release\bathos.exe"
 **How the cross-platform wiring works:** the committed `.claude/settings.json` points hooks at the bash `.sh` scripts (macOS/Linux). On Windows, `install.ps1 -Into <dir>` copies `.claude/settings.windows.json` (every hook → `.ps1`, each with `"shell": "powershell"`) over the target's `.claude/settings.json`, so the target runs the PowerShell hooks. Claude Code spawns those hooks with `-ExecutionPolicy Bypass` at process scope, so no machine policy change is needed. Both hook trees (`*.sh` and `*.ps1`) ship in `.claude/hooks/`.
 
 **➜ Full Windows install guide (Korean):** [`docs/windows-install-kr.md`](docs/windows-install-kr.md) — prerequisites, `install.ps1` flags, install-time OS dispatch, `BATHOS_BIN`/PATH, verification, troubleshooting, and bash-vs-PowerShell behavior notes.
+
+#### On Windows via WSL (Windows Subsystem for Linux)
+
+WSL is a Linux environment, so BATHOS runs there as the **bash version** — the Linux `bathos` binary and the `.sh` hooks (not the `.ps1` PowerShell port). Work entirely **inside WSL** (Claude Code, Rust, and the clone all in WSL):
+
+```bash
+# Inside your WSL distro (e.g. Ubuntu), in the WSL filesystem (~/…, not /mnt/c):
+git clone <your-fork-url> bathos && cd bathos
+
+./scripts/wsl-setup.sh          # WSL preflight: normalize .sh to LF, chmod +x, check jq/cargo/claude
+cd core && cargo build --release && cd ..   # → core/target/release/bathos (ELF)
+export BATHOS_BIN="$PWD/core/target/release/bathos"
+```
+
+The one WSL gotcha is line endings: a repo cloned on Windows with `core.autocrlf=true` gives `.sh` files CRLF, which breaks the shebang under WSL (`bad interpreter: …bash^M`). The committed **`.gitattributes` forces `.sh` to LF**, and `scripts/wsl-setup.sh` repairs an already-CRLF tree. Then follow the macOS/Linux path above (bash hooks, `install.sh`).
+
+**➜ Full WSL install guide (Korean):** [`docs/wsl-install-kr.md`](docs/wsl-install-kr.md) — WSL prerequisites, the CRLF/line-ending fix, building the Linux engine, `install.sh`, verification, and WSL-specific troubleshooting.
 
 ### 2. Use BATHOS in a project
 
@@ -460,6 +478,6 @@ BATHOS is a separate, independently implemented project and does **not** use the
 <div align="center">
 
 **BATHOS** · βάθος — depth over surface
-한국어 문서: [`docs/USECASE-kr.md`](docs/USECASE-kr.md) · [`docs/FEATURES-kr.md`](docs/FEATURES-kr.md) · [`docs/USAGE-kr.md`](docs/USAGE-kr.md) · [`docs/macos-linux-install-kr.md`](docs/macos-linux-install-kr.md) · [`docs/windows-install-kr.md`](docs/windows-install-kr.md) · [`docs/QUOTA-kr.md`](docs/QUOTA-kr.md) · [`docs/MODULE-GUIDE-kr.md`](docs/MODULE-GUIDE-kr.md) · [`CLAUDE.md`](CLAUDE.md) · [`ETHOS.md`](ETHOS.md)
+한국어 문서: [`docs/USECASE-kr.md`](docs/USECASE-kr.md) · [`docs/FEATURES-kr.md`](docs/FEATURES-kr.md) · [`docs/USAGE-kr.md`](docs/USAGE-kr.md) · [`docs/macos-linux-install-kr.md`](docs/macos-linux-install-kr.md) · [`docs/windows-install-kr.md`](docs/windows-install-kr.md) · [`docs/wsl-install-kr.md`](docs/wsl-install-kr.md) · [`docs/QUOTA-kr.md`](docs/QUOTA-kr.md) · [`docs/MODULE-GUIDE-kr.md`](docs/MODULE-GUIDE-kr.md) · [`CLAUDE.md`](CLAUDE.md) · [`ETHOS.md`](ETHOS.md)
 
 </div>

--- a/docs/wsl-install-kr.md
+++ b/docs/wsl-install-kr.md
@@ -1,0 +1,137 @@
+# BATHOS WSL 설치 가이드 (Windows Subsystem for Linux)
+
+> **BATHOS** — βάθος('깊이·심연'). 이 문서는 **WSL(Windows Subsystem for Linux)에서** BATHOS를 빌드·설치·구동하는 방법을 다룬다.
+> **핵심 한 줄:** WSL은 리눅스 환경이므로 BATHOS는 여기서 **bash 버전**(`.sh` 훅 + 리눅스 `bathos` 바이너리)으로 동작한다 — Windows 네이티브용 PowerShell 포트(`.ps1`)는 WSL에서 **쓰지 않는다**.
+> 순수 macOS/Linux는 [`macos-linux-install-kr.md`](macos-linux-install-kr.md), Windows 네이티브(PowerShell)는 [`windows-install-kr.md`](windows-install-kr.md).
+> 설치 이후 파이프라인 사용법은 플랫폼 공통 — [`USAGE-kr.md`](USAGE-kr.md).
+
+---
+
+## 0. WSL에서는 무엇을 쓰나 (한눈에)
+
+| 항목 | WSL (= 리눅스) |
+|------|----------------|
+| 엔진 바이너리 | `bathos` (**ELF**, WSL 안에서 `cargo build`) — `bathos.exe` 아님 |
+| 훅 스크립트 | `.claude/hooks/*.sh` (bash) — `.ps1` 아님 |
+| 설치기 | `install.sh` (bash) — `install.ps1` 아님 |
+| JSON 파싱 | `jq` (apt로 설치) |
+| settings.json | 커밋된 bash 배선본 그대로(교체 불필요) |
+
+> **왜 PowerShell 포트를 안 쓰나:** WSL 안의 Claude Code는 리눅스 실행환경에서 훅을 bash로 실행한다. `.ps1`/`settings.windows.json`/`install.ps1`은 **Windows 네이티브(PowerShell)** 전용이다. WSL에서는 macOS/Linux와 동일한 경로를 따른다.
+
+---
+
+## 1. 전제 (Prerequisites)
+
+WSL **안에서**(WSL 배포판 셸, 예: Ubuntu) 다음을 준비한다:
+
+- **WSL2** + 리눅스 배포판(Ubuntu 권장). Windows PowerShell에서 `wsl --install` 후 배포판 셸 진입.
+- **Claude Code v2.1.32+** — **WSL 안에** 설치된 것을 사용(Windows 네이티브 Claude Code 아님).
+- **Rust 툴체인** — WSL 안에서 [rustup.rs](https://rustup.rs)로 설치(`curl … | sh`). `cargo --version`으로 확인.
+- **`jq`** — `sudo apt-get update && sudo apt-get install -y jq` (bash 안전 훅의 JSON 파싱에 필요).
+- **Git** — 보통 기본 포함. 없으면 `sudo apt-get install -y git`.
+
+---
+
+## 2. 소스 받기 (⚠️ 줄바꿈 주의)
+
+**WSL 파일시스템 안(`~/…`)에 클론하는 것을 권장**한다(`/mnt/c/…`의 Windows 경로는 I/O가 느리고 권한/줄바꿈 문제가 잦다).
+
+```bash
+cd ~
+git clone <your-fork-url> bathos
+cd bathos
+```
+
+> **최대 함정 — CRLF 줄바꿈:** 저장소를 **Windows 쪽 git으로 클론**했거나 `core.autocrlf=true`이면 `.sh` 파일이 CRLF가 되어 WSL에서 `bad interpreter: /usr/bin/env bash^M` 오류가 난다. 이 저장소는 **`.gitattributes`로 `.sh`를 LF로 강제**하므로 WSL 안에서 클론하면 문제가 없다. 이미 CRLF로 받았다면 §3의 `wsl-setup.sh`가 복구한다.
+
+---
+
+## 3. WSL 프리플라이트 — `scripts/wsl-setup.sh`
+
+WSL 사용 전 한 번 실행한다. `.sh` 줄바꿈을 LF로 정규화하고 실행비트를 부여하며, 의존성·엔진 상태를 점검한다(아무것도 삭제하지 않음, 멱등):
+
+```bash
+./scripts/wsl-setup.sh            # 점검 + 복구
+./scripts/wsl-setup.sh --check    # 점검만(수정 안 함)
+```
+
+출력 예: WSL 감지 여부 · CRLF 파일 정규화 결과 · `cargo`/`jq`/`claude` 유무 · 엔진 바이너리 종류(Windows PE면 경고).
+
+---
+
+## 4. 엔진 빌드 (WSL 안에서 = 리눅스 ELF)
+
+```bash
+cd core
+cargo build --release        # → core/target/release/bathos  (ELF 64-bit)
+cargo test --all             # (선택) 전체 검증
+cd ..
+```
+
+> **주의:** Windows에서 빌드한 `bathos.exe`(PE)를 WSL로 복사해 쓰지 말 것 — WSL에서는 **WSL 안에서 빌드한 ELF `bathos`** 를 쓴다. (`wsl-setup.sh`가 PE를 감지하면 경고한다.)
+
+---
+
+## 5. 엔진 경로 · Agent Teams 플래그
+
+```bash
+export BATHOS_BIN="$PWD/core/target/release/bathos"
+# 영구 설정:  ~/.bashrc 에 위 export 줄 추가
+```
+
+Agent Teams 실험 기능은 배선된 `settings.json`(env)에 이미 켜져 있다. 필요 시 `export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`.
+
+---
+
+## 6. (선택) 타겟 프로젝트 주입 — `install.sh`
+
+WSL에서는 **bash 설치기**를 쓴다(`install.ps1` 아님):
+
+```bash
+./install.sh                                   # 엔진 빌드 + 안내
+./install.sh --into /abs/path/to/your-project  # + .claude/ assets/ modules/ 복사
+#   --force 로 기존 .claude/ 덮어쓰기
+```
+
+커밋된 `.claude/settings.json`(bash 배선)이 그대로 쓰이므로 Windows판 같은 배선 교체는 없다.
+
+---
+
+## 7. 설치 검증
+
+```bash
+"$BATHOS_BIN" --version
+"$BATHOS_BIN" doctor
+bash .claude/hooks/_test-hooks.sh
+
+# 파괴 명령 차단 스모크(2가 나오면 정상):
+echo '{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}' | bash .claude/hooks/careful-guard.sh; echo $?
+```
+
+이후 WSL 안에서 Claude Code를 열고 파이프라인을 구동한다(`/team-kickoff` → `/route` → 웨이브 …). 상세는 [`USAGE-kr.md`](USAGE-kr.md).
+
+---
+
+## 8. 문제 해결 (WSL 특화)
+
+| 증상 | 원인 · 해결 |
+|------|-------------|
+| `bad interpreter: /usr/bin/env bash^M` | `.sh`가 CRLF. `./scripts/wsl-setup.sh`로 LF 복구. 근본적으로는 WSL 안에서 다시 클론(`.gitattributes`가 LF 보장). |
+| `permission denied` (훅/스크립트) | 실행비트 없음. `./scripts/wsl-setup.sh`가 `chmod +x` 부여, 또는 `chmod +x .claude/hooks/*.sh scripts/*.sh install.sh`. |
+| `bathos: cannot execute binary file` / `Exec format error` | Windows용 `bathos.exe`(PE)를 WSL에서 실행 시도. WSL 안에서 `cargo build --release`로 ELF 재빌드. |
+| `jq: command not found` | `sudo apt-get install -y jq`. |
+| 빌드/파일 I/O가 느림 | 프로젝트가 `/mnt/c/…`(Windows 경로)에 있음. WSL 홈(`~/…`)으로 옮기면 빨라진다. |
+| Windows 에디터로 편집 후 훅이 깨짐 | 에디터가 CRLF로 저장. 에디터를 LF로 설정하거나 편집 후 `./scripts/wsl-setup.sh` 실행. |
+
+---
+
+## 9. 세 가지 실행 경로 정리 (참고)
+
+| 환경 | 엔진 | 훅 | 설치기 | 가이드 |
+|------|------|-----|--------|--------|
+| macOS / Linux | `bathos` (ELF/Mach-O) | `.sh` | `install.sh` | [macos-linux-install-kr.md](macos-linux-install-kr.md) |
+| **WSL** | **`bathos` (ELF, WSL 빌드)** | **`.sh`** | **`install.sh`** | **(이 문서)** |
+| Windows 네이티브 | `bathos.exe` | `.ps1` | `install.ps1` | [windows-install-kr.md](windows-install-kr.md) |
+
+세 경로 모두 동일 리포지토리에서 나온다. 두 훅 트리(`*.sh`·`*.ps1`)가 `.claude/hooks/`에 함께 들어있고, `.gitattributes`가 `.sh`를 어느 OS에서 클론하든 LF로 유지한다.

--- a/scripts/wsl-setup.sh
+++ b/scripts/wsl-setup.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# =============================================================================
+# BATHOS — wsl-setup.sh   (WSL 프리플라이트 · 복구)
+# WSL(Windows Subsystem for Linux)에서 BATHOS를 쓰기 전에 한 번 실행한다.
+#
+#   ./scripts/wsl-setup.sh            점검 + 복구(줄바꿈 LF 정규화·실행비트)
+#   ./scripts/wsl-setup.sh --check    점검만(수정하지 않음)
+#
+# 배경: WSL은 리눅스 환경이므로 BATHOS의 **bash 버전(.sh 훅 + 리눅스 `bathos`
+# 바이너리)** 을 그대로 쓴다(Windows PowerShell 포트 .ps1은 WSL에서 불필요).
+# 유일한 함정은 저장소를 **Windows에서 CRLF로 클론**한 경우 — `.sh`의 shebang이
+# `#!/usr/bin/env bash^M`이 되어 `bad interpreter` 오류가 난다. `.gitattributes`가
+# 앞으로는 이를 막지만, 이미 CRLF로 받은 트리를 이 스크립트가 LF로 복구한다.
+#
+# 안전: 아무것도 삭제하지 않는다. .sh 파일의 CR 제거 + 실행비트 부여만 한다(멱등).
+# 이식성: bash 3.2+(macOS 기본) 호환 — mapfile/연관배열 미사용.
+# =============================================================================
+set -uo pipefail
+
+PKG_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_ONLY=0
+[ "${1:-}" = "--check" ] && CHECK_ONLY=1
+
+say()  { printf '\033[0;36m[bathos-wsl]\033[0m %s\n' "$*"; }
+warn() { printf '\033[0;33m[bathos-wsl] ⚠ %s\033[0m\n' "$*" >&2; }
+ok()   { printf '\033[0;32m[bathos-wsl] ✓ %s\033[0m\n' "$*"; }
+
+# 제품 트리의 .sh 파일을 나열(core/target·.git·node_modules 제외).
+list_sh() {
+  find "$PKG_ROOT" -type f -name '*.sh' \
+    -not -path '*/core/target/*' \
+    -not -path '*/.git/*' \
+    -not -path '*/node_modules/*' 2>/dev/null | sort
+}
+
+# --- 1. WSL 여부 안내 (강제는 아님 — 리눅스/macOS에서도 무해하게 동작) -----------
+if grep -qiE '(microsoft|wsl)' /proc/version 2>/dev/null; then
+  say "WSL 환경 감지됨 — BATHOS는 여기서 bash(.sh) 버전으로 동작합니다."
+else
+  say "WSL이 아닌 것 같습니다(순수 Linux/macOS?). 이 스크립트는 그래도 안전하게 동작합니다."
+fi
+
+TOTAL_SH="$(list_sh | wc -l | tr -d ' ')"
+say "검사 대상 .sh: ${TOTAL_SH}개"
+
+# --- 2. CRLF 탐지 + (복구 모드면) LF 정규화 --------------------------------------
+crlf_count=0
+fixed_count=0
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  if LC_ALL=C grep -lq $'\r' "$f" 2>/dev/null; then
+    crlf_count=$((crlf_count + 1))
+    rel="${f#$PKG_ROOT/}"
+    if [ "$CHECK_ONLY" -eq 1 ]; then
+      warn "CRLF: $rel"
+    else
+      tmp="$f.wsl-eol.$$"
+      if tr -d '\r' < "$f" > "$tmp" 2>/dev/null && mv "$tmp" "$f"; then
+        fixed_count=$((fixed_count + 1))
+        ok "LF 정규화: $rel"
+      else
+        rm -f "$tmp" 2>/dev/null || true
+        warn "정규화 실패(권한?): $rel"
+      fi
+    fi
+  fi
+done < <(list_sh)
+
+if [ "$crlf_count" -eq 0 ]; then
+  ok "모든 .sh가 이미 LF입니다(shebang 안전)."
+elif [ "$CHECK_ONLY" -eq 1 ]; then
+  warn "$crlf_count개 파일이 CRLF입니다 — './scripts/wsl-setup.sh'(--check 없이)로 복구하세요."
+else
+  say "$fixed_count개 파일을 LF로 정규화했습니다."
+fi
+
+# --- 3. 실행비트 부여 (복구 모드) ------------------------------------------------
+if [ "$CHECK_ONLY" -eq 0 ]; then
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    [ -x "$f" ] || chmod +x "$f" 2>/dev/null || true
+  done < <(list_sh)
+  ok ".sh 실행비트 확인/부여 완료."
+fi
+
+# --- 4. 의존성 점검 (WSL=리눅스 → apt 안내) --------------------------------------
+say "의존성 점검:"
+if command -v cargo >/dev/null 2>&1; then ok "cargo 있음 ($(cargo --version 2>/dev/null | awk '{print $2}'))"; else warn "Rust 미설치 — https://rustup.rs (WSL 안에서 설치). 엔진 빌드에 필요."; fi
+if command -v jq >/dev/null 2>&1; then ok "jq 있음"; else warn "jq 미설치 — 'sudo apt-get update && sudo apt-get install -y jq' (bash 훅의 JSON 파싱에 필요)."; fi
+if command -v claude >/dev/null 2>&1; then ok "claude CLI 있음"; else warn "Claude Code CLI 미발견 — WSL 안에 설치된 Claude Code로 실행하세요(v2.1.32+)."; fi
+
+# --- 5. 엔진 바이너리 상태 -------------------------------------------------------
+# WSL은 리눅스이므로 네이티브 바이너리는 `bathos`(ELF)다. 실수의 핵심은 Windows에서
+# 빌드한 `bathos.exe`(PE)를 WSL로 들고 오는 것 — OS 무관하게 그 경우만 경고한다.
+LINUX_BIN="$PKG_ROOT/core/target/release/bathos"
+if [ -x "$LINUX_BIN" ]; then
+  btype="$(file "$LINUX_BIN" 2>/dev/null || true)"
+  if printf '%s' "$btype" | grep -qiE 'PE32|MS Windows|MS-DOS'; then
+    warn "core/target/release/bathos 가 Windows 실행파일(PE)로 보입니다 — WSL/리눅스에서는 'cd core && cargo build --release'로 네이티브(ELF) 바이너리를 다시 빌드하세요."
+  else
+    ok "엔진 빌드됨: core/target/release/bathos ($(printf '%s' "$btype" | sed 's/.*: //' | cut -c1-24))"
+  fi
+else
+  say "엔진 미빌드 — WSL 안에서: cd core && cargo build --release  (→ core/target/release/bathos)"
+fi
+
+# --- 6. 다음 단계 ----------------------------------------------------------------
+printf '\n'
+say "다음 단계(WSL):"
+printf '  1) 엔진 빌드:   cd core && cargo build --release && cd ..\n'
+printf '  2) 경로 지정:   export BATHOS_BIN="$PWD/core/target/release/bathos"\n'
+printf '  3) 설치(선택):  ./install.sh --into /abs/path/to/project\n'
+printf '  4) WSL 안에서 Claude Code를 열고 /team-kickoff 부터 진행\n'
+printf '  가이드: docs/wsl-install-kr.md · docs/macos-linux-install-kr.md\n'
+
+exit 0


### PR DESCRIPTION
## 무엇을 / 왜

**WSL(Windows Subsystem for Linux)에서 개발**할 때도 BATHOS를 쓸 수 있게 합니다. WSL은 리눅스 환경이므로 기존 **bash 버전**(리눅스 `bathos` + `.sh` 훅)이 그대로 동작합니다 — PowerShell 포트(`.ps1`)는 WSL에서 쓰지 않습니다. 따라서 새 포트가 아니라 **WSL 견고화 + 설치가이드**가 핵심입니다(엔진/훅 코드 변경 없음 — 훅은 순수 POSIX, 엔진은 이미 크로스플랫폼).

## 변경

- **`.gitattributes`** (신규) — `.sh`를 LF로 강제. Windows에서 `core.autocrlf=true`로 클론 시 CRLF shebang이 WSL에서 `bad interpreter: …bash^M`로 깨지는 최대 함정 차단. `.ps1`은 LF 유지(BOM이 PS 5.1 디코딩 담당).
- **`scripts/wsl-setup.sh`** (신규) — WSL 프리플라이트/복구(멱등): `.sh` LF 정규화·`chmod +x`·`cargo`/`jq`/`claude` 점검·Windows PE 바이너리 오용 감지. bash 3.2 호환.
- **`docs/wsl-install-kr.md`** (신규) — WSL 설치가이드(전제·CRLF 수정·리눅스 ELF 엔진 빌드·`install.sh`·검증·WSL 특화 문제해결 + 3경로 대조표).
- **`README.md`** — "On Windows via WSL" 퀵패스 + 주요 문서 표에 **세 플랫폼 설치가이드 행**(macOS/Linux · Windows PowerShell · Windows WSL) 명시.

## 검증

`.gitattributes` 라인엔딩 churn 0(전 파일 LF) · `wsl-setup.sh --check` 정상 · 기존 ubuntu CI("Safety hooks")가 WSL이 쓰는 bash 경로를 이미 검증. 이 PR에서도 CI(Engine · Safety hooks · Windows) 재실행됨.