### PR TITLE
Release: task-report system (develop → prod)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# BATHOS  session-start.sh  —  SessionStart 훅
+# 세션 시작 시각을 마커 파일에 기록한다. task-report(6항목 중 "작업 시작 시각")의
+# 정확도를 위해 존재한다. generate-task-report.sh 가 이 마커를 최우선으로 읽는다.
+#
+# 마커 : <project>/.agent-team/_state/session-start.marker  (ephemeral·gitignore)
+# 동작 : source(startup/clear) = 새 세션 → 새 시각으로 덮어씀
+#        source(resume/compact) = 진행 중 재개 → 기존 마커 보존(있으면 그대로)
+# 철칙 : fail-safe — 세션 시작을 절대 막지 않으며 항상 exit 0. 날조 금지(실제 시각만).
+# ---------------------------------------------------------------------------
+set +e
+
+PROJ="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+STATE="$PROJ/.agent-team/_state"
+# BATHOS 프로젝트가 아니면(=_state 없음) 조용히 통과
+[ -d "$STATE" ] || exit 0
+
+MARKER="$STATE/session-start.marker"
+IN="$(cat 2>/dev/null)"
+SRC="$(printf '%s' "$IN" | grep -oE '"source"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed -E 's/.*"([^"]+)"$/\1/')"
+NOW="$(date '+%Y-%m-%d %H:%M:%S %Z')"
+
+case "$SRC" in
+  resume|compact)
+    # 진행 중 세션의 연속 — 원래 시작 시각을 유지(없을 때만 기록)
+    [ -s "$MARKER" ] || printf '%s\n' "$NOW" > "$MARKER" ;;
+  *)
+    # startup·clear·미상 — 새 세션의 시작으로 간주하고 갱신
+    printf '%s\n' "$NOW" > "$MARKER" ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -137,6 +137,18 @@
         ]
       }
     ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "SessionEnd": [
       {
         "matcher": "prompt_input_exit|logout|other",

--- a/result_report/.session-content.md
+++ b/result_report/.session-content.md
@@ -14,13 +14,15 @@
   - 파일명 규약 `task_report_YYYYMMDD_HHMMSS_session_noNN.html`, **session_no는 기존 리포트 최대 순번 +1로 자동 incremental**(첫 세션=01).
   - 필수 6항목 포함: 작업 시작/종료 시각·총 소요·핵심 사항·중요 이슈·git commit/push/PR/merge 히스토리(자동 수집).
   - 서술형 항목은 `.session-content.md`에서 로드, git 히스토리는 저장소에서 자동 수집. BATHOS teal 리포트 스타일 준수.
-- **이번 세션 리포트(session_no01) 생성.**
+- **소급 백필(backfill):** `.agent-team/12-report/`의 과거 taskreport 아카이브 11건을 시간순으로 `session_no01~11`로 소급 생성(`backfill-from-archive.sh`). 원본에 기록된 사실만 이관(종료 시각·현재상태·당시 git 라인), 시작시각/소요시간은 "당시 미기록"으로 명시. → 이번 세션은 **session_no12**.
+- **세션 시작 마커 훅 추가:** `SessionStart` 훅(`.claude/hooks/session-start.sh`) 신설 — 세션 시작 시각을 `_state/session-start.marker`에 기록(startup/clear=갱신, resume/compact=보존). `generate-task-report.sh`가 이 마커를 시작시각 최우선 소스로 사용. `settings.json`에 SessionStart 등록. freeze-guard 지문 2건 승인(Paul/hooks).
+- **이번 세션 리포트(session_no12) 생성.**
 <!-- /SUMMARY -->
 
 <!-- ISSUES -->
 - **스냅샷 드리프트:** landing-web에서 `/save` 없이 종료된 세션이 있어 s7 스냅샷이 최신 상태를 반영하지 못함 → 다음 `/save-session` 시 정본화 필요.
 - **push/PR/merge 보류:** 아웃바운드 반영(원격 push·PR·merge)은 명시 요청이 없어 **로컬 커밋까지만** 수행, User 승인 대기.
 - **세션 시작 시각 근거:** 정확한 세션-start 로그가 디스크에 없어 `session-flags.json`의 활동 마커(2026-07-16T01:07:16Z = 10:07:16 KST)를 시작 시각으로 사용(추정, 날조 아님).
-- **session_no 채번 정책:** result_report/가 신설(빈 디렉토리)이라 이번 세션을 01로 시작. 과거 세션 소급 채번(backfill)이 필요하면 별도 지시 필요.
+- **session_no 채번 정책:** 과거 아카이브 11건을 01~11로 소급 백필 완료 → 이번 세션 = 12. 이후 세션은 generate-task-report.sh가 자동으로 13, 14…로 이어받음. (아카이브 = `*-taskreport-*.html` 11건, `w6-report`·구형 `session-report-*`는 세션 리포트가 아니라 제외.)
 - **엔진 잔여 CONCERNS(불변):** R1 plan-mode 신호원 · R2 fingerprint diff 정규화 · R3 audit finding 라벨 소급.
 <!-- /ISSUES -->

--- a/result_report/.session-content.md
+++ b/result_report/.session-content.md
@@ -1,0 +1,26 @@
+<!-- BATHOS task-report 세션 콘텐츠 파일 -->
+<!-- 서술형 3항목(START/SUMMARY/ISSUES)을 세션마다 갱신 후 generate-task-report.sh 실행 -->
+<!-- git 히스토리(6번)는 스크립트가 저장소에서 자동 수집하므로 여기 적지 않는다 -->
+
+<!-- START -->
+2026-07-16 10:07:16 KST
+<!-- /START -->
+
+<!-- SUMMARY -->
+- **콜드스타트 복원:** 이전 세션(s7, 2026-07-15)까지의 전체 상태를 무손실 복원. SESSION-SNAPSHOT ↔ session-state.json ↔ manifest 3자 교차확인, 감사 해시체인 무결 검증(2767 entries, genesis→tail 정상).
+- **드리프트 감지:** s7 스냅샷은 "prod PR #4 = OPEN(배포 대기)"로 얼어 있었으나 실측 결과 **PR #4 = MERGED**(bathos.cc 배포 완료) + landing-web에 **Install step 2(link) 후속 작업**이 /save 없이 추가·머지됨을 확인.
+- **feat/task-report 브랜치 생성:** develop 기준으로 분기.
+- **task-report 시스템 신설:** `result_report/` 디렉토리 + 재사용 생성기 `generate-task-report.sh` 작성.
+  - 파일명 규약 `task_report_YYYYMMDD_HHMMSS_session_noNN.html`, **session_no는 기존 리포트 최대 순번 +1로 자동 incremental**(첫 세션=01).
+  - 필수 6항목 포함: 작업 시작/종료 시각·총 소요·핵심 사항·중요 이슈·git commit/push/PR/merge 히스토리(자동 수집).
+  - 서술형 항목은 `.session-content.md`에서 로드, git 히스토리는 저장소에서 자동 수집. BATHOS teal 리포트 스타일 준수.
+- **이번 세션 리포트(session_no01) 생성.**
+<!-- /SUMMARY -->
+
+<!-- ISSUES -->
+- **스냅샷 드리프트:** landing-web에서 `/save` 없이 종료된 세션이 있어 s7 스냅샷이 최신 상태를 반영하지 못함 → 다음 `/save-session` 시 정본화 필요.
+- **push/PR/merge 보류:** 아웃바운드 반영(원격 push·PR·merge)은 명시 요청이 없어 **로컬 커밋까지만** 수행, User 승인 대기.
+- **세션 시작 시각 근거:** 정확한 세션-start 로그가 디스크에 없어 `session-flags.json`의 활동 마커(2026-07-16T01:07:16Z = 10:07:16 KST)를 시작 시각으로 사용(추정, 날조 아님).
+- **session_no 채번 정책:** result_report/가 신설(빈 디렉토리)이라 이번 세션을 01로 시작. 과거 세션 소급 채번(backfill)이 필요하면 별도 지시 필요.
+- **엔진 잔여 CONCERNS(불변):** R1 plan-mode 신호원 · R2 fingerprint diff 정규화 · R3 audit finding 라벨 소급.
+<!-- /ISSUES -->

--- a/result_report/backfill-from-archive.sh
+++ b/result_report/backfill-from-archive.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# BATHOS  result_report/backfill-from-archive.sh
+# 과거 세션 리포트(.agent-team/12-report/*-taskreport-*.html)를 새 result_report/
+# 형식으로 소급(backfill) 생성한다. 시간순으로 session_no 01 부터 채번한다.
+# 이후 generate-task-report.sh 는 자동으로 그 다음 번호(예: 12)를 이어받는다.
+#
+# 소급 리포트의 정확도(날조 금지 — 원본에 있는 사실만):
+#   - 작업 종료 시각 = 원본 리포트의 "생성" 시각(=세션 종료 시 자동 생성됐음)
+#   - 작업 시작 시각 / 총 작업 시간 = (소급 — 당시 미기록) 로 명시
+#   - 작업 핵심 사항 = 원본의 "현재 상태" 블록 verbatim(이미 이스케이프됨)
+#   - 중요 이슈 = (소급 — 당시 별도 이슈 로그 없음) + 원본 파일명 포인터
+#   - git 히스토리 = 원본 리포트에 기록된 git 라인(당시 상태) — 현재 git 로그 아님
+#
+# 사용: bash backfill-from-archive.sh          (기존 리포트 있으면 중단)
+#       bash backfill-from-archive.sh --force  (강제 진행)
+# ---------------------------------------------------------------------------
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJ="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUTDIR="$SCRIPT_DIR"
+ARCHDIR="$PROJ/.agent-team/12-report"
+
+[ -d "$ARCHDIR" ] || { echo "아카이브 디렉토리 없음: $ARCHDIR"; exit 1; }
+
+existing=$(ls "$OUTDIR"/task_report_*_session_no*.html 2>/dev/null | wc -l | tr -d ' ')
+if [ "$existing" -gt 0 ] && [ "$1" != "--force" ]; then
+  echo "result_report/ 에 이미 $existing 개 리포트 존재 → 중복 방지로 중단. 강제하려면 --force"; exit 1
+fi
+
+PROJID="$(grep -oE '"project_id"[[:space:]]*:[[:space:]]*"[^"]*"' "$PROJ/.agent-team/_state/manifest.json" 2>/dev/null | head -1 | sed -E 's/.*"([^"]+)"$/\1/')"
+[ -z "$PROJID" ] && PROJID="$(basename "$PROJ")"
+
+NN=0
+for a in $(ls "$ARCHDIR"/*-taskreport-*.html 2>/dev/null | sort); do
+  NN=$((NN + 1)); NNP="$(printf '%02d' "$NN")"
+
+  END="$(grep -oE '생성 <b>[^<]*</b>' "$a" | head -1 | sed -E 's/생성 <b>([^<]*)<\/b>/\1/')"
+  [ -z "$END" ] && END="(미상)"
+  STAMP="$(printf '%s' "$END" | sed -E 's/^([0-9]{4})-([0-9]{2})-([0-9]{2}) ([0-9]{2}):([0-9]{2}):([0-9]{2}).*/\1\2\3_\4\5\6/')"
+  case "$STAMP" in *[!0-9_]*|"") STAMP="unknown${NNP}";; esac
+
+  # 원본 "현재 상태" 섹션의 <pre>..</pre> 내용을 verbatim 추출(이미 escape 되어 있음)
+  SUMMARY="$(awk '/현재 상태/{a=1} a&&/<pre>/{p=1} p{print} p&&/<\/pre>/{exit}' "$a" \
+             | sed -E 's/.*<pre>//; s/<\/pre>.*//')"
+  [ -z "$SUMMARY" ] && SUMMARY="(원본 '현재 상태' 추출 실패 — 원본 참조)"
+
+  GIT="$(grep -oE '<b>git:</b>[^<]*' "$a" | head -1 | sed -E 's/<b>git:<\/b>[[:space:]]*//')"
+  [ -z "$GIT" ] && GIT="(원본 git 기록 없음)"
+
+  ARCHNAME="$(basename "$a")"
+  FILE="$OUTDIR/task_report_${STAMP}_session_no${NNP}.html"
+
+  cat > "$FILE" <<HTMLEOF
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>BATHOS 작업 리포트 — session_no${NNP} (소급)</title>
+<style>
+  :root{--abyss:#081215;--surface:#0f2226;--line:#1c3a40;--teal:#18b6c0;--teal-brand:#0e9aa1;--teal-soft:#7fd6dc;--ink:#e9f3f4;--muted:#8fabb0;--dim:#5f7c81;--amber:#e0a94f;
+    --mono:ui-monospace,'SFMono-Regular','JetBrains Mono',Menlo,Consolas,monospace;
+    --sans:'Pretendard','Pretendard Variable',-apple-system,BlinkMacSystemFont,'Apple SD Gothic Neo','Noto Sans KR',system-ui,sans-serif;}
+  *{box-sizing:border-box}
+  body{margin:0;font-family:var(--sans);color:var(--ink);line-height:1.65;
+    background:radial-gradient(1000px 560px at 82% -10%,rgba(14,154,161,.16),transparent 60%),var(--abyss);-webkit-font-smoothing:antialiased}
+  .wrap{max-width:920px;margin:0 auto;padding:52px 26px 72px}
+  .eyebrow{font-family:var(--mono);font-size:.76rem;letter-spacing:.16em;text-transform:uppercase;color:var(--teal)}
+  h1{font-size:clamp(1.8rem,4vw,2.6rem);margin:12px 0 8px;font-weight:800;letter-spacing:-.01em}
+  .meta{font-family:var(--mono);color:var(--muted);font-size:.88rem}
+  .meta b{color:var(--teal-soft)}
+  .badge{display:inline-block;font-family:var(--mono);font-size:.72rem;color:var(--amber);border:1px solid rgba(224,169,79,.45);border-radius:999px;padding:2px 10px;margin-left:8px}
+  h2{font-size:1.2rem;margin:38px 0 4px;font-weight:800}
+  h2 .n{font-family:var(--mono);color:var(--teal);margin-right:.5em;font-size:.88em}
+  .rule{height:1px;background:linear-gradient(90deg,var(--teal-brand),transparent);margin:9px 0 14px;opacity:.6}
+  .card{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:16px 20px;color:var(--ink)}
+  .card.state{border-left:3px solid var(--teal-brand)}
+  pre{font-family:var(--mono);font-size:.82rem;line-height:1.7;color:#cfe9ec;white-space:pre-wrap;word-break:break-word;margin:0;overflow-x:auto}
+  .times{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:4px}
+  @media(max-width:640px){.times{grid-template-columns:1fr}}
+  .tcard{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:14px 16px}
+  .tcard .lbl{font-family:var(--mono);font-size:.72rem;letter-spacing:.1em;text-transform:uppercase;color:var(--teal)}
+  .tcard .val{font-family:var(--mono);font-size:1.02rem;color:#fff;margin-top:6px;font-weight:700}
+  .tcard .val.dim{color:var(--dim);font-weight:500;font-size:.86rem}
+  .subh{font-family:var(--mono);font-size:.78rem;color:var(--teal-soft);margin:14px 0 6px;letter-spacing:.04em}
+  .note{font-family:var(--mono);font-size:.78rem;color:var(--amber);margin:0 0 14px}
+  footer{margin-top:46px;padding-top:16px;border-top:1px solid var(--line);color:var(--dim);font-family:var(--mono);font-size:.8rem;display:flex;justify-content:space-between;flex-wrap:wrap;gap:8px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">BATHOS Dynamis · 세션 작업 리포트</div>
+  <h1>작업 리포트 · session_no${NNP}<span class="badge">소급 백필 · RETROACTIVE</span></h1>
+  <div class="meta">프로젝트 <b>${PROJID}</b> · 세션 순번 <b>#${NN}</b> · 원본 <b>${ARCHNAME}</b></div>
+  <p class="note">※ 이 리포트는 과거 세션 아카이브에서 소급 생성됨 — 원본에 기록된 사실만 포함(시작 시각·소요 시간은 당시 미기록).</p>
+
+  <h2><span class="n">1–3</span>작업 시각 &amp; 총 소요</h2>
+  <div class="rule"></div>
+  <div class="times">
+    <div class="tcard"><div class="lbl">작업 시작</div><div class="val dim">(소급 — 당시 미기록)</div></div>
+    <div class="tcard"><div class="lbl">작업 종료</div><div class="val">${END}</div></div>
+    <div class="tcard"><div class="lbl">총 작업 시간</div><div class="val dim">(소급 — 산출 불가)</div></div>
+  </div>
+
+  <h2><span class="n">4</span>작업 핵심 사항 <span style="font-size:.7em;color:var(--dim)">(원본 '현재 상태')</span></h2>
+  <div class="rule"></div>
+  <div class="card state"><pre>${SUMMARY}</pre></div>
+
+  <h2><span class="n">5</span>중요 이슈</h2>
+  <div class="rule"></div>
+  <div class="card"><pre>(소급 백필 — 당시 별도 이슈 로그 없음. 상세는 원본 리포트 ${ARCHNAME} 참조.)</pre></div>
+
+  <h2><span class="n">6</span>git commit / push / PR / merge 히스토리 <span style="font-size:.7em;color:var(--dim)">(원본 기록 기준)</span></h2>
+  <div class="rule"></div>
+  <div class="card"><pre>${GIT}</pre></div>
+
+  <footer>
+    <span>BATHOS · βάθος — 표층이 아닌 깊이 · 소급 백필</span>
+    <span>task_report_${STAMP}_session_no${NNP}.html</span>
+  </footer>
+</div>
+</body>
+</html>
+HTMLEOF
+
+  echo "백필: session_no${NNP}  ← ${ARCHNAME}  (종료=${END})"
+done
+
+echo "완료: 총 ${NN} 개 세션 소급 생성. 다음 세션은 generate-task-report.sh 가 $(printf '%02d' $((NN+1))) 부터 이어받습니다."
+exit 0

--- a/result_report/generate-task-report.sh
+++ b/result_report/generate-task-report.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# BATHOS  result_report/generate-task-report.sh
+# 한 세션의 작업 사항을 self-contained HTML 리포트로 저장한다.
+#
+# 파일명 규약 : task_report_<YYYYMMDD>_<HHMMSS>_session_no<NN>.html
+#   - <YYYYMMDD>_<HHMMSS> = 생성(=작업 종료) 시각
+#   - <NN>                = 세션 순번(첫 세션부터 incremental, 2자리 zero-pad)
+#                           result_report/ 안의 기존 리포트 최대 순번 + 1로 자동 결정
+# 저장 위치   : <project>/result_report/
+#
+# 필수 포함 6항목:
+#   1) 작업 시작 시각  2) 작업 종료 시각  3) 총 작업 시간
+#   4) 작업 핵심 사항  5) 중요 이슈       6) git commit/push/PR/merge 히스토리
+#
+# 서술형 항목(시작시각·핵심사항·이슈)은 콘텐츠 파일에서 읽는다(모델/작성자가 갱신).
+#   기본 경로: result_report/.session-content.md  (또는 1번째 인자로 경로 지정)
+#   구획: <!-- START -->..<!-- /START -->  <!-- SUMMARY -->..  <!-- ISSUES -->..
+# git 히스토리(6번)는 저장소에서 자동 수집한다.
+#
+# 철칙: 날조 금지(디스크·git 사실만). start 시각 미기재 시 "(미기재)"로 표기.
+# ---------------------------------------------------------------------------
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJ="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUTDIR="$SCRIPT_DIR"
+CONTENT="${1:-$SCRIPT_DIR/.session-content.md}"
+
+# ── 세션 순번 자동 증가 (기존 리포트 최대 + 1) ────────────────────────────────
+N=0
+for f in "$OUTDIR"/task_report_*_session_no*.html; do
+  [ -e "$f" ] || continue
+  num="$(printf '%s' "$f" | sed -E 's/.*_session_no([0-9]+)\.html$/\1/')"
+  case "$num" in ''|*[!0-9]*) continue;; esac
+  num=$((10#$num))
+  [ "$num" -gt "$N" ] && N=$num
+done
+N=$((N + 1))
+NN="$(printf '%02d' "$N")"
+
+# ── 시각 ─────────────────────────────────────────────────────────────────────
+END_TS="$(date '+%Y-%m-%d %H:%M:%S %Z')"
+STAMP="$(date '+%Y%m%d_%H%M%S')"
+FILE="$OUTDIR/task_report_${STAMP}_session_no${NN}.html"
+
+# ── HTML 이스케이프 & 초경량 markdown → HTML ─────────────────────────────────
+esc(){ sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'; }
+# 콘텐츠 파일에서 <!-- TAG -->..<!-- /TAG --> 구간 추출
+extract(){ awk -v t="$1" '$0 ~ ("<!-- "t" -->"){f=1;next} $0 ~ ("<!-- /"t" -->"){f=0} f' "$CONTENT" 2>/dev/null; }
+# 불릿(- )·굵게(**..**)만 지원하는 경량 렌더러(먼저 esc → 태그 주입 → 목록 묶음)
+md2html(){
+  esc | sed -E 's/\*\*([^*]+)\*\*/<b>\1<\/b>/g' | awk '
+    /^[[:space:]]*-[[:space:]]/ { if(!u){print "<ul>";u=1} sub(/^[[:space:]]*-[[:space:]]/,""); print "<li>"$0"</li>"; next }
+    { if(u){print "</ul>";u=0} if($0 ~ /^[[:space:]]*$/) next; print "<p>"$0"</p>" }
+    END{ if(u) print "</ul>" }'
+}
+
+# ── 서술형 콘텐츠 로드 ────────────────────────────────────────────────────────
+START_RAW="$(extract START | sed '/^[[:space:]]*$/d' | head -1)"
+[ -z "$START_RAW" ] && START_RAW="(미기재)"
+SUMMARY_HTML="$(extract SUMMARY | md2html)"
+[ -z "$SUMMARY_HTML" ] && SUMMARY_HTML="<p>(핵심 사항 미기재 — result_report/.session-content.md의 SUMMARY 구획을 채우세요)</p>"
+ISSUES_HTML="$(extract ISSUES | md2html)"
+[ -z "$ISSUES_HTML" ] && ISSUES_HTML="<p>(중요 이슈 없음/미기재)</p>"
+
+# ── 총 작업 시간 계산 (GNU date -d / BSD date -j 모두 대응) ───────────────────
+to_epoch(){
+  local s; s="$(printf '%s' "$1" | sed -E 's/[[:space:]]*[A-Za-z]{2,4}$//')" # 끝의 tz명 제거
+  date -d "$s" +%s 2>/dev/null || date -j -f "%Y-%m-%d %H:%M:%S" "$s" +%s 2>/dev/null
+}
+DUR="(계산 불가 — 시작 시각 미기재)"
+if [ "$START_RAW" != "(미기재)" ]; then
+  se="$(to_epoch "$START_RAW")"; ee="$(to_epoch "$END_TS")"
+  if [ -n "$se" ] && [ -n "$ee" ] && [ "$ee" -ge "$se" ] 2>/dev/null; then
+    d=$((ee - se)); DUR="$((d/3600))시간 $(((d%3600)/60))분 $((d%60))초"
+  fi
+fi
+
+# ── 프로젝트 식별자(있으면 manifest에서) ─────────────────────────────────────
+PROJID="$(grep -oE '"project_id"[[:space:]]*:[[:space:]]*"[^"]*"' "$PROJ/.agent-team/_state/manifest.json" 2>/dev/null | head -1 | sed -E 's/.*"([^"]+)"$/\1/')"
+[ -z "$PROJID" ] && PROJID="$(basename "$PROJ")"
+
+# ── 6) git commit/push/PR/merge 히스토리 자동 수집 ───────────────────────────
+if git -C "$PROJ" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  BR="$(git -C "$PROJ" branch --show-current 2>/dev/null)"
+  SYNC="$(git -C "$PROJ" status -sb 2>/dev/null | head -1 | sed 's/^## //')"
+  COMMITS="$(git -C "$PROJ" log --oneline --decorate -15 2>/dev/null | esc)"
+  MERGES="$(git -C "$PROJ" log --merges --oneline -10 2>/dev/null | esc)"
+  [ -z "$MERGES" ] && MERGES="(merge 커밋 없음)"
+  # push 상태: 로컬 브랜치가 upstream 대비 ahead/behind인지 (=미push 여부의 프록시)
+  PUSH="$(git -C "$PROJ" for-each-ref --format='%(refname:short) → %(upstream:short) [%(upstream:track)]' refs/heads 2>/dev/null | esc)"
+  [ -z "$PUSH" ] && PUSH="(upstream 추적 브랜치 없음)"
+  if command -v gh >/dev/null 2>&1; then
+    PRS="$(gh pr list --repo "$(git -C "$PROJ" remote get-url origin 2>/dev/null)" --state all --limit 15 \
+            --json number,state,title,headRefName,baseRefName \
+            --template '{{range .}}#{{.number}} [{{.state}}] {{.headRefName}}→{{.baseRefName}} · {{.title}}{{"\n"}}{{end}}' 2>/dev/null | esc)"
+    [ -z "$PRS" ] && PRS="(PR 없음 또는 gh 조회 실패)"
+  else
+    PRS="(gh CLI 미설치 — PR 히스토리 수집 생략)"
+  fi
+else
+  BR="(git repo 아님)"; SYNC="-"; COMMITS="(git repo 아님)"; MERGES="-"; PUSH="-"; PRS="-"
+fi
+
+# ── 리포트 렌더 ──────────────────────────────────────────────────────────────
+cat > "$FILE" <<HTMLEOF
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>BATHOS 작업 리포트 — session_no${NN}</title>
+<style>
+  :root{--abyss:#081215;--surface:#0f2226;--line:#1c3a40;--teal:#18b6c0;--teal-brand:#0e9aa1;--teal-soft:#7fd6dc;--ink:#e9f3f4;--muted:#8fabb0;--dim:#5f7c81;--grn:#4fbf9a;
+    --mono:ui-monospace,'SFMono-Regular','JetBrains Mono',Menlo,Consolas,monospace;
+    --sans:'Pretendard','Pretendard Variable',-apple-system,BlinkMacSystemFont,'Apple SD Gothic Neo','Noto Sans KR',system-ui,sans-serif;}
+  *{box-sizing:border-box}
+  body{margin:0;font-family:var(--sans);color:var(--ink);line-height:1.65;
+    background:radial-gradient(1000px 560px at 82% -10%,rgba(14,154,161,.16),transparent 60%),var(--abyss);-webkit-font-smoothing:antialiased}
+  .wrap{max-width:920px;margin:0 auto;padding:52px 26px 72px}
+  .eyebrow{font-family:var(--mono);font-size:.76rem;letter-spacing:.16em;text-transform:uppercase;color:var(--teal)}
+  h1{font-size:clamp(1.8rem,4vw,2.6rem);margin:12px 0 8px;font-weight:800;letter-spacing:-.01em}
+  .meta{font-family:var(--mono);color:var(--muted);font-size:.88rem}
+  .meta b{color:var(--teal-soft)}
+  h2{font-size:1.2rem;margin:38px 0 4px;font-weight:800}
+  h2 .n{font-family:var(--mono);color:var(--teal);margin-right:.5em;font-size:.88em}
+  .rule{height:1px;background:linear-gradient(90deg,var(--teal-brand),transparent);margin:9px 0 14px;opacity:.6}
+  .card{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:16px 20px;color:var(--ink)}
+  .card.state{border-left:3px solid var(--teal-brand)}
+  .card p{margin:.35em 0}.card ul{margin:.35em 0 .35em 0;padding-left:1.25em}.card li{margin:.28em 0}
+  .card b{color:#fff}
+  pre{font-family:var(--mono);font-size:.82rem;line-height:1.7;color:#cfe9ec;white-space:pre-wrap;word-break:break-word;margin:0;overflow-x:auto}
+  .times{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:4px}
+  @media(max-width:640px){.times{grid-template-columns:1fr}}
+  .tcard{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:14px 16px}
+  .tcard .lbl{font-family:var(--mono);font-size:.72rem;letter-spacing:.1em;text-transform:uppercase;color:var(--teal)}
+  .tcard .val{font-family:var(--mono);font-size:1.02rem;color:#fff;margin-top:6px;font-weight:700}
+  .subh{font-family:var(--mono);font-size:.78rem;color:var(--teal-soft);margin:14px 0 6px;letter-spacing:.04em}
+  footer{margin-top:46px;padding-top:16px;border-top:1px solid var(--line);color:var(--dim);font-family:var(--mono);font-size:.8rem;display:flex;justify-content:space-between;flex-wrap:wrap;gap:8px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">BATHOS Dynamis · 세션 작업 리포트</div>
+  <h1>작업 리포트 · session_no${NN}</h1>
+  <div class="meta">생성 <b>${END_TS}</b> · 프로젝트 <b>${PROJID}</b> · 세션 순번 <b>#${N}</b></div>
+
+  <h2><span class="n">1–3</span>작업 시각 &amp; 총 소요</h2>
+  <div class="rule"></div>
+  <div class="times">
+    <div class="tcard"><div class="lbl">작업 시작</div><div class="val">${START_RAW}</div></div>
+    <div class="tcard"><div class="lbl">작업 종료</div><div class="val">${END_TS}</div></div>
+    <div class="tcard"><div class="lbl">총 작업 시간</div><div class="val">${DUR}</div></div>
+  </div>
+
+  <h2><span class="n">4</span>작업 핵심 사항</h2>
+  <div class="rule"></div>
+  <div class="card state">${SUMMARY_HTML}</div>
+
+  <h2><span class="n">5</span>중요 이슈</h2>
+  <div class="rule"></div>
+  <div class="card">${ISSUES_HTML}</div>
+
+  <h2><span class="n">6</span>git commit / push / PR / merge 히스토리</h2>
+  <div class="rule"></div>
+  <div class="card">
+    <div class="subh">현재 브랜치 · 동기화</div>
+    <pre>${BR}   ·   ${SYNC}</pre>
+    <div class="subh" style="margin-top:14px">최근 커밋 (commit, 최신 15)</div>
+    <pre>${COMMITS}</pre>
+    <div class="subh" style="margin-top:14px">merge 히스토리 (최신 10)</div>
+    <pre>${MERGES}</pre>
+    <div class="subh" style="margin-top:14px">push 상태 (로컬 → upstream [track])</div>
+    <pre>${PUSH}</pre>
+    <div class="subh" style="margin-top:14px">Pull Request (전체 상태)</div>
+    <pre>${PRS}</pre>
+  </div>
+
+  <footer>
+    <span>BATHOS · βάθος — 표층이 아닌 깊이</span>
+    <span>task_report_${STAMP}_session_no${NN}.html</span>
+  </footer>
+</div>
+</body>
+</html>
+HTMLEOF
+
+echo "생성됨: $FILE"
+
+# 감사 기록(있으면) — 직접 append 금지, CLI 경유(hash_self 보존)
+BIN="${BATHOS_BIN:-}"
+[ -z "$BIN" ] && command -v bathos >/dev/null 2>&1 && BIN="$(command -v bathos)"
+[ -z "$BIN" ] && [ -x "$PROJ/core/target/release/bathos" ] && BIN="$PROJ/core/target/release/bathos"
+[ -n "$BIN" ] && [ -d "$PROJ/.agent-team/_state" ] && \
+  "$BIN" -s "$PROJ/.agent-team/_state" audit append --actor hook --action taskreport.generate --target "$(basename "$FILE")" >/dev/null 2>&1
+
+exit 0

--- a/result_report/generate-task-report.sh
+++ b/result_report/generate-task-report.sh
@@ -57,7 +57,12 @@ md2html(){
 }
 
 # ── 서술형 콘텐츠 로드 ────────────────────────────────────────────────────────
-START_RAW="$(extract START | sed '/^[[:space:]]*$/d' | head -1)"
+# 작업 시작 시각 우선순위: (1) SessionStart 훅이 남긴 마커(정확·자동) →
+#                          (2) .session-content.md 의 START 구획(수동/폴백) → (3) 미기재
+MARKER="$PROJ/.agent-team/_state/session-start.marker"
+START_RAW=""
+[ -s "$MARKER" ] && START_RAW="$(sed '/^[[:space:]]*$/d' "$MARKER" | head -1)"
+[ -z "$START_RAW" ] && START_RAW="$(extract START | sed '/^[[:space:]]*$/d' | head -1)"
 [ -z "$START_RAW" ] && START_RAW="(미기재)"
 SUMMARY_HTML="$(extract SUMMARY | md2html)"
 [ -z "$SUMMARY_HTML" ] && SUMMARY_HTML="<p>(핵심 사항 미기재 — result_report/.session-content.md의 SUMMARY 구획을 채우세요)</p>"

--- a/result_report/task_report_20260709_172109_session_no01.html
+++ b/result_report/task_report_20260709_172109_session_no01.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>BATHOS 작업 리포트 — session_no01 (소급)</title>
+<style>
+  :root{--abyss:#081215;--surface:#0f2226;--line:#1c3a40;--teal:#18b6c0;--teal-brand:#0e9aa1;--teal-soft:#7fd6dc;--ink:#e9f3f4;--muted:#8fabb0;--dim:#5f7c81;--amber:#e0a94f;
+    --mono:ui-monospace,'SFMono-Regular','JetBrains Mono',Menlo,Consolas,monospace;
+    --sans:'Pretendard','Pretendard Variable',-apple-system,BlinkMacSystemFont,'Apple SD Gothic Neo','Noto Sans KR',system-ui,sans-serif;}
+  *{box-sizing:border-box}
+  body{margin:0;font-family:var(--sans);color:var(--ink);line-height:1.65;
+    background:radial-gradient(1000px 560px at 82% -10%,rgba(14,154,161,.16),transparent 60%),var(--abyss);-webkit-font-smoothing:antialiased}
+  .wrap{max-width:920px;margin:0 auto;padding:52px 26px 72px}
+  .eyebrow{font-family:var(--mono);font-size:.76rem;letter-spacing:.16em;text-transform:uppercase;color:var(--teal)}
+  h1{font-size:clamp(1.8rem,4vw,2.6rem);margin:12px 0 8px;font-weight:800;letter-spacing:-.01em}
+  .meta{font-family:var(--mono);color:var(--muted);font-size:.88rem}
+  .meta b{color:var(--teal-soft)}
+  .badge{display:inline-block;font-family:var(--mono);font-size:.72rem;color:var(--amber);border:1px solid rgba(224,169,79,.45);border-radius:999px;padding:2px 10px;margin-left:8px}
+  h2{font-size:1.2rem;margin:38px 0 4px;font-weight:800}
+  h2 .n{font-family:var(--mono);color:var(--teal);margin-right:.5em;font-size:.88em}
+  .rule{height:1px;background:linear-gradient(90deg,var(--teal-brand),transparent);margin:9px 0 14px;opacity:.6}
+  .card{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:16px 20px;color:var(--ink)}
+  .card.state{border-left:3px solid var(--teal-brand)}
+  pre{font-family:var(--mono);font-size:.82rem;line-height:1.7;color:#cfe9ec;white-space:pre-wrap;word-break:break-word;margin:0;overflow-x:auto}
+  .times{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:4px}
+  @media(max-width:640px){.times{grid-template-columns:1fr}}
+  .tcard{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:14px 16px}
+  .tcard .lbl{font-family:var(--mono);font-size:.72rem;letter-spacing:.1em;text-transform:uppercase;color:var(--teal)}
+  .tcard .val{font-family:var(--mono);font-size:1.02rem;color:#fff;margin-top:6px;font-weight:700}
+  .tcard .val.dim{color:var(--dim);font-weight:500;font-size:.86rem}
+  .subh{font-family:var(--mono);font-size:.78rem;color:var(--teal-soft);margin:14px 0 6px;letter-spacing:.04em}
+  .note{font-family:var(--mono);font-size:.78rem;color:var(--amber);margin:0 0 14px}
+  footer{margin-top:46px;padding-top:16px;border-top:1px solid var(--line);color:var(--dim);font-family:var(--mono);font-size:.8rem;display:flex;justify-content:space-between;flex-wrap:wrap;gap:8px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">BATHOS Dynamis · 세션 작업 리포트</div>
+  <h1>작업 리포트 · session_no01<span class="badge">소급 백필 · RETROACTIVE</span></h1>
+  <div class="meta">프로젝트 <b>bathos-dynamis</b> · 세션 순번 <b>#1</b> · 원본 <b>2026-07-09-taskreport-1.html</b></div>
+  <p class="note">※ 이 리포트는 과거 세션 아카이브에서 소급 생성됨 — 원본에 기록된 사실만 포함(시작 시각·소요 시간은 당시 미기록).</p>
+
+  <h2><span class="n">1–3</span>작업 시각 &amp; 총 소요</h2>
+  <div class="rule"></div>
+  <div class="times">
+    <div class="tcard"><div class="lbl">작업 시작</div><div class="val dim">(소급 — 당시 미기록)</div></div>
+    <div class="tcard"><div class="lbl">작업 종료</div><div class="val">2026-07-09 17:21:09 KST</div></div>
+    <div class="tcard"><div class="lbl">총 작업 시간</div><div class="val dim">(소급 — 산출 불가)</div></div>
+  </div>
+
+  <h2><span class="n">4</span>작업 핵심 사항 <span style="font-size:.7em;color:var(--dim)">(원본 '현재 상태')</span></h2>
+  <div class="rule"></div>
+  <div class="card state"><pre>
+open-swe·ponytail 패턴을 흡수한 BATHOS Dynamis의 **전 파이프라인(W2 설계 → W3 스토리·게이트 → W4 구현 → W5 리뷰) + 최종 조립 + humanize(산문)** 가 모두 끝났다. 제품은 완결형 스탠드얼론 트리(**VERSION 0.2.0**, 341파일 시딩). 2026-07-09 세션에서 이월돼 있던 humanize를 종결했고, 이어서 **모델 표기 정정(Sonnet 4.6 → Sonnet 5)**과 **강의안 3부작(시리즈)**을 추가했다. **활성 팀원 0, 재스폰 필요 팀원 없음.**
+
+### 2차 세션 추가분 (2026-07-09)
+- **모델 표기 정정:** 역할 사용 모델 표시 텍스트 `Sonnet 4.6` → `Sonnet 5`로 3개 트리 일괄 치환(dynamis + sibling `bathos/` + repo-root `.claude/agents/`). 이력 주석 `(was Sonnet 4.6)` 보존, **Opus 4.8은 그대로**(User 지시). 프론트매터 `model:` 필드는 이미 `claude-sonnet-5`/별칭 `sonnet`이라 미변경(표시 텍스트만). 스테일 `* 2.md` 제외.
+- **강의안 시리즈 3부작:** `site/lectures/{usecase,features,usage}-lecture.html` — 자체완결 슬라이드 덱(한/영 토글, 키보드/닷/스와이프 내비, 진행바, print). 헤더 시리즈 내비로 상호연결(① 사례 14 · ② 원리 14 · ③ 사용 19 슬라이드). USAGE-kr/en·FEATURES-kr/en·USECASE-kr/en 기반. BATHOS 아이덴티티(심연+틸+Pretendard, 흑백 기호). 헤드리스 렌더 검증 완료.
+- **사이트 링크:** `site/index.html` 상단 nav에 강의 링크(en/ko/es 3언어, 시리즈 시작점 ①로) + **문서 허브 3언어 전부** `site/docs/{index,index-en,index-es}.html`에 "강의(슬라이드)" 카드 그룹 3장 추가.
+- **세션 리포트(HTML):** `.agent-team/12-report/session-report-2026-07-09.html` — 이번 세션 전체(타임라인·산출물·검증·상태)를 BATHOS 아이덴티티로 정리. 헤드리스 렌더 검증.
+- **Artifact 발행(시리즈 허브 1개):** 3덱을 한 URL에 담아 내부 전환(숫자키 1/2/3·한영 토글). 소스 `site/lectures/series-hub-artifact.html`(Artifact 규정상 body-only로 조립, 기존 3파일에서 슬라이드 배열 추출·병합). **URL:** https://claude.ai/code/artifact/32e2142e-f0af-4e22-a985-31e186143f04 (기본 비공개; 재발행은 같은 파일 경로로 하면 URL 유지).
+
+- 제품/작업 상태: 파이프라인 완료 · 조립 완료(v0.2.0) · humanize 산문 완료 · 운영 파일 윤문 제외(판정)
+- 현재 레벨(Lv): **Lv3** · 진행 중 웨이브: **없음(전 단계 종결)**
+
+**미완 / 다음 작업 (우선순위):**
+1. (선택) `/team-confirm` — 최종 사인오프 + cleanup.
+2. (선택) 열린 CONCERNS R1~R3 해소 추적 — `/bathos-debt` 또는 `_state/risk-log.md`.
+3. (선택) 개별 운영 파일에 실제 AI-tell 발견 시 예외 윤문(가역적).
+
+**▶ 다음에 실행할 커맨드:** `/team-confirm`  (신규 작업이면 먼저 `/route`로 레벨 재확인)</pre></div>
+
+  <h2><span class="n">5</span>중요 이슈</h2>
+  <div class="rule"></div>
+  <div class="card"><pre>(소급 백필 — 당시 별도 이슈 로그 없음. 상세는 원본 리포트 2026-07-09-taskreport-1.html 참조.)</pre></div>
+
+  <h2><span class="n">6</span>git commit / push / PR / merge 히스토리 <span style="font-size:.7em;color:var(--dim)">(원본 기록 기준)</span></h2>
+  <div class="rule"></div>
+  <div class="card"><pre>git repo 아님(파일 직접 저장)</pre></div>
+
+  <footer>
+    <span>BATHOS · βάθος — 표층이 아닌 깊이 · 소급 백필</span>
+    <span>task_report_20260709_172109_session_no01.html</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/result_report/task_report_20260712_124438_session_no02.html
+++ b/result_report/task_report_20260712_124438_session_no02.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>BATHOS 작업 리포트 — session_no02 (소급)</title>
+<style>
+  :root{--abyss:#081215;--surface:#0f2226;--line:#1c3a40;--teal:#18b6c0;--teal-brand:#0e9aa1;--teal-soft:#7fd6dc;--ink:#e9f3f4;--muted:#8fabb0;--dim:#5f7c81;--amber:#e0a94f;
+    --mono:ui-monospace,'SFMono-Regular','JetBrains Mono',Menlo,Consolas,monospace;
+    --sans:'Pretendard','Pretendard Variable',-apple-system,BlinkMacSystemFont,'Apple SD Gothic Neo','Noto Sans KR',system-ui,sans-serif;}
+  *{box-sizing:border-box}
+  body{margin:0;font-family:var(--sans);color:var(--ink);line-height:1.65;
+    background:radial-gradient(1000px 560px at 82% -10%,rgba(14,154,161,.16),transparent 60%),var(--abyss);-webkit-font-smoothing:antialiased}
+  .wrap{max-width:920px;margin:0 auto;padding:52px 26px 72px}
+  .eyebrow{font-family:var(--mono);font-size:.76rem;letter-spacing:.16em;text-transform:uppercase;color:var(--teal)}
+  h1{font-size:clamp(1.8rem,4vw,2.6rem);margin:12px 0 8px;font-weight:800;letter-spacing:-.01em}
+  .meta{font-family:var(--mono);color:var(--muted);font-size:.88rem}
+  .meta b{color:var(--teal-soft)}
+  .badge{display:inline-block;font-family:var(--mono);font-size:.72rem;color:var(--amber);border:1px solid rgba(224,169,79,.45);border-radius:999px;padding:2px 10px;margin-left:8px}
+  h2{font-size:1.2rem;margin:38px 0 4px;font-weight:800}
+  h2 .n{font-family:var(--mono);color:var(--teal);margin-right:.5em;font-size:.88em}
+  .rule{height:1px;background:linear-gradient(90deg,var(--teal-brand),transparent);margin:9px 0 14px;opacity:.6}
+  .card{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:16px 20px;color:var(--ink)}
+  .card.state{border-left:3px solid var(--teal-brand)}
+  pre{font-family:var(--mono);font-size:.82rem;line-height:1.7;color:#cfe9ec;white-space:pre-wrap;word-break:break-word;margin:0;overflow-x:auto}
+  .times{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:4px}
+  @media(max-width:640px){.times{grid-template-columns:1fr}}
+  .tcard{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:14px 16px}
+  .tcard .lbl{font-family:var(--mono);font-size:.72rem;letter-spacing:.1em;text-transform:uppercase;color:var(--teal)}
+  .tcard .val{font-family:var(--mono);font-size:1.02rem;color:#fff;margin-top:6px;font-weight:700}
+  .tcard .val.dim{color:var(--dim);font-weight:500;font-size:.86rem}
+  .subh{font-family:var(--mono);font-size:.78rem;color:var(--teal-soft);margin:14px 0 6px;letter-spacing:.04em}
+  .note{font-family:var(--mono);font-size:.78rem;color:var(--amber);margin:0 0 14px}
+  footer{margin-top:46px;padding-top:16px;border-top:1px solid var(--line);color:var(--dim);font-family:var(--mono);font-size:.8rem;display:flex;justify-content:space-between;flex-wrap:wrap;gap:8px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">BATHOS Dynamis · 세션 작업 리포트</div>
+  <h1>작업 리포트 · session_no02<span class="badge">소급 백필 · RETROACTIVE</span></h1>
+  <div class="meta">프로젝트 <b>bathos-dynamis</b> · 세션 순번 <b>#2</b> · 원본 <b>2026-07-12-taskreport-1.html</b></div>
+  <p class="note">※ 이 리포트는 과거 세션 아카이브에서 소급 생성됨 — 원본에 기록된 사실만 포함(시작 시각·소요 시간은 당시 미기록).</p>
+
+  <h2><span class="n">1–3</span>작업 시각 &amp; 총 소요</h2>
+  <div class="rule"></div>
+  <div class="times">
+    <div class="tcard"><div class="lbl">작업 시작</div><div class="val dim">(소급 — 당시 미기록)</div></div>
+    <div class="tcard"><div class="lbl">작업 종료</div><div class="val">2026-07-12 12:44:38 KST</div></div>
+    <div class="tcard"><div class="lbl">총 작업 시간</div><div class="val dim">(소급 — 산출 불가)</div></div>
+  </div>
+
+  <h2><span class="n">4</span>작업 핵심 사항 <span style="font-size:.7em;color:var(--dim)">(원본 '현재 상태')</span></h2>
+  <div class="rule"></div>
+  <div class="card state"><pre>
+이번 세션은 **역할 체계 진화 작업**만 수행했다(파이프라인 웨이브 재실행 아님). ① 먼저 `.claude/agents/_base/`의 역할 정의를 `bathos_alpha`와 동기화하고 중복/여분 파일을 제거해 깨끗한 15역할로 정리했다. ② 이어 사용자 요청으로 **Hananiah(Refactoring Specialist)** 를 **#13**(Thomas #12 다음)으로 신설하고, Matthias 13→14 · Martin 14→15 · Matthew 15→16으로 +1 재번호했다. ③ "16역할" 재번호를 **CLAUDE.md · AGENTS.md · README.md · ETHOS.md(.orig) · glossary · 3개 .agent-team 문서 · 2개 .rs main · 2개 플러그인 manifest · site/docs 3개 HTML**(1차 스윕)에 이어, **살아있는 사용자 문서 전체**(docs/USAGE·USECASE·QUOTA en/kr/es + 대응 site/docs HTML + site/index.html + site/lectures 3개, 2차 스윕)까지 전파했다. 역할 정의(`_base`)와 모든 살아있는 문서는 잔여 "15역할"/"15 roles" 0으로 검증 완료. 파이프라인(W2~W5+humanize+assembly)은 이전 세션에서 이미 완료 상태이며 이번 세션에서 변경 없음.
+
+- 제품/작업 상태: 역할 체계 16역할로 진화 완료 · 파이프라인은 기완료(변경 없음) · 미완은 **의도적으로 남긴 코드/이력/컴파일 산출물의 #15 표기**뿐
+- 현재 레벨(Lv): **Lv3** · 진행 중 웨이브: **없음(역할 정의 편집 세션, 팀원 미스폰)**
+
+**미완 / 다음 작업 (우선순위):**
+1. (사용자 확인 대기) 엔진 코드 **주석**(bathos-wave-engine `config.rs`/`engine.rs`, bathos-inspect `readiness.rs`)과 훅(`_test-hooks.sh`, `artifact-verify.sh`)의 `#15 Matthew` 주석, `CHANGELOG.md`(과거 기록)을 16역할로 갱신할지 여부 — 이번 세션은 사용자 선택("살아있는 사용자 문서까지")에 따라 **의도적으로 제외**함.
+2. `core/target/` 컴파일 산출물 7개는 `#15 Matthew`를 포함하나 **다음 `cargo build` 시 자동 재생성**되므로 수동 편집 불필요.
+3. (선택) 신규 Hananiah 역할용 산출물 폴더 `.agent-team/10-refactoring/`는 규약에만 추가됨 — 실제 W6 리팩토링 실행 시 생성.
+
+**▶ 다음에 실행할 커맨드:** `/cold-start` (재개 시) — 또는 코드 주석까지 마저 갱신하려면 사용자 승인 후 이어서 편집.</pre></div>
+
+  <h2><span class="n">5</span>중요 이슈</h2>
+  <div class="rule"></div>
+  <div class="card"><pre>(소급 백필 — 당시 별도 이슈 로그 없음. 상세는 원본 리포트 2026-07-12-taskreport-1.html 참조.)</pre></div>
+
+  <h2><span class="n">6</span>git commit / push / PR / merge 히스토리 <span style="font-size:.7em;color:var(--dim)">(원본 기록 기준)</span></h2>
+  <div class="rule"></div>
+  <div class="card"><pre>git repo 아님(파일 직접 저장)</pre></div>
+
+  <footer>
+    <span>BATHOS · βάθος — 표층이 아닌 깊이 · 소급 백필</span>
+    <span>task_report_20260712_124438_session_no02.html</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/result_report/task_report_20260713_054917_session_no03.html
+++ b/result_report/task_report_20260713_054917_session_no03.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>BATHOS 작업 리포트 — session_no03 (소급)</title>
+<style>
+  :root{--abyss:#081215;--surface:#0f2226;--line:#1c3a40;--teal:#18b6c0;--teal-brand:#0e9aa1;--teal-soft:#7fd6dc;--ink:#e9f3f4;--muted:#8fabb0;--dim:#5f7c81;--amber:#e0a94f;
+    --mono:ui-monospace,'SFMono-Regular','JetBrains Mono',Menlo,Consolas,monospace;
+    --sans:'Pretendard','Pretendard Variable',-apple-system,BlinkMacSystemFont,'Apple SD Gothic Neo','Noto Sans KR',system-ui,sans-serif;}
+  *{box-sizing:border-box}
+  body{margin:0;font-family:var(--sans);color:var(--ink);line-height:1.65;
+    background:radial-gradient(1000px 560px at 82% -10%,rgba(14,154,161,.16),transparent 60%),var(--abyss);-webkit-font-smoothing:antialiased}
+  .wrap{max-width:920px;margin:0 auto;padding:52px 26px 72px}
+  .eyebrow{font-family:var(--mono);font-size:.76rem;letter-spacing:.16em;text-transform:uppercase;color:var(--teal)}
+  h1{font-size:clamp(1.8rem,4vw,2.6rem);margin:12px 0 8px;font-weight:800;letter-spacing:-.01em}
+  .meta{font-family:var(--mono);color:var(--muted);font-size:.88rem}
+  .meta b{color:var(--teal-soft)}
+  .badge{display:inline-block;font-family:var(--mono);font-size:.72rem;color:var(--amber);border:1px solid rgba(224,169,79,.45);border-radius:999px;padding:2px 10px;margin-left:8px}
+  h2{font-size:1.2rem;margin:38px 0 4px;font-weight:800}
+  h2 .n{font-family:var(--mono);color:var(--teal);margin-right:.5em;font-size:.88em}
+  .rule{height:1px;background:linear-gradient(90deg,var(--teal-brand),transparent);margin:9px 0 14px;opacity:.6}
+  .card{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:16px 20px;color:var(--ink)}
+  .card.state{border-left:3px solid var(--teal-brand)}
+  pre{font-family:var(--mono);font-size:.82rem;line-height:1.7;color:#cfe9ec;white-space:pre-wrap;word-break:break-word;margin:0;overflow-x:auto}
+  .times{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:4px}
+  @media(max-width:640px){.times{grid-template-columns:1fr}}
+  .tcard{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:14px 16px}
+  .tcard .lbl{font-family:var(--mono);font-size:.72rem;letter-spacing:.1em;text-transform:uppercase;color:var(--teal)}
+  .tcard .val{font-family:var(--mono);font-size:1.02rem;color:#fff;margin-top:6px;font-weight:700}
+  .tcard .val.dim{color:var(--dim);font-weight:500;font-size:.86rem}
+  .subh{font-family:var(--mono);font-size:.78rem;color:var(--teal-soft);margin:14px 0 6px;letter-spacing:.04em}
+  .note{font-family:var(--mono);font-size:.78rem;color:var(--amber);margin:0 0 14px}
+  footer{margin-top:46px;padding-top:16px;border-top:1px solid var(--line);color:var(--dim);font-family:var(--mono);font-size:.8rem;display:flex;justify-content:space-between;flex-wrap:wrap;gap:8px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">BATHOS Dynamis · 세션 작업 리포트</div>
+  <h1>작업 리포트 · session_no03<span class="badge">소급 백필 · RETROACTIVE</span></h1>
+  <div class="meta">프로젝트 <b>bathos-dynamis</b> · 세션 순번 <b>#3</b> · 원본 <b>2026-07-13-taskreport-1.html</b></div>
+  <p class="note">※ 이 리포트는 과거 세션 아카이브에서 소급 생성됨 — 원본에 기록된 사실만 포함(시작 시각·소요 시간은 당시 미기록).</p>
+
+  <h2><span class="n">1–3</span>작업 시각 &amp; 총 소요</h2>
+  <div class="rule"></div>
+  <div class="times">
+    <div class="tcard"><div class="lbl">작업 시작</div><div class="val dim">(소급 — 당시 미기록)</div></div>
+    <div class="tcard"><div class="lbl">작업 종료</div><div class="val">2026-07-13 05:49:17 KST</div></div>
+    <div class="tcard"><div class="lbl">총 작업 시간</div><div class="val dim">(소급 — 산출 불가)</div></div>
+  </div>
+
+  <h2><span class="n">4</span>작업 핵심 사항 <span style="font-size:.7em;color:var(--dim)">(원본 '현재 상태')</span></h2>
+  <div class="rule"></div>
+  <div class="card state"><pre>
+세션2(2026-07-12)에서 수행 완료: ① **역할 16→17 진화** — Michael(#13 Security Specialist) 신설 + 전원 +1 재번호(Hananiah14·Matthias15·Martin16·Matthew17), 전 범위 전파. ② **정합성 부채 청산** — 코드/훅 `#15`→`#17`. ③ **D-09 해결** — `manifest.json`을 엔진 정본 스키마로 마이그레이션(`state show`·`fingerprint approve` 복구), 스키마 `role_no` max 15→17, 재빌드. ④ **W6 전체 실행**(이 세션 강행, Michael·Hananiah=general-purpose+_base 주입) — Thomas·Timothy·Matthias·Michael·Hananiah·Martin 6역할 산출, **게이트 Release Readiness=CONCERNS**(blocking 0). ⑤ **(B) 재번호 잔재 청산** — matrix.rs/config.rs role_set에 Michael·Hananiah 추가, FEATURES 16→17, 고아파일 4개 격리. ⑥ **.claude/agents 정합** — 상위 레지스트리 번호 충돌 해소(matthias15·martin16·matthew17). ⑦ **Rust 주석 영어화** — 8개 크레이트 완료, **bathos-inspect 부분(미완)**.
+
+- 제품/작업 상태: 17역할·D-09·W6·주석EN(부분) · `cargo build` 정상 · 활성 팀원 **없음**(전부 정지)
+- 현재 레벨: **Lv3** · 진행 중 웨이브: 없음(W6 게이트까지 완료)
+
+**미완 / 다음 작업 (우선순위):**
+1. **✅ [완료] Rust 주석 영어화 — 9/9 크레이트(bathos-inspect 포함) 완료.** 검증: cargo build OK·test 22그룹 0 failed·진짜 미번역 주석 0. 의도적 한글 유지: 문자열 리터럴·clap `///` 도움말·doctest 코드·doc의 한글 문자열/섹션제목 인용·서빙 HTML 내 JS 주석.
+2. **[리드 결정 — 2·3·4 처리 완료(2026-07-13)]** ✅ ②engine.rs:436 `#15`→`Jonnathan`(콘텐츠 버그) · ✅ ③story-lint 스코핑 가드(lite→warn skip, doctor fail 해소) · ✅ ④clippy 0·SEC-04 server.py·SEC-01 careful-guard tee/dd/patch(fingerprint 승인)·SEC-02 감사체인 코드 정직표기. **잔여(후속):** ①clap `///` 도움말 영어화 여부(미결정 — 현재 한글=동작보존) · SEC-02 문서 "tamper-evident" 전체 sweep + HMAC 전환(파괴적, 후속). ✅ **story lite↔canonical 완전 통일 완료(2026-07-13)** — 15/15 canonical, `story compile` OK, 템플릿 정렬(Timothy G1 해소), doctor story PASS.
+3. **[선택]** W6 CONCERNS 후속 · 상위 `discovery_bmad_code/{CLAUDE,AGENTS}.md` 구 거버넌스(14/15역할, 별개 레이어) 정합.
+
+**▶ 다음 실행 커맨드:** (재개 시) `/cold-start` → 리드 결정 4건 처리(아래 #2) 또는 W6 CONCERNS 후속. Rust 주석 영어화는 9/9 완료. (Michael·Hananiah 정식 타입 스폰 원하면 **세션 재시작 후** 가능 — 레지스트리 등록됨.)</pre></div>
+
+  <h2><span class="n">5</span>중요 이슈</h2>
+  <div class="rule"></div>
+  <div class="card"><pre>(소급 백필 — 당시 별도 이슈 로그 없음. 상세는 원본 리포트 2026-07-13-taskreport-1.html 참조.)</pre></div>
+
+  <h2><span class="n">6</span>git commit / push / PR / merge 히스토리 <span style="font-size:.7em;color:var(--dim)">(원본 기록 기준)</span></h2>
+  <div class="rule"></div>
+  <div class="card"><pre>git repo 아님(파일 직접 저장)</pre></div>
+
+  <footer>
+    <span>BATHOS · βάθος — 표층이 아닌 깊이 · 소급 백필</span>
+    <span>task_report_20260713_054917_session_no03.html</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/result_report/task_report_20260713_193015_session_no04.html
+++ b/result_report/task_report_20260713_193015_session_no04.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>BATHOS 작업 리포트 — session_no04 (소급)</title>
+<style>
+  :root{--abyss:#081215;--surface:#0f2226;--line:#1c3a40;--teal:#18b6c0;--teal-brand:#0e9aa1;--teal-soft:#7fd6dc;--ink:#e9f3f4;--muted:#8fabb0;--dim:#5f7c81;--amber:#e0a94f;
+    --mono:ui-monospace,'SFMono-Regular','JetBrains Mono',Menlo,Consolas,monospace;
+    --sans:'Pretendard','Pretendard Variable',-apple-system,BlinkMacSystemFont,'Apple SD Gothic Neo','Noto Sans KR',system-ui,sans-serif;}
+  *{box-sizing:border-box}
+  body{margin:0;font-family:var(--sans);color:var(--ink);line-height:1.65;
+    background:radial-gradient(1000px 560px at 82% -10%,rgba(14,154,161,.16),transparent 60%),var(--abyss);-webkit-font-smoothing:antialiased}
+  .wrap{max-width:920px;margin:0 auto;padding:52px 26px 72px}
+  .eyebrow{font-family:var(--mono);font-size:.76rem;letter-spacing:.16em;text-transform:uppercase;color:var(--teal)}
+  h1{font-size:clamp(1.8rem,4vw,2.6rem);margin:12px 0 8px;font-weight:800;letter-spacing:-.01em}
+  .meta{font-family:var(--mono);color:var(--muted);font-size:.88rem}
+  .meta b{color:var(--teal-soft)}
+  .badge{display:inline-block;font-family:var(--mono);font-size:.72rem;color:var(--amber);border:1px solid rgba(224,169,79,.45);border-radius:999px;padding:2px 10px;margin-left:8px}
+  h2{font-size:1.2rem;margin:38px 0 4px;font-weight:800}
+  h2 .n{font-family:var(--mono);color:var(--teal);margin-right:.5em;font-size:.88em}
+  .rule{height:1px;background:linear-gradient(90deg,var(--teal-brand),transparent);margin:9px 0 14px;opacity:.6}
+  .card{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:16px 20px;color:var(--ink)}
+  .card.state{border-left:3px solid var(--teal-brand)}
+  pre{font-family:var(--mono);font-size:.82rem;line-height:1.7;color:#cfe9ec;white-space:pre-wrap;word-break:break-word;margin:0;overflow-x:auto}
+  .times{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:4px}
+  @media(max-width:640px){.times{grid-template-columns:1fr}}
+  .tcard{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:14px 16px}
+  .tcard .lbl{font-family:var(--mono);font-size:.72rem;letter-spacing:.1em;text-transform:uppercase;color:var(--teal)}
+  .tcard .val{font-family:var(--mono);font-size:1.02rem;color:#fff;margin-top:6px;font-weight:700}
+  .tcard .val.dim{color:var(--dim);font-weight:500;font-size:.86rem}
+  .subh{font-family:var(--mono);font-size:.78rem;color:var(--teal-soft);margin:14px 0 6px;letter-spacing:.04em}
+  .note{font-family:var(--mono);font-size:.78rem;color:var(--amber);margin:0 0 14px}
+  footer{margin-top:46px;padding-top:16px;border-top:1px solid var(--line);color:var(--dim);font-family:var(--mono);font-size:.8rem;display:flex;justify-content:space-between;flex-wrap:wrap;gap:8px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">BATHOS Dynamis · 세션 작업 리포트</div>
+  <h1>작업 리포트 · session_no04<span class="badge">소급 백필 · RETROACTIVE</span></h1>
+  <div class="meta">프로젝트 <b>bathos-dynamis</b> · 세션 순번 <b>#4</b> · 원본 <b>2026-07-13-taskreport-2.html</b></div>
+  <p class="note">※ 이 리포트는 과거 세션 아카이브에서 소급 생성됨 — 원본에 기록된 사실만 포함(시작 시각·소요 시간은 당시 미기록).</p>
+
+  <h2><span class="n">1–3</span>작업 시각 &amp; 총 소요</h2>
+  <div class="rule"></div>
+  <div class="times">
+    <div class="tcard"><div class="lbl">작업 시작</div><div class="val dim">(소급 — 당시 미기록)</div></div>
+    <div class="tcard"><div class="lbl">작업 종료</div><div class="val">2026-07-13 19:30:15 KST</div></div>
+    <div class="tcard"><div class="lbl">총 작업 시간</div><div class="val dim">(소급 — 산출 불가)</div></div>
+  </div>
+
+  <h2><span class="n">4</span>작업 핵심 사항 <span style="font-size:.7em;color:var(--dim)">(원본 '현재 상태')</span></h2>
+  <div class="rule"></div>
+  <div class="card state"><pre>
+**BATHOS dynamis 랜딩페이지(`outputs/landing-web/`)를 신규 제작**했고, 사용자와 다회 디자인 이터레이션을 마친 상태. 스택: **Next.js 16.2.10(보안패치본) + React 19 + TS + Pretendard**, i18n **en/ko/es/ja**(`/[lang]` 라우팅 + `proxy.ts` + 헤더 **펄럭이는 SVG 국기** 스위처). 디자인: JetBrains식 레이아웃 + 자체 **Bathos Blue 심연 하강** 팔레트(챕터별 연속 그라데이션 d2~d10, 위=밝음→아래=심해), 헤더/히어로 시작색=최심(#04283c)·히어로 밝은끝=#1d6c94, 섹션 타이틀 ExtraBold, 대표문구 전 언어 2줄, 섹션 경계 얇은 화이트 라인, 히어로 바로 다음에 **설치법 섹션**. 보안: Caddy TLS 엣지(compose, 앱 내부격리)+CSP/보안헤더+컨테이너 하드닝. **로컬 구동 중: http://localhost:3200** (Docker 컨테이너 `bathos-landing-local`, 이미지 `bathos-landing:local`). `npm run build`·Docker·compose+Caddy TLS 리허설 모두 통과.
+
+- 제품/작업 상태: 랜딩 코드 완성·로컬 검증 완료 · 배포 미실행(대기) · 활성 팀원 **없음**
+- 엔진(bathos-dynamis) 레벨: **Lv3** · 웨이브 W2/W3/W5/W6 **done** · 게이트 Plan PASS·Impl CONCERNS·Release CONCERNS · 감사 **OK(keyed HMAC, 1914 entries)**
+
+**미완 / 다음 작업 (배포 3종 입력 대기):**
+1. `outputs/landing-web/lib/site.config.ts` — `BATHOS_GITHUB_URL`, `BATHOS_WEB_URL` 실제 URL 입력(마커).
+2. GitHub repo secrets — `GCP_PROJECT_ID`·`GCP_SA_KEY`·`GCE_INSTANCE`·`GCE_ZONE` (+선택 `SITE_DOMAIN`·`SITE_URL`). 사용자가 GCE 정보/credential 공유 예정.
+3. `git init` + 최초 커밋 → push → GitHub Actions가 GCR 빌드·GCE compose 배포. 라이브 후 bathos README들의 `BATHOS_LANDING_URL`(href="#") 연동.
+
+**▶ 다음 실행 커맨드:** (재개 시) `/cold-start` → 랜딩 추가 디자인 조정 계속, **또는** 위 3종 입력 받아 `git init`+커밋+배포. 로컬 미리보기 재기동: `cd outputs/landing-web &amp;&amp; docker run -d --name bathos-landing-local -p 3200:3000 bathos-landing:local` (또는 `docker compose up -d`로 TLS 포함).</pre></div>
+
+  <h2><span class="n">5</span>중요 이슈</h2>
+  <div class="rule"></div>
+  <div class="card"><pre>(소급 백필 — 당시 별도 이슈 로그 없음. 상세는 원본 리포트 2026-07-13-taskreport-2.html 참조.)</pre></div>
+
+  <h2><span class="n">6</span>git commit / push / PR / merge 히스토리 <span style="font-size:.7em;color:var(--dim)">(원본 기록 기준)</span></h2>
+  <div class="rule"></div>
+  <div class="card"><pre>git repo 아님(파일 직접 저장)</pre></div>
+
+  <footer>
+    <span>BATHOS · βάθος — 표층이 아닌 깊이 · 소급 백필</span>
+    <span>task_report_20260713_193015_session_no04.html</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/result_report/task_report_20260714_054056_session_no05.html
+++ b/result_report/task_report_20260714_054056_session_no05.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>BATHOS 작업 리포트 — session_no05 (소급)</title>
+<style>
+  :root{--abyss:#081215;--surface:#0f2226;--line:#1c3a40;--teal:#18b6c0;--teal-brand:#0e9aa1;--teal-soft:#7fd6dc;--ink:#e9f3f4;--muted:#8fabb0;--dim:#5f7c81;--amber:#e0a94f;
+    --mono:ui-monospace,'SFMono-Regular','JetBrains Mono',Menlo,Consolas,monospace;
+    --sans:'Pretendard','Pretendard Variable',-apple-system,BlinkMacSystemFont,'Apple SD Gothic Neo','Noto Sans KR',system-ui,sans-serif;}
+  *{box-sizing:border-box}
+  body{margin:0;font-family:var(--sans);color:var(--ink);line-height:1.65;
+    background:radial-gradient(1000px 560px at 82% -10%,rgba(14,154,161,.16),transparent 60%),var(--abyss);-webkit-font-smoothing:antialiased}
+  .wrap{max-width:920px;margin:0 auto;padding:52px 26px 72px}
+  .eyebrow{font-family:var(--mono);font-size:.76rem;letter-spacing:.16em;text-transform:uppercase;color:var(--teal)}
+  h1{font-size:clamp(1.8rem,4vw,2.6rem);margin:12px 0 8px;font-weight:800;letter-spacing:-.01em}
+  .meta{font-family:var(--mono);color:var(--muted);font-size:.88rem}
+  .meta b{color:var(--teal-soft)}
+  .badge{display:inline-block;font-family:var(--mono);font-size:.72rem;color:var(--amber);border:1px solid rgba(224,169,79,.45);border-radius:999px;padding:2px 10px;margin-left:8px}
+  h2{font-size:1.2rem;margin:38px 0 4px;font-weight:800}
+  h2 .n{font-family:var(--mono);color:var(--teal);margin-right:.5em;font-size:.88em}
+  .rule{height:1px;background:linear-gradient(90deg,var(--teal-brand),transparent);margin:9px 0 14px;opacity:.6}
+  .card{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:16px 20px;color:var(--ink)}
+  .card.state{border-left:3px solid var(--teal-brand)}
+  pre{font-family:var(--mono);font-size:.82rem;line-height:1.7;color:#cfe9ec;white-space:pre-wrap;word-break:break-word;margin:0;overflow-x:auto}
+  .times{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:4px}
+  @media(max-width:640px){.times{grid-template-columns:1fr}}
+  .tcard{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:14px 16px}
+  .tcard .lbl{font-family:var(--mono);font-size:.72rem;letter-spacing:.1em;text-transform:uppercase;color:var(--teal)}
+  .tcard .val{font-family:var(--mono);font-size:1.02rem;color:#fff;margin-top:6px;font-weight:700}
+  .tcard .val.dim{color:var(--dim);font-weight:500;font-size:.86rem}
+  .subh{font-family:var(--mono);font-size:.78rem;color:var(--teal-soft);margin:14px 0 6px;letter-spacing:.04em}
+  .note{font-family:var(--mono);font-size:.78rem;color:var(--amber);margin:0 0 14px}
+  footer{margin-top:46px;padding-top:16px;border-top:1px solid var(--line);color:var(--dim);font-family:var(--mono);font-size:.8rem;display:flex;justify-content:space-between;flex-wrap:wrap;gap:8px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">BATHOS Dynamis · 세션 작업 리포트</div>
+  <h1>작업 리포트 · session_no05<span class="badge">소급 백필 · RETROACTIVE</span></h1>
+  <div class="meta">프로젝트 <b>bathos-dynamis</b> · 세션 순번 <b>#5</b> · 원본 <b>2026-07-14-taskreport-1.html</b></div>
+  <p class="note">※ 이 리포트는 과거 세션 아카이브에서 소급 생성됨 — 원본에 기록된 사실만 포함(시작 시각·소요 시간은 당시 미기록).</p>
+
+  <h2><span class="n">1–3</span>작업 시각 &amp; 총 소요</h2>
+  <div class="rule"></div>
+  <div class="times">
+    <div class="tcard"><div class="lbl">작업 시작</div><div class="val dim">(소급 — 당시 미기록)</div></div>
+    <div class="tcard"><div class="lbl">작업 종료</div><div class="val">2026-07-14 05:40:56 KST</div></div>
+    <div class="tcard"><div class="lbl">총 작업 시간</div><div class="val dim">(소급 — 산출 불가)</div></div>
+  </div>
+
+  <h2><span class="n">4</span>작업 핵심 사항 <span style="font-size:.7em;color:var(--dim)">(원본 '현재 상태')</span></h2>
+  <div class="rule"></div>
+  <div class="card state"><pre>
+**BATHOS dynamis 랜딩페이지(`outputs/landing-web/`)의 디자인을 다회 조정**하고 **배포 파이프라인을 GCP Cloud Run + GitHub Actions CI/CD로 전환**했다. landing-web은 이번 세션 중 **git 저장소가 됨**(branch `prod`, remote `https://github.com/taxideftis/bathos-intro.git`, 최신 커밋 `308236d bathos intro web first footage`). 로컬 미리보기 **http://localhost:3200** 컨테이너(`bathos-landing-local`, 이미지 `bathos-landing:local`) healthy 구동 중. `npm run build` 무경고(4 로케일). 활성 팀원 **없음**.
+
+**⚠️ 배포 전 반드시 확인할 블로커 2건:**
+1. **CD 트리거 브랜치 불일치** — `deploy.yml`은 `push: branches:[main]`에서 배포하는데, 실제 저장소 작업 브랜치는 **`prod`**. `prod`로 push해도 CD가 안 뜬다 → 트리거 브랜치를 실제 배포 브랜치와 정합(예: `main`에 병합하거나 workflow 트리거를 `prod`로 변경)해야 함.
+2. **stray 파일** — `lib/i18n/dictionaries/es 2.ts` 가 untracked로 존재(맥 Finder 중복본 추정). 커밋 오염 전 검토/삭제 필요(리드 판단 대기, 임의 삭제 안 함).
+
+**▶ 다음 실행 커맨드:** (재개 시) `/cold-start` → 이후 **①위 블로커 2건 정리 → ②`lib/site.config.ts` URL 2개 입력 → ③GitHub Secrets(`GCP_PROJECT_ID`·`GCP_SA_KEY`) 설정 → ④push → CI/CD 가동 → ⑤도메인 확정 시 `DEPLOY.md` LB 절차 실행**, 또는 랜딩 추가 디자인 조정 계속. 로컬 재기동: `cd outputs/landing-web &amp;&amp; docker run -d --name bathos-landing-local -p 3200:3000 bathos-landing:local`.
+
+- 제품/작업 상태: 랜딩 코드 완성·로컬 검증 완료 · Cloud Run 배포 자산 준비 완료 · 실제 배포 미실행(위 블로커 대기)
+- 엔진(bathos-dynamis) 레벨: **Lv3** · 웨이브 W2/W3/W5/W6 **done** · 게이트 Plan PASS·Impl CONCERNS·Release CONCERNS · 감사 **OK(keyed HMAC, 1999 entries)**</pre></div>
+
+  <h2><span class="n">5</span>중요 이슈</h2>
+  <div class="rule"></div>
+  <div class="card"><pre>(소급 백필 — 당시 별도 이슈 로그 없음. 상세는 원본 리포트 2026-07-14-taskreport-1.html 참조.)</pre></div>
+
+  <h2><span class="n">6</span>git commit / push / PR / merge 히스토리 <span style="font-size:.7em;color:var(--dim)">(원본 기록 기준)</span></h2>
+  <div class="rule"></div>
+  <div class="card"><pre>git repo 아님(파일 직접 저장)</pre></div>
+
+  <footer>
+    <span>BATHOS · βάθος — 표층이 아닌 깊이 · 소급 백필</span>
+    <span>task_report_20260714_054056_session_no05.html</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/result_report/task_report_20260714_125630_session_no06.html
+++ b/result_report/task_report_20260714_125630_session_no06.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>BATHOS 작업 리포트 — session_no06 (소급)</title>
+<style>
+  :root{--abyss:#081215;--surface:#0f2226;--line:#1c3a40;--teal:#18b6c0;--teal-brand:#0e9aa1;--teal-soft:#7fd6dc;--ink:#e9f3f4;--muted:#8fabb0;--dim:#5f7c81;--amber:#e0a94f;
+    --mono:ui-monospace,'SFMono-Regular','JetBrains Mono',Menlo,Consolas,monospace;
+    --sans:'Pretendard','Pretendard Variable',-apple-system,BlinkMacSystemFont,'Apple SD Gothic Neo','Noto Sans KR',system-ui,sans-serif;}
+  *{box-sizing:border-box}
+  body{margin:0;font-family:var(--sans);color:var(--ink);line-height:1.65;
+    background:radial-gradient(1000px 560px at 82% -10%,rgba(14,154,161,.16),transparent 60%),var(--abyss);-webkit-font-smoothing:antialiased}
+  .wrap{max-width:920px;margin:0 auto;padding:52px 26px 72px}
+  .eyebrow{font-family:var(--mono);font-size:.76rem;letter-spacing:.16em;text-transform:uppercase;color:var(--teal)}
+  h1{font-size:clamp(1.8rem,4vw,2.6rem);margin:12px 0 8px;font-weight:800;letter-spacing:-.01em}
+  .meta{font-family:var(--mono);color:var(--muted);font-size:.88rem}
+  .meta b{color:var(--teal-soft)}
+  .badge{display:inline-block;font-family:var(--mono);font-size:.72rem;color:var(--amber);border:1px solid rgba(224,169,79,.45);border-radius:999px;padding:2px 10px;margin-left:8px}
+  h2{font-size:1.2rem;margin:38px 0 4px;font-weight:800}
+  h2 .n{font-family:var(--mono);color:var(--teal);margin-right:.5em;font-size:.88em}
+  .rule{height:1px;background:linear-gradient(90deg,var(--teal-brand),transparent);margin:9px 0 14px;opacity:.6}
+  .card{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:16px 20px;color:var(--ink)}
+  .card.state{border-left:3px solid var(--teal-brand)}
+  pre{font-family:var(--mono);font-size:.82rem;line-height:1.7;color:#cfe9ec;white-space:pre-wrap;word-break:break-word;margin:0;overflow-x:auto}
+  .times{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:4px}
+  @media(max-width:640px){.times{grid-template-columns:1fr}}
+  .tcard{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:14px 16px}
+  .tcard .lbl{font-family:var(--mono);font-size:.72rem;letter-spacing:.1em;text-transform:uppercase;color:var(--teal)}
+  .tcard .val{font-family:var(--mono);font-size:1.02rem;color:#fff;margin-top:6px;font-weight:700}
+  .tcard .val.dim{color:var(--dim);font-weight:500;font-size:.86rem}
+  .subh{font-family:var(--mono);font-size:.78rem;color:var(--teal-soft);margin:14px 0 6px;letter-spacing:.04em}
+  .note{font-family:var(--mono);font-size:.78rem;color:var(--amber);margin:0 0 14px}
+  footer{margin-top:46px;padding-top:16px;border-top:1px solid var(--line);color:var(--dim);font-family:var(--mono);font-size:.8rem;display:flex;justify-content:space-between;flex-wrap:wrap;gap:8px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">BATHOS Dynamis · 세션 작업 리포트</div>
+  <h1>작업 리포트 · session_no06<span class="badge">소급 백필 · RETROACTIVE</span></h1>
+  <div class="meta">프로젝트 <b>bathos-dynamis</b> · 세션 순번 <b>#6</b> · 원본 <b>2026-07-14-taskreport-2.html</b></div>
+  <p class="note">※ 이 리포트는 과거 세션 아카이브에서 소급 생성됨 — 원본에 기록된 사실만 포함(시작 시각·소요 시간은 당시 미기록).</p>
+
+  <h2><span class="n">1–3</span>작업 시각 &amp; 총 소요</h2>
+  <div class="rule"></div>
+  <div class="times">
+    <div class="tcard"><div class="lbl">작업 시작</div><div class="val dim">(소급 — 당시 미기록)</div></div>
+    <div class="tcard"><div class="lbl">작업 종료</div><div class="val">2026-07-14 12:56:30 KST</div></div>
+    <div class="tcard"><div class="lbl">총 작업 시간</div><div class="val dim">(소급 — 산출 불가)</div></div>
+  </div>
+
+  <h2><span class="n">4</span>작업 핵심 사항 <span style="font-size:.7em;color:var(--dim)">(원본 '현재 상태')</span></h2>
+  <div class="rule"></div>
+  <div class="card state"><pre>
+**배포·저장소·SEO 인프라 세션.** 엔진(bathos-dynamis 코드/게이트) 불변. 이번 세션 성과:
+
+1. **랜딩 `https://bathos.cc` LIVE** — Cloud Run(`bathos-landing`, asia-northeast3, GCP `project-ce7730fb-e740-4c03-bad`) + 글로벌 HTTPS LB(IP `8.233.119.207`) + 관리형 cert ACTIVE(apex+www) + Namecheap DNS. GitHub Secrets(GCP_PROJECT_ID·GCP_SA_KEY=전용 SA `bathos-deployer`).
+2. **bathos-dynamis → GitHub `taxideftis/bathos`(PUBLIC)** — 브랜치 `develop`(기본)·`prod` 둘 다 `ff45986`. CI(Rust build/test/clippy/fmt+drift-guard) 초록.
+3. **브랜치 정책** = `feat/* → PR → develop → PR → prod` (두 저장소 공통).
+4. **Committer** = 전 커밋 `taxideftis &lt;renew.inspirit@gmail.com&gt;`, **Claude 트레일러/신원 노출 금지**(기억: `no-claude-commit-trailer`). git config 두 저장소 설정 완료. **Contributor**: 각 저장소 **초기(root) 커밋 author만 `themindful &lt;55673858+themindful@users.noreply.github.com&gt;`**(committer는 taxideftis 유지)로 재귀속 → Contributors에 taxideftis + themindful. GitHub 그래프는 비동기 재계산이라 반영에 수 분~수 시간 지연(커밋 데이터는 확정).
+5. **랜딩 SEO+GEO** prod 반영 — bathos.cc에 robots.txt·sitemap.xml(4로케일+hreflang)·manifest·**llms.txt**(GEO)·JSON-LD(WebSite/Organization/SoftwareApplication)·canonical·hreflang(x-default 포함) 라이브. `metadataBase` localhost→bathos.cc 버그 수정 확인.
+
+- 활성 팀원: **없음**. 작업트리: 두 저장소 모두 **clean**, 둘 다 `develop` 체크아웃.
+- **▶ 다음 실행 커맨드:** (재개 시) `/cold-start` → 이후 새 작업은 **`feat/&lt;작업&gt;` 브랜치**(develop 기준)에서 시작 → PR→develop→PR→prod.
+
+- 엔진 레벨: **Lv3** · 웨이브 W2/W3/W5/W6 **done** · 게이트 Plan PASS·Impl CONCERNS(10/0)·Release CONCERNS · 감사 **OK(keyed HMAC, 2248 entries)**.</pre></div>
+
+  <h2><span class="n">5</span>중요 이슈</h2>
+  <div class="rule"></div>
+  <div class="card"><pre>(소급 백필 — 당시 별도 이슈 로그 없음. 상세는 원본 리포트 2026-07-14-taskreport-2.html 참조.)</pre></div>
+
+  <h2><span class="n">6</span>git commit / push / PR / merge 히스토리 <span style="font-size:.7em;color:var(--dim)">(원본 기록 기준)</span></h2>
+  <div class="rule"></div>
+  <div class="card"><pre>0 changed · ff45986 Merge PR #1: chore(repo) stop tracking site/</pre></div>
+
+  <footer>
+    <span>BATHOS · βάθος — 표층이 아닌 깊이 · 소급 백필</span>
+    <span>task_report_20260714_125630_session_no06.html</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/result_report/task_report_20260715_054504_session_no07.html
+++ b/result_report/task_report_20260715_054504_session_no07.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>BATHOS 작업 리포트 — session_no07 (소급)</title>
+<style>
+  :root{--abyss:#081215;--surface:#0f2226;--line:#1c3a40;--teal:#18b6c0;--teal-brand:#0e9aa1;--teal-soft:#7fd6dc;--ink:#e9f3f4;--muted:#8fabb0;--dim:#5f7c81;--amber:#e0a94f;
+    --mono:ui-monospace,'SFMono-Regular','JetBrains Mono',Menlo,Consolas,monospace;
+    --sans:'Pretendard','Pretendard Variable',-apple-system,BlinkMacSystemFont,'Apple SD Gothic Neo','Noto Sans KR',system-ui,sans-serif;}
+  *{box-sizing:border-box}
+  body{margin:0;font-family:var(--sans);color:var(--ink);line-height:1.65;
+    background:radial-gradient(1000px 560px at 82% -10%,rgba(14,154,161,.16),transparent 60%),var(--abyss);-webkit-font-smoothing:antialiased}
+  .wrap{max-width:920px;margin:0 auto;padding:52px 26px 72px}
+  .eyebrow{font-family:var(--mono);font-size:.76rem;letter-spacing:.16em;text-transform:uppercase;color:var(--teal)}
+  h1{font-size:clamp(1.8rem,4vw,2.6rem);margin:12px 0 8px;font-weight:800;letter-spacing:-.01em}
+  .meta{font-family:var(--mono);color:var(--muted);font-size:.88rem}
+  .meta b{color:var(--teal-soft)}
+  .badge{display:inline-block;font-family:var(--mono);font-size:.72rem;color:var(--amber);border:1px solid rgba(224,169,79,.45);border-radius:999px;padding:2px 10px;margin-left:8px}
+  h2{font-size:1.2rem;margin:38px 0 4px;font-weight:800}
+  h2 .n{font-family:var(--mono);color:var(--teal);margin-right:.5em;font-size:.88em}
+  .rule{height:1px;background:linear-gradient(90deg,var(--teal-brand),transparent);margin:9px 0 14px;opacity:.6}
+  .card{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:16px 20px;color:var(--ink)}
+  .card.state{border-left:3px solid var(--teal-brand)}
+  pre{font-family:var(--mono);font-size:.82rem;line-height:1.7;color:#cfe9ec;white-space:pre-wrap;word-break:break-word;margin:0;overflow-x:auto}
+  .times{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:4px}
+  @media(max-width:640px){.times{grid-template-columns:1fr}}
+  .tcard{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:14px 16px}
+  .tcard .lbl{font-family:var(--mono);font-size:.72rem;letter-spacing:.1em;text-transform:uppercase;color:var(--teal)}
+  .tcard .val{font-family:var(--mono);font-size:1.02rem;color:#fff;margin-top:6px;font-weight:700}
+  .tcard .val.dim{color:var(--dim);font-weight:500;font-size:.86rem}
+  .subh{font-family:var(--mono);font-size:.78rem;color:var(--teal-soft);margin:14px 0 6px;letter-spacing:.04em}
+  .note{font-family:var(--mono);font-size:.78rem;color:var(--amber);margin:0 0 14px}
+  footer{margin-top:46px;padding-top:16px;border-top:1px solid var(--line);color:var(--dim);font-family:var(--mono);font-size:.8rem;display:flex;justify-content:space-between;flex-wrap:wrap;gap:8px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">BATHOS Dynamis · 세션 작업 리포트</div>
+  <h1>작업 리포트 · session_no07<span class="badge">소급 백필 · RETROACTIVE</span></h1>
+  <div class="meta">프로젝트 <b>bathos-dynamis</b> · 세션 순번 <b>#7</b> · 원본 <b>2026-07-15-taskreport-1.html</b></div>
+  <p class="note">※ 이 리포트는 과거 세션 아카이브에서 소급 생성됨 — 원본에 기록된 사실만 포함(시작 시각·소요 시간은 당시 미기록).</p>
+
+  <h2><span class="n">1–3</span>작업 시각 &amp; 총 소요</h2>
+  <div class="rule"></div>
+  <div class="times">
+    <div class="tcard"><div class="lbl">작업 시작</div><div class="val dim">(소급 — 당시 미기록)</div></div>
+    <div class="tcard"><div class="lbl">작업 종료</div><div class="val">2026-07-15 05:45:04 KST</div></div>
+    <div class="tcard"><div class="lbl">총 작업 시간</div><div class="val dim">(소급 — 산출 불가)</div></div>
+  </div>
+
+  <h2><span class="n">4</span>작업 핵심 사항 <span style="font-size:.7em;color:var(--dim)">(원본 '현재 상태')</span></h2>
+  <div class="rule"></div>
+  <div class="card state"><pre>
+**GitHub 저장소 기여자/히스토리 정리 세션.** 엔진(코드·게이트) 불변. `taxideftis/bathos`를 **삭제 후 재생성**하여 Claude 흔적과 옛 PR ref·캐시를 근본 제거했습니다. 최종 상태:
+
+- **Contributors = `taxideftis` + `themindful`** (Claude 없음). stats: taxideftis:3, themindful:1.
+- **원격 refs = `develop` + `prod` 뿐** (옛 PR ref·옛 커밋 전부 소멸). Claude 신원·메시지 0건.
+- 신원: author 8 taxideftis + 1 themindful(초기 커밋), committer 전부 taxideftis. 단, prod 최상단 머지커밋 `30f0c8b`만 committer=GitHub(재생성 후 사용자가 GitHub UI로 develop→prod PR #1 머지 → GitHub UI 머지는 committer=GitHub 자동 스탬프. Claude 아님, contributor에 영향 없음).
+- 기본 브랜치 = **`prod`** (`30f0c8b`). develop = `95f7e52`.
+- 활성 팀원: **없음**. 로컬 develop=원격 동기화(95f7e52), 로컬 prod는 원격 `30f0c8b`보다 뒤(로컬 5cb7943 — 재개 시 `git fetch &amp;&amp; git update-ref` 정합 가능, 비차단).
+
+- 엔진 레벨: **Lv3** · 웨이브 W2/W3/W5/W6 **done** · 게이트 Plan PASS·Impl CONCERNS(10/0)·Release CONCERNS · 감사 **OK(2346 entries)**.
+
+**미완 / 다음 작업 (우선순위):**
+1. (선택) 로컬 prod를 원격 `30f0c8b`에 정합(`git fetch &amp;&amp; git update-ref refs/heads/prod origin/prod`).
+2. (선택) 로컬 백업 태그(`backup/*`·`backup2/*`·`backup3/*`) + 스크래치패드 번들 정리 — 결과 안정 확인됨.
+3. (참고) 이후 GitHub UI/웹에서 PR "Merge" 시 committer=GitHub가 붙음 — 전부 taxideftis 유지하려면 로컬 머지 후 push.
+
+**▶ 다음에 실행할 커맨드:** `/cold-start` (재개 시) → 이후 새 작업은 `feat/&lt;작업&gt;`(develop 기준) → PR→develop→PR→prod.</pre></div>
+
+  <h2><span class="n">5</span>중요 이슈</h2>
+  <div class="rule"></div>
+  <div class="card"><pre>(소급 백필 — 당시 별도 이슈 로그 없음. 상세는 원본 리포트 2026-07-15-taskreport-1.html 참조.)</pre></div>
+
+  <h2><span class="n">6</span>git commit / push / PR / merge 히스토리 <span style="font-size:.7em;color:var(--dim)">(원본 기록 기준)</span></h2>
+  <div class="rule"></div>
+  <div class="card"><pre>0 changed · 95f7e52 Merge pull request #6 from taxideftis/prod</pre></div>
+
+  <footer>
+    <span>BATHOS · βάθος — 표층이 아닌 깊이 · 소급 백필</span>
+    <span>task_report_20260715_054504_session_no07.html</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/result_report/task_report_20260715_110043_session_no08.html
+++ b/result_report/task_report_20260715_110043_session_no08.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>BATHOS 작업 리포트 — session_no08 (소급)</title>
+<style>
+  :root{--abyss:#081215;--surface:#0f2226;--line:#1c3a40;--teal:#18b6c0;--teal-brand:#0e9aa1;--teal-soft:#7fd6dc;--ink:#e9f3f4;--muted:#8fabb0;--dim:#5f7c81;--amber:#e0a94f;
+    --mono:ui-monospace,'SFMono-Regular','JetBrains Mono',Menlo,Consolas,monospace;
+    --sans:'Pretendard','Pretendard Variable',-apple-system,BlinkMacSystemFont,'Apple SD Gothic Neo','Noto Sans KR',system-ui,sans-serif;}
+  *{box-sizing:border-box}
+  body{margin:0;font-family:var(--sans);color:var(--ink);line-height:1.65;
+    background:radial-gradient(1000px 560px at 82% -10%,rgba(14,154,161,.16),transparent 60%),var(--abyss);-webkit-font-smoothing:antialiased}
+  .wrap{max-width:920px;margin:0 auto;padding:52px 26px 72px}
+  .eyebrow{font-family:var(--mono);font-size:.76rem;letter-spacing:.16em;text-transform:uppercase;color:var(--teal)}
+  h1{font-size:clamp(1.8rem,4vw,2.6rem);margin:12px 0 8px;font-weight:800;letter-spacing:-.01em}
+  .meta{font-family:var(--mono);color:var(--muted);font-size:.88rem}
+  .meta b{color:var(--teal-soft)}
+  .badge{display:inline-block;font-family:var(--mono);font-size:.72rem;color:var(--amber);border:1px solid rgba(224,169,79,.45);border-radius:999px;padding:2px 10px;margin-left:8px}
+  h2{font-size:1.2rem;margin:38px 0 4px;font-weight:800}
+  h2 .n{font-family:var(--mono);color:var(--teal);margin-right:.5em;font-size:.88em}
+  .rule{height:1px;background:linear-gradient(90deg,var(--teal-brand),transparent);margin:9px 0 14px;opacity:.6}
+  .card{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:16px 20px;color:var(--ink)}
+  .card.state{border-left:3px solid var(--teal-brand)}
+  pre{font-family:var(--mono);font-size:.82rem;line-height:1.7;color:#cfe9ec;white-space:pre-wrap;word-break:break-word;margin:0;overflow-x:auto}
+  .times{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:4px}
+  @media(max-width:640px){.times{grid-template-columns:1fr}}
+  .tcard{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:14px 16px}
+  .tcard .lbl{font-family:var(--mono);font-size:.72rem;letter-spacing:.1em;text-transform:uppercase;color:var(--teal)}
+  .tcard .val{font-family:var(--mono);font-size:1.02rem;color:#fff;margin-top:6px;font-weight:700}
+  .tcard .val.dim{color:var(--dim);font-weight:500;font-size:.86rem}
+  .subh{font-family:var(--mono);font-size:.78rem;color:var(--teal-soft);margin:14px 0 6px;letter-spacing:.04em}
+  .note{font-family:var(--mono);font-size:.78rem;color:var(--amber);margin:0 0 14px}
+  footer{margin-top:46px;padding-top:16px;border-top:1px solid var(--line);color:var(--dim);font-family:var(--mono);font-size:.8rem;display:flex;justify-content:space-between;flex-wrap:wrap;gap:8px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">BATHOS Dynamis · 세션 작업 리포트</div>
+  <h1>작업 리포트 · session_no08<span class="badge">소급 백필 · RETROACTIVE</span></h1>
+  <div class="meta">프로젝트 <b>bathos-dynamis</b> · 세션 순번 <b>#8</b> · 원본 <b>2026-07-15-taskreport-2.html</b></div>
+  <p class="note">※ 이 리포트는 과거 세션 아카이브에서 소급 생성됨 — 원본에 기록된 사실만 포함(시작 시각·소요 시간은 당시 미기록).</p>
+
+  <h2><span class="n">1–3</span>작업 시각 &amp; 총 소요</h2>
+  <div class="rule"></div>
+  <div class="times">
+    <div class="tcard"><div class="lbl">작업 시작</div><div class="val dim">(소급 — 당시 미기록)</div></div>
+    <div class="tcard"><div class="lbl">작업 종료</div><div class="val">2026-07-15 11:00:43 KST</div></div>
+    <div class="tcard"><div class="lbl">총 작업 시간</div><div class="val dim">(소급 — 산출 불가)</div></div>
+  </div>
+
+  <h2><span class="n">4</span>작업 핵심 사항 <span style="font-size:.7em;color:var(--dim)">(원본 '현재 상태')</span></h2>
+  <div class="rule"></div>
+  <div class="card state"><pre>
+**GitHub 저장소 기여자/히스토리 정리 세션.** 엔진(코드·게이트) 불변. `taxideftis/bathos`를 **삭제 후 재생성**하여 Claude 흔적과 옛 PR ref·캐시를 근본 제거했습니다. 최종 상태:
+
+- **Contributors = `taxideftis` + `themindful`** (Claude 없음). stats: taxideftis:3, themindful:1.
+- **원격 refs = `develop` + `prod` 뿐** (옛 PR ref·옛 커밋 전부 소멸). Claude 신원·메시지 0건.
+- 신원: author 8 taxideftis + 1 themindful(초기 커밋), committer 전부 taxideftis. 단, prod 최상단 머지커밋 `30f0c8b`만 committer=GitHub(재생성 후 사용자가 GitHub UI로 develop→prod PR #1 머지 → GitHub UI 머지는 committer=GitHub 자동 스탬프. Claude 아님, contributor에 영향 없음).
+- 기본 브랜치 = **`prod`** (`30f0c8b`). develop = `95f7e52`.
+- 활성 팀원: **없음**. 로컬 develop=원격 동기화(95f7e52), 로컬 prod는 원격 `30f0c8b`보다 뒤(로컬 5cb7943 — 재개 시 `git fetch &amp;&amp; git update-ref` 정합 가능, 비차단).
+
+- 엔진 레벨: **Lv3** · 웨이브 W2/W3/W5/W6 **done** · 게이트 Plan PASS·Impl CONCERNS(10/0)·Release CONCERNS · 감사 **OK(2346 entries)**.
+
+**미완 / 다음 작업 (우선순위):**
+1. (선택) 로컬 prod를 원격 `30f0c8b`에 정합(`git fetch &amp;&amp; git update-ref refs/heads/prod origin/prod`).
+2. (선택) 로컬 백업 태그(`backup/*`·`backup2/*`·`backup3/*`) + 스크래치패드 번들 정리 — 결과 안정 확인됨.
+3. (참고) 이후 GitHub UI/웹에서 PR "Merge" 시 committer=GitHub가 붙음 — 전부 taxideftis 유지하려면 로컬 머지 후 push.
+
+**▶ 다음에 실행할 커맨드:** `/cold-start` (재개 시) → 이후 새 작업은 `feat/&lt;작업&gt;`(develop 기준) → PR→develop→PR→prod.</pre></div>
+
+  <h2><span class="n">5</span>중요 이슈</h2>
+  <div class="rule"></div>
+  <div class="card"><pre>(소급 백필 — 당시 별도 이슈 로그 없음. 상세는 원본 리포트 2026-07-15-taskreport-2.html 참조.)</pre></div>
+
+  <h2><span class="n">6</span>git commit / push / PR / merge 히스토리 <span style="font-size:.7em;color:var(--dim)">(원본 기록 기준)</span></h2>
+  <div class="rule"></div>
+  <div class="card"><pre>49 changed · 95f7e52 Merge pull request #6 from taxideftis/prod</pre></div>
+
+  <footer>
+    <span>BATHOS · βάθος — 표층이 아닌 깊이 · 소급 백필</span>
+    <span>task_report_20260715_110043_session_no08.html</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/result_report/task_report_20260715_135900_session_no09.html
+++ b/result_report/task_report_20260715_135900_session_no09.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>BATHOS 작업 리포트 — session_no09 (소급)</title>
+<style>
+  :root{--abyss:#081215;--surface:#0f2226;--line:#1c3a40;--teal:#18b6c0;--teal-brand:#0e9aa1;--teal-soft:#7fd6dc;--ink:#e9f3f4;--muted:#8fabb0;--dim:#5f7c81;--amber:#e0a94f;
+    --mono:ui-monospace,'SFMono-Regular','JetBrains Mono',Menlo,Consolas,monospace;
+    --sans:'Pretendard','Pretendard Variable',-apple-system,BlinkMacSystemFont,'Apple SD Gothic Neo','Noto Sans KR',system-ui,sans-serif;}
+  *{box-sizing:border-box}
+  body{margin:0;font-family:var(--sans);color:var(--ink);line-height:1.65;
+    background:radial-gradient(1000px 560px at 82% -10%,rgba(14,154,161,.16),transparent 60%),var(--abyss);-webkit-font-smoothing:antialiased}
+  .wrap{max-width:920px;margin:0 auto;padding:52px 26px 72px}
+  .eyebrow{font-family:var(--mono);font-size:.76rem;letter-spacing:.16em;text-transform:uppercase;color:var(--teal)}
+  h1{font-size:clamp(1.8rem,4vw,2.6rem);margin:12px 0 8px;font-weight:800;letter-spacing:-.01em}
+  .meta{font-family:var(--mono);color:var(--muted);font-size:.88rem}
+  .meta b{color:var(--teal-soft)}
+  .badge{display:inline-block;font-family:var(--mono);font-size:.72rem;color:var(--amber);border:1px solid rgba(224,169,79,.45);border-radius:999px;padding:2px 10px;margin-left:8px}
+  h2{font-size:1.2rem;margin:38px 0 4px;font-weight:800}
+  h2 .n{font-family:var(--mono);color:var(--teal);margin-right:.5em;font-size:.88em}
+  .rule{height:1px;background:linear-gradient(90deg,var(--teal-brand),transparent);margin:9px 0 14px;opacity:.6}
+  .card{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:16px 20px;color:var(--ink)}
+  .card.state{border-left:3px solid var(--teal-brand)}
+  pre{font-family:var(--mono);font-size:.82rem;line-height:1.7;color:#cfe9ec;white-space:pre-wrap;word-break:break-word;margin:0;overflow-x:auto}
+  .times{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:4px}
+  @media(max-width:640px){.times{grid-template-columns:1fr}}
+  .tcard{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:14px 16px}
+  .tcard .lbl{font-family:var(--mono);font-size:.72rem;letter-spacing:.1em;text-transform:uppercase;color:var(--teal)}
+  .tcard .val{font-family:var(--mono);font-size:1.02rem;color:#fff;margin-top:6px;font-weight:700}
+  .tcard .val.dim{color:var(--dim);font-weight:500;font-size:.86rem}
+  .subh{font-family:var(--mono);font-size:.78rem;color:var(--teal-soft);margin:14px 0 6px;letter-spacing:.04em}
+  .note{font-family:var(--mono);font-size:.78rem;color:var(--amber);margin:0 0 14px}
+  footer{margin-top:46px;padding-top:16px;border-top:1px solid var(--line);color:var(--dim);font-family:var(--mono);font-size:.8rem;display:flex;justify-content:space-between;flex-wrap:wrap;gap:8px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">BATHOS Dynamis · 세션 작업 리포트</div>
+  <h1>작업 리포트 · session_no09<span class="badge">소급 백필 · RETROACTIVE</span></h1>
+  <div class="meta">프로젝트 <b>bathos-dynamis</b> · 세션 순번 <b>#9</b> · 원본 <b>2026-07-15-taskreport-3.html</b></div>
+  <p class="note">※ 이 리포트는 과거 세션 아카이브에서 소급 생성됨 — 원본에 기록된 사실만 포함(시작 시각·소요 시간은 당시 미기록).</p>
+
+  <h2><span class="n">1–3</span>작업 시각 &amp; 총 소요</h2>
+  <div class="rule"></div>
+  <div class="times">
+    <div class="tcard"><div class="lbl">작업 시작</div><div class="val dim">(소급 — 당시 미기록)</div></div>
+    <div class="tcard"><div class="lbl">작업 종료</div><div class="val">2026-07-15 13:59:00 KST</div></div>
+    <div class="tcard"><div class="lbl">총 작업 시간</div><div class="val dim">(소급 — 산출 불가)</div></div>
+  </div>
+
+  <h2><span class="n">4</span>작업 핵심 사항 <span style="font-size:.7em;color:var(--dim)">(원본 '현재 상태')</span></h2>
+  <div class="rule"></div>
+  <div class="card state"><pre>
+**GitHub 저장소 기여자/히스토리 정리 세션.** 엔진(코드·게이트) 불변. `taxideftis/bathos`를 **삭제 후 재생성**하여 Claude 흔적과 옛 PR ref·캐시를 근본 제거했습니다. 최종 상태:
+
+- **Contributors = `taxideftis` + `themindful`** (Claude 없음). stats: taxideftis:3, themindful:1.
+- **원격 refs = `develop` + `prod` 뿐** (옛 PR ref·옛 커밋 전부 소멸). Claude 신원·메시지 0건.
+- 신원: author 8 taxideftis + 1 themindful(초기 커밋), committer 전부 taxideftis. 단, prod 최상단 머지커밋 `30f0c8b`만 committer=GitHub(재생성 후 사용자가 GitHub UI로 develop→prod PR #1 머지 → GitHub UI 머지는 committer=GitHub 자동 스탬프. Claude 아님, contributor에 영향 없음).
+- 기본 브랜치 = **`prod`** (`30f0c8b`). develop = `95f7e52`.
+- 활성 팀원: **없음**. 로컬 develop=원격 동기화(95f7e52), 로컬 prod는 원격 `30f0c8b`보다 뒤(로컬 5cb7943 — 재개 시 `git fetch &amp;&amp; git update-ref` 정합 가능, 비차단).
+
+- 엔진 레벨: **Lv3** · 웨이브 W2/W3/W5/W6 **done** · 게이트 Plan PASS·Impl CONCERNS(10/0)·Release CONCERNS · 감사 **OK(2346 entries)**.
+
+**미완 / 다음 작업 (우선순위):**
+1. (선택) 로컬 prod를 원격 `30f0c8b`에 정합(`git fetch &amp;&amp; git update-ref refs/heads/prod origin/prod`).
+2. (선택) 로컬 백업 태그(`backup/*`·`backup2/*`·`backup3/*`) + 스크래치패드 번들 정리 — 결과 안정 확인됨.
+3. (참고) 이후 GitHub UI/웹에서 PR "Merge" 시 committer=GitHub가 붙음 — 전부 taxideftis 유지하려면 로컬 머지 후 push.
+
+**▶ 다음에 실행할 커맨드:** `/cold-start` (재개 시) → 이후 새 작업은 `feat/&lt;작업&gt;`(develop 기준) → PR→develop→PR→prod.</pre></div>
+
+  <h2><span class="n">5</span>중요 이슈</h2>
+  <div class="rule"></div>
+  <div class="card"><pre>(소급 백필 — 당시 별도 이슈 로그 없음. 상세는 원본 리포트 2026-07-15-taskreport-3.html 참조.)</pre></div>
+
+  <h2><span class="n">6</span>git commit / push / PR / merge 히스토리 <span style="font-size:.7em;color:var(--dim)">(원본 기록 기준)</span></h2>
+  <div class="rule"></div>
+  <div class="card"><pre>53 changed · 95f7e52 Merge pull request #6 from taxideftis/prod</pre></div>
+
+  <footer>
+    <span>BATHOS · βάθος — 표층이 아닌 깊이 · 소급 백필</span>
+    <span>task_report_20260715_135900_session_no09.html</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/result_report/task_report_20260715_150301_session_no10.html
+++ b/result_report/task_report_20260715_150301_session_no10.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>BATHOS 작업 리포트 — session_no10 (소급)</title>
+<style>
+  :root{--abyss:#081215;--surface:#0f2226;--line:#1c3a40;--teal:#18b6c0;--teal-brand:#0e9aa1;--teal-soft:#7fd6dc;--ink:#e9f3f4;--muted:#8fabb0;--dim:#5f7c81;--amber:#e0a94f;
+    --mono:ui-monospace,'SFMono-Regular','JetBrains Mono',Menlo,Consolas,monospace;
+    --sans:'Pretendard','Pretendard Variable',-apple-system,BlinkMacSystemFont,'Apple SD Gothic Neo','Noto Sans KR',system-ui,sans-serif;}
+  *{box-sizing:border-box}
+  body{margin:0;font-family:var(--sans);color:var(--ink);line-height:1.65;
+    background:radial-gradient(1000px 560px at 82% -10%,rgba(14,154,161,.16),transparent 60%),var(--abyss);-webkit-font-smoothing:antialiased}
+  .wrap{max-width:920px;margin:0 auto;padding:52px 26px 72px}
+  .eyebrow{font-family:var(--mono);font-size:.76rem;letter-spacing:.16em;text-transform:uppercase;color:var(--teal)}
+  h1{font-size:clamp(1.8rem,4vw,2.6rem);margin:12px 0 8px;font-weight:800;letter-spacing:-.01em}
+  .meta{font-family:var(--mono);color:var(--muted);font-size:.88rem}
+  .meta b{color:var(--teal-soft)}
+  .badge{display:inline-block;font-family:var(--mono);font-size:.72rem;color:var(--amber);border:1px solid rgba(224,169,79,.45);border-radius:999px;padding:2px 10px;margin-left:8px}
+  h2{font-size:1.2rem;margin:38px 0 4px;font-weight:800}
+  h2 .n{font-family:var(--mono);color:var(--teal);margin-right:.5em;font-size:.88em}
+  .rule{height:1px;background:linear-gradient(90deg,var(--teal-brand),transparent);margin:9px 0 14px;opacity:.6}
+  .card{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:16px 20px;color:var(--ink)}
+  .card.state{border-left:3px solid var(--teal-brand)}
+  pre{font-family:var(--mono);font-size:.82rem;line-height:1.7;color:#cfe9ec;white-space:pre-wrap;word-break:break-word;margin:0;overflow-x:auto}
+  .times{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:4px}
+  @media(max-width:640px){.times{grid-template-columns:1fr}}
+  .tcard{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:14px 16px}
+  .tcard .lbl{font-family:var(--mono);font-size:.72rem;letter-spacing:.1em;text-transform:uppercase;color:var(--teal)}
+  .tcard .val{font-family:var(--mono);font-size:1.02rem;color:#fff;margin-top:6px;font-weight:700}
+  .tcard .val.dim{color:var(--dim);font-weight:500;font-size:.86rem}
+  .subh{font-family:var(--mono);font-size:.78rem;color:var(--teal-soft);margin:14px 0 6px;letter-spacing:.04em}
+  .note{font-family:var(--mono);font-size:.78rem;color:var(--amber);margin:0 0 14px}
+  footer{margin-top:46px;padding-top:16px;border-top:1px solid var(--line);color:var(--dim);font-family:var(--mono);font-size:.8rem;display:flex;justify-content:space-between;flex-wrap:wrap;gap:8px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">BATHOS Dynamis · 세션 작업 리포트</div>
+  <h1>작업 리포트 · session_no10<span class="badge">소급 백필 · RETROACTIVE</span></h1>
+  <div class="meta">프로젝트 <b>bathos-dynamis</b> · 세션 순번 <b>#10</b> · 원본 <b>2026-07-15-taskreport-4.html</b></div>
+  <p class="note">※ 이 리포트는 과거 세션 아카이브에서 소급 생성됨 — 원본에 기록된 사실만 포함(시작 시각·소요 시간은 당시 미기록).</p>
+
+  <h2><span class="n">1–3</span>작업 시각 &amp; 총 소요</h2>
+  <div class="rule"></div>
+  <div class="times">
+    <div class="tcard"><div class="lbl">작업 시작</div><div class="val dim">(소급 — 당시 미기록)</div></div>
+    <div class="tcard"><div class="lbl">작업 종료</div><div class="val">2026-07-15 15:03:01 KST</div></div>
+    <div class="tcard"><div class="lbl">총 작업 시간</div><div class="val dim">(소급 — 산출 불가)</div></div>
+  </div>
+
+  <h2><span class="n">4</span>작업 핵심 사항 <span style="font-size:.7em;color:var(--dim)">(원본 '현재 상태')</span></h2>
+  <div class="rule"></div>
+  <div class="card state"><pre>
+**GitHub 저장소 기여자/히스토리 정리 세션.** 엔진(코드·게이트) 불변. `taxideftis/bathos`를 **삭제 후 재생성**하여 Claude 흔적과 옛 PR ref·캐시를 근본 제거했습니다. 최종 상태:
+
+- **Contributors = `taxideftis` + `themindful`** (Claude 없음). stats: taxideftis:3, themindful:1.
+- **원격 refs = `develop` + `prod` 뿐** (옛 PR ref·옛 커밋 전부 소멸). Claude 신원·메시지 0건.
+- 신원: author 8 taxideftis + 1 themindful(초기 커밋), committer 전부 taxideftis. 단, prod 최상단 머지커밋 `30f0c8b`만 committer=GitHub(재생성 후 사용자가 GitHub UI로 develop→prod PR #1 머지 → GitHub UI 머지는 committer=GitHub 자동 스탬프. Claude 아님, contributor에 영향 없음).
+- 기본 브랜치 = **`prod`** (`30f0c8b`). develop = `95f7e52`.
+- 활성 팀원: **없음**. 로컬 develop=원격 동기화(95f7e52), 로컬 prod는 원격 `30f0c8b`보다 뒤(로컬 5cb7943 — 재개 시 `git fetch &amp;&amp; git update-ref` 정합 가능, 비차단).
+
+- 엔진 레벨: **Lv3** · 웨이브 W2/W3/W5/W6 **done** · 게이트 Plan PASS·Impl CONCERNS(10/0)·Release CONCERNS · 감사 **OK(2346 entries)**.
+
+**미완 / 다음 작업 (우선순위):**
+1. (선택) 로컬 prod를 원격 `30f0c8b`에 정합(`git fetch &amp;&amp; git update-ref refs/heads/prod origin/prod`).
+2. (선택) 로컬 백업 태그(`backup/*`·`backup2/*`·`backup3/*`) + 스크래치패드 번들 정리 — 결과 안정 확인됨.
+3. (참고) 이후 GitHub UI/웹에서 PR "Merge" 시 committer=GitHub가 붙음 — 전부 taxideftis 유지하려면 로컬 머지 후 push.
+
+**▶ 다음에 실행할 커맨드:** `/cold-start` (재개 시) → 이후 새 작업은 `feat/&lt;작업&gt;`(develop 기준) → PR→develop→PR→prod.</pre></div>
+
+  <h2><span class="n">5</span>중요 이슈</h2>
+  <div class="rule"></div>
+  <div class="card"><pre>(소급 백필 — 당시 별도 이슈 로그 없음. 상세는 원본 리포트 2026-07-15-taskreport-4.html 참조.)</pre></div>
+
+  <h2><span class="n">6</span>git commit / push / PR / merge 히스토리 <span style="font-size:.7em;color:var(--dim)">(원본 기록 기준)</span></h2>
+  <div class="rule"></div>
+  <div class="card"><pre>26 changed · babcbc7 feat(windows): PowerShell 5.1+ port with feature parity (hooks, installer, engine, CI)</pre></div>
+
+  <footer>
+    <span>BATHOS · βάθος — 표층이 아닌 깊이 · 소급 백필</span>
+    <span>task_report_20260715_150301_session_no10.html</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/result_report/task_report_20260715_180642_session_no11.html
+++ b/result_report/task_report_20260715_180642_session_no11.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>BATHOS 작업 리포트 — session_no11 (소급)</title>
+<style>
+  :root{--abyss:#081215;--surface:#0f2226;--line:#1c3a40;--teal:#18b6c0;--teal-brand:#0e9aa1;--teal-soft:#7fd6dc;--ink:#e9f3f4;--muted:#8fabb0;--dim:#5f7c81;--amber:#e0a94f;
+    --mono:ui-monospace,'SFMono-Regular','JetBrains Mono',Menlo,Consolas,monospace;
+    --sans:'Pretendard','Pretendard Variable',-apple-system,BlinkMacSystemFont,'Apple SD Gothic Neo','Noto Sans KR',system-ui,sans-serif;}
+  *{box-sizing:border-box}
+  body{margin:0;font-family:var(--sans);color:var(--ink);line-height:1.65;
+    background:radial-gradient(1000px 560px at 82% -10%,rgba(14,154,161,.16),transparent 60%),var(--abyss);-webkit-font-smoothing:antialiased}
+  .wrap{max-width:920px;margin:0 auto;padding:52px 26px 72px}
+  .eyebrow{font-family:var(--mono);font-size:.76rem;letter-spacing:.16em;text-transform:uppercase;color:var(--teal)}
+  h1{font-size:clamp(1.8rem,4vw,2.6rem);margin:12px 0 8px;font-weight:800;letter-spacing:-.01em}
+  .meta{font-family:var(--mono);color:var(--muted);font-size:.88rem}
+  .meta b{color:var(--teal-soft)}
+  .badge{display:inline-block;font-family:var(--mono);font-size:.72rem;color:var(--amber);border:1px solid rgba(224,169,79,.45);border-radius:999px;padding:2px 10px;margin-left:8px}
+  h2{font-size:1.2rem;margin:38px 0 4px;font-weight:800}
+  h2 .n{font-family:var(--mono);color:var(--teal);margin-right:.5em;font-size:.88em}
+  .rule{height:1px;background:linear-gradient(90deg,var(--teal-brand),transparent);margin:9px 0 14px;opacity:.6}
+  .card{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:16px 20px;color:var(--ink)}
+  .card.state{border-left:3px solid var(--teal-brand)}
+  pre{font-family:var(--mono);font-size:.82rem;line-height:1.7;color:#cfe9ec;white-space:pre-wrap;word-break:break-word;margin:0;overflow-x:auto}
+  .times{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:4px}
+  @media(max-width:640px){.times{grid-template-columns:1fr}}
+  .tcard{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:14px 16px}
+  .tcard .lbl{font-family:var(--mono);font-size:.72rem;letter-spacing:.1em;text-transform:uppercase;color:var(--teal)}
+  .tcard .val{font-family:var(--mono);font-size:1.02rem;color:#fff;margin-top:6px;font-weight:700}
+  .tcard .val.dim{color:var(--dim);font-weight:500;font-size:.86rem}
+  .subh{font-family:var(--mono);font-size:.78rem;color:var(--teal-soft);margin:14px 0 6px;letter-spacing:.04em}
+  .note{font-family:var(--mono);font-size:.78rem;color:var(--amber);margin:0 0 14px}
+  footer{margin-top:46px;padding-top:16px;border-top:1px solid var(--line);color:var(--dim);font-family:var(--mono);font-size:.8rem;display:flex;justify-content:space-between;flex-wrap:wrap;gap:8px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">BATHOS Dynamis · 세션 작업 리포트</div>
+  <h1>작업 리포트 · session_no11<span class="badge">소급 백필 · RETROACTIVE</span></h1>
+  <div class="meta">프로젝트 <b>bathos-dynamis</b> · 세션 순번 <b>#11</b> · 원본 <b>2026-07-15-taskreport-5.html</b></div>
+  <p class="note">※ 이 리포트는 과거 세션 아카이브에서 소급 생성됨 — 원본에 기록된 사실만 포함(시작 시각·소요 시간은 당시 미기록).</p>
+
+  <h2><span class="n">1–3</span>작업 시각 &amp; 총 소요</h2>
+  <div class="rule"></div>
+  <div class="times">
+    <div class="tcard"><div class="lbl">작업 시작</div><div class="val dim">(소급 — 당시 미기록)</div></div>
+    <div class="tcard"><div class="lbl">작업 종료</div><div class="val">2026-07-15 18:06:42 KST</div></div>
+    <div class="tcard"><div class="lbl">총 작업 시간</div><div class="val dim">(소급 — 산출 불가)</div></div>
+  </div>
+
+  <h2><span class="n">4</span>작업 핵심 사항 <span style="font-size:.7em;color:var(--dim)">(원본 '현재 상태')</span></h2>
+  <div class="rule"></div>
+  <div class="card state"><pre>
+**크로스플랫폼 확장 완료·릴리스됨.** Mac/Linux 전용이던 BATHOS를 Windows(PowerShell) + WSL 로 확장하고, 세 플랫폼 설치가이드를 갖췄습니다. 모두 prod까지 머지 완료.
+
+- **원격:** `origin/prod = 7187204` · `origin/develop = 7259660`. **오픈 PR 0건.** `prod..develop` 비어있음(완전 동기).
+- **이번 세션 머지 완료 PR:** #2(Windows 포트→develop) · #3(→prod) · #4(설치가이드 docs→develop→prod) · #5(WSL→develop) · #6(→prod). 전부 **로컬 no-ff 머지 → committer=taxideftis**, Claude 트레일러 없음.
+- **CI 전 단계 green:** Engine · Safety hooks · **Windows(windows-latest: 엔진빌드→bathos.exe·cargo test·전.ps1 파싱린트·PS5.1 훅하네스)**.
+- **활성 팀원: 없음.** 포트 에이전트 3개(hooks/installer/test-harness) 모두 종료. 재스폰 대상 없음.
+- **머지 완료 feat 브랜치 2개(`feat/windows-powershell`·`feat/windows-wsl`) 로컬+원격 삭제 완료.**
+- **엔진 웨이브/게이트: 불변** — Lv3 · W2/W3/W5/W6 done · Plan PASS / Implementation CONCERNS(10/0) / Release CONCERNS · 감사 **OK(2752 entries)**.
+- **로컬 체크아웃 = `develop`** (동기 상태).
+
+**미완 / 다음 작업:** 없음(크로스플랫폼 확장 마무리됨). 새 작업은 `feat/&lt;작업&gt;`(develop 기준) → PR→develop→PR→prod.
+
+**▶ 다음에 실행할 커맨드:** `/cold-start`(재개 시) → 새 작업은 `feat/&lt;작업&gt;` 브랜치.</pre></div>
+
+  <h2><span class="n">5</span>중요 이슈</h2>
+  <div class="rule"></div>
+  <div class="card"><pre>(소급 백필 — 당시 별도 이슈 로그 없음. 상세는 원본 리포트 2026-07-15-taskreport-5.html 참조.)</pre></div>
+
+  <h2><span class="n">6</span>git commit / push / PR / merge 히스토리 <span style="font-size:.7em;color:var(--dim)">(원본 기록 기준)</span></h2>
+  <div class="rule"></div>
+  <div class="card"><pre>26 changed · 7259660 Merge PR #5: WSL development support into develop</pre></div>
+
+  <footer>
+    <span>BATHOS · βάθος — 표층이 아닌 깊이 · 소급 백필</span>
+    <span>task_report_20260715_180642_session_no11.html</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/result_report/task_report_20260716_102053_session_no01.html
+++ b/result_report/task_report_20260716_102053_session_no01.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>BATHOS 작업 리포트 — session_no01</title>
+<style>
+  :root{--abyss:#081215;--surface:#0f2226;--line:#1c3a40;--teal:#18b6c0;--teal-brand:#0e9aa1;--teal-soft:#7fd6dc;--ink:#e9f3f4;--muted:#8fabb0;--dim:#5f7c81;--grn:#4fbf9a;
+    --mono:ui-monospace,'SFMono-Regular','JetBrains Mono',Menlo,Consolas,monospace;
+    --sans:'Pretendard','Pretendard Variable',-apple-system,BlinkMacSystemFont,'Apple SD Gothic Neo','Noto Sans KR',system-ui,sans-serif;}
+  *{box-sizing:border-box}
+  body{margin:0;font-family:var(--sans);color:var(--ink);line-height:1.65;
+    background:radial-gradient(1000px 560px at 82% -10%,rgba(14,154,161,.16),transparent 60%),var(--abyss);-webkit-font-smoothing:antialiased}
+  .wrap{max-width:920px;margin:0 auto;padding:52px 26px 72px}
+  .eyebrow{font-family:var(--mono);font-size:.76rem;letter-spacing:.16em;text-transform:uppercase;color:var(--teal)}
+  h1{font-size:clamp(1.8rem,4vw,2.6rem);margin:12px 0 8px;font-weight:800;letter-spacing:-.01em}
+  .meta{font-family:var(--mono);color:var(--muted);font-size:.88rem}
+  .meta b{color:var(--teal-soft)}
+  h2{font-size:1.2rem;margin:38px 0 4px;font-weight:800}
+  h2 .n{font-family:var(--mono);color:var(--teal);margin-right:.5em;font-size:.88em}
+  .rule{height:1px;background:linear-gradient(90deg,var(--teal-brand),transparent);margin:9px 0 14px;opacity:.6}
+  .card{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:16px 20px;color:var(--ink)}
+  .card.state{border-left:3px solid var(--teal-brand)}
+  .card p{margin:.35em 0}.card ul{margin:.35em 0 .35em 0;padding-left:1.25em}.card li{margin:.28em 0}
+  .card b{color:#fff}
+  pre{font-family:var(--mono);font-size:.82rem;line-height:1.7;color:#cfe9ec;white-space:pre-wrap;word-break:break-word;margin:0;overflow-x:auto}
+  .times{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:4px}
+  @media(max-width:640px){.times{grid-template-columns:1fr}}
+  .tcard{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:14px 16px}
+  .tcard .lbl{font-family:var(--mono);font-size:.72rem;letter-spacing:.1em;text-transform:uppercase;color:var(--teal)}
+  .tcard .val{font-family:var(--mono);font-size:1.02rem;color:#fff;margin-top:6px;font-weight:700}
+  .subh{font-family:var(--mono);font-size:.78rem;color:var(--teal-soft);margin:14px 0 6px;letter-spacing:.04em}
+  footer{margin-top:46px;padding-top:16px;border-top:1px solid var(--line);color:var(--dim);font-family:var(--mono);font-size:.8rem;display:flex;justify-content:space-between;flex-wrap:wrap;gap:8px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">BATHOS Dynamis · 세션 작업 리포트</div>
+  <h1>작업 리포트 · session_no01</h1>
+  <div class="meta">생성 <b>2026-07-16 10:20:53 KST</b> · 프로젝트 <b>bathos-dynamis</b> · 세션 순번 <b>#1</b></div>
+
+  <h2><span class="n">1–3</span>작업 시각 &amp; 총 소요</h2>
+  <div class="rule"></div>
+  <div class="times">
+    <div class="tcard"><div class="lbl">작업 시작</div><div class="val">2026-07-16 10:07:16 KST</div></div>
+    <div class="tcard"><div class="lbl">작업 종료</div><div class="val">2026-07-16 10:20:53 KST</div></div>
+    <div class="tcard"><div class="lbl">총 작업 시간</div><div class="val">0시간 13분 37초</div></div>
+  </div>
+
+  <h2><span class="n">4</span>작업 핵심 사항</h2>
+  <div class="rule"></div>
+  <div class="card state"><ul>
+<li><b>콜드스타트 복원:</b> 이전 세션(s7, 2026-07-15)까지의 전체 상태를 무손실 복원. SESSION-SNAPSHOT ↔ session-state.json ↔ manifest 3자 교차확인, 감사 해시체인 무결 검증(2767 entries, genesis→tail 정상).</li>
+<li><b>드리프트 감지:</b> s7 스냅샷은 "prod PR #4 = OPEN(배포 대기)"로 얼어 있었으나 실측 결과 <b>PR #4 = MERGED</b>(bathos.cc 배포 완료) + landing-web에 <b>Install step 2(link) 후속 작업</b>이 /save 없이 추가·머지됨을 확인.</li>
+<li><b>feat/task-report 브랜치 생성:</b> develop 기준으로 분기.</li>
+<li><b>task-report 시스템 신설:</b> `result_report/` 디렉토리 + 재사용 생성기 `generate-task-report.sh` 작성.</li>
+<li>파일명 규약 `task_report_YYYYMMDD_HHMMSS_session_noNN.html`, <b>session_no는 기존 리포트 최대 순번 +1로 자동 incremental</b>(첫 세션=01).</li>
+<li>필수 6항목 포함: 작업 시작/종료 시각·총 소요·핵심 사항·중요 이슈·git commit/push/PR/merge 히스토리(자동 수집).</li>
+<li>서술형 항목은 `.session-content.md`에서 로드, git 히스토리는 저장소에서 자동 수집. BATHOS teal 리포트 스타일 준수.</li>
+<li><b>이번 세션 리포트(session_no01) 생성.</b></li>
+</ul></div>
+
+  <h2><span class="n">5</span>중요 이슈</h2>
+  <div class="rule"></div>
+  <div class="card"><ul>
+<li><b>스냅샷 드리프트:</b> landing-web에서 `/save` 없이 종료된 세션이 있어 s7 스냅샷이 최신 상태를 반영하지 못함 → 다음 `/save-session` 시 정본화 필요.</li>
+<li><b>push/PR/merge 보류:</b> 아웃바운드 반영(원격 push·PR·merge)은 명시 요청이 없어 <b>로컬 커밋까지만</b> 수행, User 승인 대기.</li>
+<li><b>세션 시작 시각 근거:</b> 정확한 세션-start 로그가 디스크에 없어 `session-flags.json`의 활동 마커(2026-07-16T01:07:16Z = 10:07:16 KST)를 시작 시각으로 사용(추정, 날조 아님).</li>
+<li><b>session_no 채번 정책:</b> result_report/가 신설(빈 디렉토리)이라 이번 세션을 01로 시작. 과거 세션 소급 채번(backfill)이 필요하면 별도 지시 필요.</li>
+<li><b>엔진 잔여 CONCERNS(불변):</b> R1 plan-mode 신호원 · R2 fingerprint diff 정규화 · R3 audit finding 라벨 소급.</li>
+</ul></div>
+
+  <h2><span class="n">6</span>git commit / push / PR / merge 히스토리</h2>
+  <div class="rule"></div>
+  <div class="card">
+    <div class="subh">현재 브랜치 · 동기화</div>
+    <pre>feat/task-report   ·   feat/task-report</pre>
+    <div class="subh" style="margin-top:14px">최근 커밋 (commit, 최신 15)</div>
+    <pre>7259660 (HEAD -&gt; feat/task-report, origin/develop, develop) Merge PR #5: WSL development support into develop
+593ec79 feat(wsl): support development under WSL (line-ending guard + preflight + guide)
+1c9a067 docs: document both macOS/Linux and Windows install guides in README
+2cb80b6 Merge PR #2: Windows PowerShell port into develop
+f923e16 fix(windows): save all .ps1 hooks as UTF-8 with BOM for PowerShell 5.1
+d6bc035 fix(windows): reject unix-style absolute artifact paths in doctor path guard
+8f3d162 docs(windows): add Windows PowerShell install guide
+babcbc7 feat(windows): PowerShell 5.1+ port with feature parity (hooks, installer, engine, CI)
+95f7e52 Merge pull request #6 from taxideftis/prod
+5cb7943 Merge PR #5: release develop -&gt; prod (CI push triggers)
+57a602e Merge PR #4: ci align push triggers to develop/prod
+c840135 ci: align push triggers to develop/prod branch policy
+f28a245 Merge PR #1: chore(repo) stop tracking site/
+db6f6f1 Merge PR #2: style(core) apply cargo fmt --all
+ccf58fe style(core): apply cargo fmt --all</pre>
+    <div class="subh" style="margin-top:14px">merge 히스토리 (최신 10)</div>
+    <pre>7259660 Merge PR #5: WSL development support into develop
+2cb80b6 Merge PR #2: Windows PowerShell port into develop
+95f7e52 Merge pull request #6 from taxideftis/prod
+5cb7943 Merge PR #5: release develop -&gt; prod (CI push triggers)
+57a602e Merge PR #4: ci align push triggers to develop/prod
+f28a245 Merge PR #1: chore(repo) stop tracking site/
+db6f6f1 Merge PR #2: style(core) apply cargo fmt --all</pre>
+    <div class="subh" style="margin-top:14px">push 상태 (로컬 → upstream [track])</div>
+    <pre>develop → origin/develop []
+feat/ci-branch-triggers → origin/feat/ci-branch-triggers [[gone]]
+feat/task-report →  []
+prod → origin/prod []</pre>
+    <div class="subh" style="margin-top:14px">Pull Request (전체 상태)</div>
+    <pre>#6 [MERGED] develop→prod · Release: WSL development support (develop → prod)
+#5 [MERGED] feat/windows-wsl→develop · feat(wsl): WSL development support (line-ending guard · preflight · install guide)
+#4 [MERGED] develop→prod · Release: install-guide docs (develop → prod)
+#3 [MERGED] develop→prod · Release: Windows PowerShell port (develop → prod)
+#2 [MERGED] feat/windows-powershell→develop · feat(windows): Windows PowerShell port with feature parity (hooks · installer · engine · CI · docs)
+#1 [MERGED] develop→prod · Merge pull request #6 from taxideftis/prod</pre>
+  </div>
+
+  <footer>
+    <span>BATHOS · βάθος — 표층이 아닌 깊이</span>
+    <span>task_report_20260716_102053_session_no01.html</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/result_report/task_report_20260716_104150_session_no12.html
+++ b/result_report/task_report_20260716_104150_session_no12.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>BATHOS 작업 리포트 — session_no01</title>
+<title>BATHOS 작업 리포트 — session_no12</title>
 <style>
   :root{--abyss:#081215;--surface:#0f2226;--line:#1c3a40;--teal:#18b6c0;--teal-brand:#0e9aa1;--teal-soft:#7fd6dc;--ink:#e9f3f4;--muted:#8fabb0;--dim:#5f7c81;--grn:#4fbf9a;
     --mono:ui-monospace,'SFMono-Regular','JetBrains Mono',Menlo,Consolas,monospace;
@@ -36,15 +36,15 @@
 <body>
 <div class="wrap">
   <div class="eyebrow">BATHOS Dynamis · 세션 작업 리포트</div>
-  <h1>작업 리포트 · session_no01</h1>
-  <div class="meta">생성 <b>2026-07-16 10:20:53 KST</b> · 프로젝트 <b>bathos-dynamis</b> · 세션 순번 <b>#1</b></div>
+  <h1>작업 리포트 · session_no12</h1>
+  <div class="meta">생성 <b>2026-07-16 10:41:50 KST</b> · 프로젝트 <b>bathos-dynamis</b> · 세션 순번 <b>#12</b></div>
 
   <h2><span class="n">1–3</span>작업 시각 &amp; 총 소요</h2>
   <div class="rule"></div>
   <div class="times">
     <div class="tcard"><div class="lbl">작업 시작</div><div class="val">2026-07-16 10:07:16 KST</div></div>
-    <div class="tcard"><div class="lbl">작업 종료</div><div class="val">2026-07-16 10:20:53 KST</div></div>
-    <div class="tcard"><div class="lbl">총 작업 시간</div><div class="val">0시간 13분 37초</div></div>
+    <div class="tcard"><div class="lbl">작업 종료</div><div class="val">2026-07-16 10:41:50 KST</div></div>
+    <div class="tcard"><div class="lbl">총 작업 시간</div><div class="val">0시간 34분 34초</div></div>
   </div>
 
   <h2><span class="n">4</span>작업 핵심 사항</h2>
@@ -57,7 +57,9 @@
 <li>파일명 규약 `task_report_YYYYMMDD_HHMMSS_session_noNN.html`, <b>session_no는 기존 리포트 최대 순번 +1로 자동 incremental</b>(첫 세션=01).</li>
 <li>필수 6항목 포함: 작업 시작/종료 시각·총 소요·핵심 사항·중요 이슈·git commit/push/PR/merge 히스토리(자동 수집).</li>
 <li>서술형 항목은 `.session-content.md`에서 로드, git 히스토리는 저장소에서 자동 수집. BATHOS teal 리포트 스타일 준수.</li>
-<li><b>이번 세션 리포트(session_no01) 생성.</b></li>
+<li><b>소급 백필(backfill):</b> `.agent-team/12-report/`의 과거 taskreport 아카이브 11건을 시간순으로 `session_no01~11`로 소급 생성(`backfill-from-archive.sh`). 원본에 기록된 사실만 이관(종료 시각·현재상태·당시 git 라인), 시작시각/소요시간은 "당시 미기록"으로 명시. → 이번 세션은 <b>session_no12</b>.</li>
+<li><b>세션 시작 마커 훅 추가:</b> `SessionStart` 훅(`.claude/hooks/session-start.sh`) 신설 — 세션 시작 시각을 `_state/session-start.marker`에 기록(startup/clear=갱신, resume/compact=보존). `generate-task-report.sh`가 이 마커를 시작시각 최우선 소스로 사용. `settings.json`에 SessionStart 등록. freeze-guard 지문 2건 승인(Paul/hooks).</li>
+<li><b>이번 세션 리포트(session_no12) 생성.</b></li>
 </ul></div>
 
   <h2><span class="n">5</span>중요 이슈</h2>
@@ -66,7 +68,7 @@
 <li><b>스냅샷 드리프트:</b> landing-web에서 `/save` 없이 종료된 세션이 있어 s7 스냅샷이 최신 상태를 반영하지 못함 → 다음 `/save-session` 시 정본화 필요.</li>
 <li><b>push/PR/merge 보류:</b> 아웃바운드 반영(원격 push·PR·merge)은 명시 요청이 없어 <b>로컬 커밋까지만</b> 수행, User 승인 대기.</li>
 <li><b>세션 시작 시각 근거:</b> 정확한 세션-start 로그가 디스크에 없어 `session-flags.json`의 활동 마커(2026-07-16T01:07:16Z = 10:07:16 KST)를 시작 시각으로 사용(추정, 날조 아님).</li>
-<li><b>session_no 채번 정책:</b> result_report/가 신설(빈 디렉토리)이라 이번 세션을 01로 시작. 과거 세션 소급 채번(backfill)이 필요하면 별도 지시 필요.</li>
+<li><b>session_no 채번 정책:</b> 과거 아카이브 11건을 01~11로 소급 백필 완료 → 이번 세션 = 12. 이후 세션은 generate-task-report.sh가 자동으로 13, 14…로 이어받음. (아카이브 = `*-taskreport-*.html` 11건, `w6-report`·구형 `session-report-*`는 세션 리포트가 아니라 제외.)</li>
 <li><b>엔진 잔여 CONCERNS(불변):</b> R1 plan-mode 신호원 · R2 fingerprint diff 정규화 · R3 audit finding 라벨 소급.</li>
 </ul></div>
 
@@ -76,7 +78,8 @@
     <div class="subh">현재 브랜치 · 동기화</div>
     <pre>feat/task-report   ·   feat/task-report</pre>
     <div class="subh" style="margin-top:14px">최근 커밋 (commit, 최신 15)</div>
-    <pre>7259660 (HEAD -&gt; feat/task-report, origin/develop, develop) Merge PR #5: WSL development support into develop
+    <pre>6ad0457 (HEAD -&gt; feat/task-report) feat(report): add per-session task-report generator + result_report/
+7259660 (origin/develop, develop) Merge PR #5: WSL development support into develop
 593ec79 feat(wsl): support development under WSL (line-ending guard + preflight + guide)
 1c9a067 docs: document both macOS/Linux and Windows install guides in README
 2cb80b6 Merge PR #2: Windows PowerShell port into develop
@@ -89,8 +92,7 @@ babcbc7 feat(windows): PowerShell 5.1+ port with feature parity (hooks, installe
 57a602e Merge PR #4: ci align push triggers to develop/prod
 c840135 ci: align push triggers to develop/prod branch policy
 f28a245 Merge PR #1: chore(repo) stop tracking site/
-db6f6f1 Merge PR #2: style(core) apply cargo fmt --all
-ccf58fe style(core): apply cargo fmt --all</pre>
+db6f6f1 Merge PR #2: style(core) apply cargo fmt --all</pre>
     <div class="subh" style="margin-top:14px">merge 히스토리 (최신 10)</div>
     <pre>7259660 Merge PR #5: WSL development support into develop
 2cb80b6 Merge PR #2: Windows PowerShell port into develop
@@ -115,7 +117,7 @@ prod → origin/prod []</pre>
 
   <footer>
     <span>BATHOS · βάθος — 표층이 아닌 깊이</span>
-    <span>task_report_20260716_102053_session_no01.html</span>
+    <span>task_report_20260716_104150_session_no12.html</span>
   </footer>
 </div>
 </body>


### PR DESCRIPTION
## Release develop → prod

세션별 작업 리포트 시스템을 prod에 반영합니다.

### 포함 (develop 최신 3 커밋)
- `result_report/` 세션 리포트 생성기(`generate-task-report.sh`) — session_no 자동 증가, git commit/push/PR/merge 히스토리 자동 수집, 필수 6항목
- 과거 세션 아카이브 소급 백필(`session_no01~11`) + 이번 세션(`session_no12`)
- `SessionStart` 시작-시각 마커 훅(`.claude/hooks/session-start.sh` + settings.json)

### 검증
- develop에서 CI 3종(Engine · Safety hooks · Windows) 통과, PR #7로 머지 완료.
- prod 트리거 워크플로우는 CI/드리프트 가드뿐(배포 없음).