### PR TITLE
Release: /remote-dev command + slash-command index (develop → prod)

### DIFF
--- a/.claude/commands/remote-dev.md
+++ b/.claude/commands/remote-dev.md
@@ -1,0 +1,47 @@
+---
+description: "원격 개발(Remote Control) 셋업·가이드 — 내 머신 세션을 폰/웹에서 조종. BATHOS 상태·안전훅을 유지하는 원격 근무 정본 워크플로우."
+argument-hint: "[선택: 대상 프로젝트 절대경로 — 생략 시 현재 디렉터리]"
+allowed-tools: Read, Bash, Glob, Grep
+model: sonnet
+---
+당신은 총괄/리드 **Paul** 입니다. 개발자가 **자신의 메인 머신을 원격으로 조종**하며 편하게 일하도록, Claude Code의 **Remote Control**(내 머신에서 세션 실행 + 폰/웹에서 실시간 조종)을 이 BATHOS 프로젝트에 맞게 셋업·안내합니다. **읽기·점검만** 하고, 설정 토글은 사용자가 직접 하도록 안내합니다(User Sovereignty).
+
+## 0. 대상 경로
+- `$1`이 있으면 그 절대경로, 없으면 현재 작업 디렉터리를 프로젝트 루트로. 상태 `<state>` = `<root>/.agent-team/_state`.
+
+## 1. 왜 Remote Control인가 (BATHOS 핵심 근거)
+이 프로젝트는 **`.agent-team/`와 `_state/`가 gitignore** 대상이고, 안전 훅은 `core/target/release/bathos` 바이너리에 의존합니다. 따라서:
+- **클라우드형(Claude Code on Web / Routines)** 은 fresh clone으로 시작 → **BATHOS 세션 상태·감사로그·manifest·`result_report/`·마커가 없고, careful/freeze 안전훅·게이트가 무력화**됩니다. → BATHOS 파이프라인 작업에 **부적합**.
+- **Remote Control** 은 세션이 **내 로컬 머신에서** 그대로 돌고 폰/웹은 "창"일 뿐 → 로컬 파일·MCP·`bathos` 바이너리·`_state`·안전훅이 **전부 유지** → **원격 근무의 정본**.
+
+## 2. 프리플라이트 점검 (아래를 실측해 보고)
+1. **엔진 바이너리:** `core/target/release/bathos` 존재? (없으면 `cargo build --release -p bathos-cli` 권장 — 훅/상태/감사 정상 동작 전제)
+2. **상태 디렉터리:** `<state>/manifest.json` 존재 + `bathos -s <state> audit verify` 무결성 OK?
+3. **세션 저장 여부:** `<state>/SESSION-SNAPSHOT.md` 최신인지(오래됐으면 §5로 저장 권장).
+4. **현재 브랜치/변경분:** `git -C <root> status -sb` 한 줄 요약(원격에서 이어서 작업할 기준점).
+> 각 항목을 사실/추정 구분해 보고. 수치 날조 금지. 실패 항목은 "점검 실패"로 표기하고 계속.
+
+## 3. Remote Control 켜기 (사용자 안내 — 정확한 명령은 버전별 확인)
+Remote Control은 **Claude Code 내장 기능**입니다(프로젝트 커맨드가 토글하지 않음). 사용자에게 다음을 안내:
+- **활성화:** 세션에서 `/config` → **Remote Control** 활성화(모든 세션 자동 활성 옵션 포함). 버전에 따라 `/remote-control`·`/rc` 단축 커맨드가 있을 수 있음 → `/help`로 확인.
+- **접속:** 표시되는 **세션 URL** 클릭 또는 **QR 코드**를 **Claude 모바일 앱(iOS/Android)** 또는 `claude.ai/code`에서 스캔 → 폰/다른 기기에서 실시간 조종.
+- **푸시 알림:** `/config` → "Push when Claude decides" / "Push when actions required" 활성 → 작업 완료·입력 필요·권한 요청 시 모바일 푸시. (앱 알림 권한·Focus 모드·배터리 최적화 확인.)
+
+## 4. 원격 근무 중 유의 (BATHOS 안전 경계)
+- **머신 켜둘 것:** 세션은 로컬 프로세스가 살아 있어야 유지(닫으면 종료). SSH/tmux 병행 시 tmux가 프로세스 지속에 유리.
+- **권한 프롬프트는 로컬 승인:** careful-guard가 막는 파괴적 명령(`rm -rf`·force-push 등)과 freeze-guard 위험경로(`.claude/hooks`·`settings.json`) 변경은 **로컬 터미널에서만** 승인 가능(원격은 대기). 이는 원격 상황에서 오히려 안전장치.
+- **네트워크 두절:** 일정 시간 이상 끊기면 자동 타임아웃 가능 → 재접속.
+
+## 5. 무손실 인계 (자리 뜰 때 ↔ 복귀/타 기기)
+- **떠나기 전:** `/save-session`("저장") — 스냅샷 + SSOT 덤프 + 감사·git·산출물 인벤토리 + 전역 레지스트리 upsert.
+- **복귀/다른 기기:** `/cold-start`("이어서") — 문맥 0에서 이전 세션까지 100% 복원 브리핑.
+- **다른 프로젝트에서:** `/recall` — 전역 레지스트리로 이 프로젝트 지식 warm-start.
+
+## 6. 마무리 출력 (체크리스트)
+다음을 간결히 정리해 사용자에게 제시:
+- 프리플라이트 결과(바이너리·상태·감사·브랜치) 요약 표.
+- Remote Control 활성화 3단계(활성화 → 폰 접속 → 푸시) 안내.
+- ⚠️ "BATHOS 파이프라인 작업은 반드시 로컬/Remote Control로 — 클라우드형은 `_state`·바이너리·안전훅 부재" 경고 1줄.
+- ▶ 다음 커맨드: (저장 필요 시) `/save-session`, (복귀 시) `/cold-start`.
+
+> 정본/경계: 이 커맨드는 **BATHOS-aware 가이드·점검**입니다. 실제 Remote Control 토글은 Claude Code 내장(`/config`)이며, 클라우드 실행(Web/Routines/`/schedule`)은 BATHOS 무관 단발 작업에만 권장합니다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 > **BATHOS**(그리스어 βάθος = '깊이·심연') — 표층 지식과 대비되는 압도적 깊이의 AI Workflow Agent. BMAD-METHOD v6 리버스 흡수로 14역할·5웨이브 → 17역할·7웨이브 진화.
 > 운영 규칙 상세는 `CLAUDE.md`, 운영 철학은 `ETHOS.md`(gstack 적응), 출처는 `CREDITS.md`. 모든 팀원은 스폰 시 ETHOS를 숙지합니다. "BMAD/BMad" 상표 사용 금지.
+> **전체 슬래시 커맨드(35개) 카테고리별 레퍼런스: [`docs/COMMANDS-kr.md`](docs/COMMANDS-kr.md).** 아래는 핵심 요약.
 
 ## 역할(서브에이전트) — `.claude/agents/`
 Paul(0·리드/CEO렌즈) · John(1·리버스) · Caleb(2·시장분석 +W0 Analyst 겸임) · Joshua(3·기획) · James(4·아키텍트) · Mark(5·IP) · Nathanael(6·논문) · Jonnathan(7·디자인) · Phillip(8·백엔드) · Andrew(9·프론트) · Stephen(10·ML) · Timothy(11·문서) · Thomas(12·리뷰) · **Michael(13·보안, 방어적 웹·사이버 보안 감사·하드닝, 신규)** · Hananiah(14·리팩토링, 동작보존) · Matthias(15·QA) · Martin(16·리포트) · **Matthew(17·Story Engineer, 스토리파일+W3 게이트)**.
@@ -39,6 +40,14 @@ Paul(0·리드/CEO렌즈) · John(1·리버스) · Caleb(2·시장분석 +W0 Ana
 
 ## 안전·스코핑 (gstack)
 `/guard`(careful+freeze 활성) · `/unfreeze`(잠금 해제). careful는 `PreToolUse` 훅으로 파괴적 명령을 차단.
+
+## 세션·메모리·원격 (BATHOS)
+- **세션 저장/복원:** `/save-session`(정본, 별칭 `/save`) → 다음 세션 `/cold-start`(정본, 별칭 `/resume`)로 무손실 복원. gstack 레거시 `/context-save`·`/context-restore` 동일 `_state`.
+- **크로스-프로젝트 메모리:** `/project-handoff`(전역 레지스트리 upsert) · `/recall`(이전 프로젝트 warm-start).
+- **리포트:** `/taskreport`(온디맨드 HTML) · 세션별 정식 리포트는 `result_report/generate-task-report.sh`(session_no 자동 증가·6항목).
+- **라우팅/현황:** `/route`(Lv0~4 확정) · `/team-status` · `/team-cleanup`.
+- **원격 개발:** `/remote-dev`(Remote Control 셋업·가이드 — 내 머신 세션을 폰/웹에서 조종, `_state`·안전훅 유지). ⚠️ 클라우드형(Web/Routines)은 fresh clone이라 BATHOS 상태·훅 부재 → 파이프라인 부적합. 상세 비교: `docs/COMMANDS-kr.md`.
+- **교육:** `/lecture`(David 튜터 강의안 생성).
 
 ## 권장 흐름
 `/team-kickoff` → `/wave0-analysis`(선택) → `/wave1-discovery` → `/wave2-design` *(필요 시 `/autoplan`로 락인)* → **`/wave3-story-gate`**(PASS/CONCERNS면 진입) → `/wave3-ip-research`(W4·선택) → `/wave4-implement`(W5) → `/wave5-verify-report`(W6) → `/team-confirm`. 위험 작업 전 `/guard`. (규모에 따라 scale-adaptive로 일부 웨이브 생략.)

--- a/docs/COMMANDS-kr.md
+++ b/docs/COMMANDS-kr.md
@@ -1,0 +1,122 @@
+# BATHOS 슬래시 커맨드 모음 (`/` 명령어 레퍼런스)
+
+> **BATHOS** — βάθος(그리스어 '깊이·심연'). 17역할 · 7웨이브 AI Workflow Agent.
+> 이 문서는 `.claude/commands/`의 모든 슬래시 커맨드를 카테고리별로 정리한 단일 인덱스입니다.
+> 커맨드 정의(정본)는 각 `.claude/commands/<name>.md`. 운영 규칙은 `CLAUDE.md`, 역할·흐름은 `AGENTS.md`.
+> 총 **35개** 커맨드(웨이브 9 · 세션/메모리 8 · plan 리뷰 5 · 안전 2 · gstack 운영 5 · 원격/기타 2 · 라우팅/현황 3 · 리포트 1).
+
+---
+
+## 1. 웨이브 파이프라인 (BATHOS 본류)
+
+> 본류 의존성: **W0 → W1 → W2 → W3 → W5 → W6** (W4는 선택·비본류 플러그). 게이트 용어: **PASS / CONCERNS / FAIL**.
+
+| 커맨드 | 웨이브 | 설명 | 인자 |
+|--------|--------|------|------|
+| `/team-kickoff` | (사전) | 리드 단독 — `.agent-team` 골격 + charter + manifest 초기화 | `[프로젝트경로] [컨셉 한 줄]` |
+| `/wave0-analysis` | W0 | Analysis(선택·전단) — Caleb이 brainstorm→forge→brief → Brief Readiness 게이트 | `[프로젝트경로]` |
+| `/wave1-discovery` | W1 | John(리버스)+Caleb(시장분석) 동시 스폰 → USP Readiness 게이트 | `[프로젝트경로] [레포경로/URL]` |
+| `/wave2-design` | W2 | Joshua(기획) 게이트 → James(아키)+Jonnathan(디자인) 병렬 → Plan Readiness 게이트 | `[프로젝트경로]` |
+| `/wave3-story-gate` | W3 ★ | Story Engineering & Readiness Gate(심장) — Matthew(#17) 자족 스토리파일 + Thomas·Matthias 독립리뷰 → 이중 게이트 | `[프로젝트경로]` |
+| `/wave4-ip-research` | W4 | (플러그) Mark(특허)+Nathanael(논문) — W2 이후 언제든 실행 | `[프로젝트경로]` |
+| `/wave5-implement` | W5 | Phillip+Andrew+Stephen 3명 스폰(소유경로 분리)→구현→검수 | `[프로젝트경로]` |
+| `/wave6-verify-report` | W6 | Thomas+Timothy+Matthias 검증·문서화 → Michael(보안) → Hananiah(리팩토링) → Martin(리포트) → Release Readiness | `[프로젝트경로]` |
+| `/team-confirm` | (사후) | 리드 최종 confirm + signoff + 팀 cleanup | `[프로젝트경로]` |
+
+## 2. 라우팅 · 현황 · 정리
+
+| 커맨드 | 설명 | 인자 |
+|--------|------|------|
+| `/route` | Scale-Adaptive 라우팅 — 작업 stakes 입력 → Lv0~4 추천 + wave-set + User 확정 | `[프로젝트경로] [--level=0..4]` |
+| `/team-status` | 진행 현황 점검 — manifest/wave-log/산출물 인벤토리·다음 커맨드 안내 | `[프로젝트경로]` |
+| `/team-cleanup` | 긴급·수동 정리 — 잔여 팀원 shutdown + 팀 cleanup | — |
+
+## 3. 세션 저장 / 복원 (무손실 인계)
+
+> 정본 2개(`/save-session`·`/cold-start`) + 짧은 별칭 + gstack 레거시 별칭. 모두 동일 `_state`·동일 SSOT.
+
+| 커맨드 | 설명 | 인자 |
+|--------|------|------|
+| `/save-session` | **(정본)** 세션 전체 저장 — 서술 스냅샷 + 머신 SSOT 덤프 완전 보존 | `[프로젝트경로]` |
+| `/save` | 별칭 — `/save-session`과 동일 | `[프로젝트경로]` |
+| `/cold-start` | **(정본)** 콜드스타트 — 문맥 0에서 이전 세션까지 100% 복원·브리핑(읽기 전용) | `[프로젝트경로]` |
+| `/resume` | 별칭 — `/cold-start`와 동일 | `[프로젝트경로]` |
+| `/context-save` | [gstack 레거시] 작업 컨텍스트 저장(git 상태/결정/남은 작업) | `[프로젝트경로]` |
+| `/context-restore` | [gstack 레거시] 저장된 컨텍스트에서 재개 | `[프로젝트경로]` |
+
+**자연어 트리거:** "저장/세이브/체크포인트" → `/save-session` · "이어서/재개/콜드스타트/continue" → `/cold-start`.
+
+## 4. 크로스-프로젝트 메모리 (`~/.bathos/registry`)
+
+| 커맨드 | 설명 | 인자 |
+|--------|------|------|
+| `/project-handoff` | 현 프로젝트를 전역 레지스트리에 카드로 증류·upsert(다른 프로젝트가 `/recall`로 참조). `/save-session`이 자동 수행 | `[프로젝트경로]` |
+| `/recall` | 전역 레지스트리에서 관련 이전 프로젝트 컨텍스트를 끌어와 warm-start(읽기 전용) | `[관심 주제/기술/도메인]` |
+
+## 5. 작업 리포트
+
+| 커맨드 | 설명 | 인자 |
+|--------|------|------|
+| `/taskreport` | 즉시 작업 리포트 생성 — `YYYY-MM-DD-taskreport-N.html`를 `.agent-team/12-report/`에 저장(온디맨드). `/exit` 시엔 SessionEnd 훅이 자동 생성 | `[프로젝트경로]` |
+
+> 참고: 세션별 정식 리포트(`result_report/task_report_<날짜>_<시각>_session_no<NN>.html`, session_no 자동 증가, 필수 6항목)는 `bash result_report/generate-task-report.sh`로 생성. 과거 세션 소급 백필은 `result_report/backfill-from-archive.sh`.
+
+## 6. plan-mode 리뷰 게이트 (gstack · Wave 2 보강)
+
+| 커맨드 | 설명 | 인자 |
+|--------|------|------|
+| `/autoplan` | CEO→디자인→엔지니어링→DX 플랜 리뷰를 순차 실행 | `[프로젝트경로]` |
+| `/plan-ceo-review` | CEO/창업자 모드 — '10점짜리 제품'을 찾고 전제를 도전 | `[프로젝트경로]` |
+| `/plan-design-review` | 디자이너의 눈 — Jonnathan이 디자인 품질 루브릭 11차원 0~10 적대적 자기검증 | `[프로젝트경로]` |
+| `/plan-eng-review` | 엔지니어링 매니저 — James가 아키텍처/엣지케이스/테스트/성능 락인 | `[프로젝트경로]` |
+| `/plan-devex-review` | DX/UX — 페르소나·매직 모먼트·마찰점·TTHW 점검 | `[프로젝트경로]` |
+
+## 7. 안전 · 스코핑 (gstack)
+
+| 커맨드 | 설명 | 인자 |
+|--------|------|------|
+| `/guard` | careful(파괴적 명령 차단) + freeze(편집 범위 잠금) 활성 | `[허용 편집 경로…]` |
+| `/unfreeze` | freeze 해제 — 사용자 명시 요청 시만 | — |
+
+> careful/freeze는 `PreToolUse` 훅(`careful-guard.sh`·`freeze-guard.sh`)이 하드 강제. 위험경로 변경은 `bathos fingerprint approve`로 정식 승인.
+
+## 8. 구현 · 리뷰 · 운영 (gstack)
+
+| 커맨드 | 설명 | 인자 |
+|--------|------|------|
+| `/review` | 랜딩 전 PR 리뷰 — Thomas가 'CI 통과·prod에서 깨지는' 버그를 찾는다 | `[프로젝트경로]` |
+| `/investigate` | 체계적 근본원인 디버깅 — '조사 없이는 수정 없다' | `[프로젝트경로] [증상/버그]` |
+| `/cso` | 보안 감사 — OWASP Top 10 + STRIDE 위협 모델링 | `[프로젝트경로]` |
+| `/retro` | 회고 — 이번 사이클 산출물/지표/배운 점/다음 액션 | `[프로젝트경로]` |
+| `/health` | 코드 품질 대시보드 — 타입체커/린터/테스트/데드코드 요약 | `[프로젝트경로]` |
+
+## 9. 원격 · 교육 · 기타
+
+| 커맨드 | 설명 | 인자 |
+|--------|------|------|
+| `/remote-dev` | **(신규)** 원격 개발(Remote Control) 셋업·가이드 — 내 머신 세션을 폰/웹에서 조종. BATHOS 상태·안전훅 유지하는 원격 근무 정본 | `[프로젝트경로]` |
+| `/lecture` | David(Engineering Tutor) 스폰 — 가이드·코드·웹 소개 기반 주니어용 강의안(MD+HTML) 생성 | `[프로젝트경로]` |
+
+---
+
+## 권장 흐름
+
+```
+/team-kickoff → /route(레벨 확정) → /wave0-analysis(선택) → /wave1-discovery
+→ /wave2-design [→ /autoplan 로 락인] → /wave3-story-gate(PASS/CONCERNS면 진입)
+→ /wave4-ip-research(선택) → /wave5-implement → /wave6-verify-report → /team-confirm
+```
+- 위험 작업 전 `/guard`. 규모에 따라 scale-adaptive로 일부 웨이브 생략(Lv0~4).
+- 원격 근무: `/remote-dev`로 셋업 → 자리 뜰 때 `/save`(저장) → 복귀·타 기기에서 `/resume`(이어서).
+- 커맨드 정합 메모: `/wave4-ip-research`·`/wave5-implement`·`/wave6-verify-report`는 각각 웨이브 W4·W5·W6에 매핑(파일명은 구 번호 흔적 유지).
+
+## 원격 실행 옵션 요약 (BATHOS 관점)
+
+| 옵션 | 실행 위치 | `_state`·바이너리·안전훅 | BATHOS 파이프라인 |
+|------|-----------|--------------------------|-------------------|
+| 로컬 | 내 머신 | ✅ 유지 | ✅ 권장 |
+| **Remote Control** (`/remote-dev`) | 내 머신(폰/웹은 조종창) | ✅ 유지 | ✅ **원격 정본** |
+| SSH + tmux + `/save`·`/resume` | 내 머신 | ✅ 유지 | ✅ 권장 |
+| 클라우드(Web/Routines/`/schedule`) | Anthropic 클라우드(fresh clone) | ✗ 부재 | ⚠️ BATHOS 무관 단발 작업만 |
+
+> ⚠️ `.agent-team/`·`_state/`는 gitignore, 안전훅은 `bathos` 바이너리 의존 → **클라우드형은 BATHOS 상태·감사·게이트가 없음**. 파이프라인 작업은 로컬/Remote Control로.


### PR DESCRIPTION
## Release develop → prod

- `/remote-dev` — 원격 개발(Remote Control) 셋업·가이드 커맨드
- `docs/COMMANDS-kr.md` — 전체 35개 슬래시 커맨드 카테고리별 레퍼런스
- `AGENTS.md` — 인덱스 정합화(포인터 + 세션/메모리/원격 섹션)

develop에서 CI 3종(Engine·Safety hooks·Windows) 통과, PR #9로 머지 완료.
prod 트리거 워크플로우는 CI/드리프트 가드뿐(배포 없음).