### PR TITLE
feat(runtime): GLM live smoke test + Codex P4 gate implementation

### DIFF
--- a/codex-adapter/README.md
+++ b/codex-adapter/README.md
@@ -1,0 +1,117 @@
+# codex-adapter — BATHOS × OpenAI Codex CLI 게이트/저장 어댑터
+
+> 성격: Claude Code의 `TaskCompleted`(W3 게이트) · `SessionEnd`(종료 시 저장)를
+> Codex CLI의 확장점(`PreToolUse` · `Stop`)으로 재설계한 실구현. 설계 원본:
+> `.agent-team/04-architecture/w2-runtime-p4-design-kr.md` §B (James, 2026-07-16).
+> 왜 `.claude/hooks/`가 아니라 이 디렉터리인가: freeze-guard 경로 충돌을 피하고,
+> Codex 전용 런타임 코드를 Claude Code 훅과 분리하기 위해서다.
+
+---
+
+## 무엇이 들어있나
+
+```
+codex-adapter/
+├── hooks/
+│   ├── pretooluse-gate.sh       # W3 Implementation 게이트: FAIL이면 구현 진입 exit 2 차단
+│   ├── stop-save.sh             # SessionEnd 근사: 턴마다 증분 저장(state show 덤프)
+│   └── _test-codex-hooks.sh     # 시뮬레이션 테스트(실제 Codex 설치 불요, 14케이스)
+└── config.toml.example          # ~/.codex/config.toml 등록 예시
+```
+
+## 설치
+
+1. `bathos` 바이너리를 빌드해 둔다(`cargo build --release -p bathos-cli` 또는
+   저장소 루트에서 `cargo build --release`). 훅은 다음 순서로 바이너리를 찾는다:
+   `$BATHOS_BIN` > `<project>/core/target/release/bathos` >
+   `<project>/core/target/debug/bathos` > `PATH`의 `bathos`.
+2. `codex-adapter/config.toml.example`을 열어 `<BATHOS_ROOT>`를 실제 절대경로로
+   치환한 뒤, 그 내용을 `~/.codex/config.toml`에 병합한다(기존 `[hooks.*]`가
+   있으면 배열 항목을 추가). `hooks.json`을 이미 쓰고 있다면 Codex가 둘을
+   병합하며 경고를 낼 수 있다([문서]) — 한쪽으로 통일 권장.
+3. 두 훅 스크립트가 실행 가능한지 확인: `chmod +x codex-adapter/hooks/*.sh`
+   (이미 실행 권한이 설정돼 있음).
+4. Codex를 재시작하고, 아무 도구 호출이나 실행해 훅이 조용히 통과하는지 확인
+   (기본값 = 무해).
+
+## 동작 요약
+
+### `pretooluse-gate.sh` — W3 게이트
+
+- **트리거될 때만** `bathos gate show`를 호출한다(모든 도구 호출마다가 아님):
+  - **T1 소스 쓰기**: `apply_patch`/`write_file`/`edit`/`create_file` 도구가
+    `src/`·`core/crates/`·`core/src/`·`codex-adapter/hooks/` 경로를 언급.
+    `.agent-team/` 전용 언급은 제외(문서 쓰기는 게이트 대상 아님).
+  - **T2 웨이브 진입 명령**: `Bash` 계열 도구의 command가
+    `bathos wave advance|start|enter`, `wave5`, `wave4-implement`,
+    `W5 진입/시작`, `implementation start` 등에 매치.
+- verdict가 **FAIL**일 때만 `exit 2` + stderr 사유로 차단한다. PASS/CONCERNS/
+  verdict 확인 불가(bathos·state·report 모두 없음)는 전부 `exit 0`(fail-safe).
+- verdict 조회 우선순위: `bathos gate show` > `manifest.json` 보수적 파싱 >
+  `readiness-report-kr.md` 프론트매터(`.claude/hooks/gate-enforce.sh`와 동일
+  3단 우선순위·동일 판정 의미론 — ADR-P4-2).
+
+### `stop-save.sh` — SessionEnd 근사
+
+- Codex에는 `SessionEnd`가 없다. 이 훅은 **매 턴 종료(Stop)마다** 다음을
+  증분 수행해 근사한다:
+  1. `bathos state show` 덤프를 `_state/session-state.json`에 원자적으로
+     (`tmp` → `mv`) 교체 저장.
+  2. `_state/codex-stop-save.log`에 1줄 append(500줄 롤링, 1행은 항상 마지막
+     heavy-save epoch을 자기 기록).
+  3. `_state/SESSION-SNAPSHOT.md`가 있으면 그날짜 아카이브로 복사(원본이
+     없으면 아무 것도 만들지 않는다 — 훅은 서술을 생성하지 않는다).
+  4. **디바운스**(기본 10초, `BATHOS_STOP_SAVE_DEBOUNCE`로 조정, 0=끔): 짧은
+     간격의 연속 턴에서는 무거운 저장(1·3)을 건너뛰고 로그만 남긴다.
+- **항상 exit 0.** `stop_hook_active=true`면 즉시 통과(루프 가드).
+
+### 정직한 한계 (읽어야 함)
+
+- **LLM 서술 스냅샷 생성 불가** — `SESSION-SNAPSHOT.md`의 "★ 현재 상태" 같은
+  서술은 훅이 아니라 모델 턴에서만 만들 수 있다. Codex에서도 세션 중
+  `/save-session` 상당(프롬프트) 수동 실행을 병행해야 한다.
+- **HTML 태스크리포트 생성은 범위 밖** — `session-report.sh` 이식은 P4
+  스코프가 아니다.
+- **저장 손실 창** — 최대 "1턴 + 디바운스(기본 10초)". SessionEnd 방식보다
+  좁지만(세션 단위가 아니라 턴 단위) 0은 아니다.
+- **Codex `tool_name` 실측값 미확인(⚠️ 최대 리스크)** — 공식 문서 예시는
+  `"Bash"`·`"apply_patch"`뿐이라, 실제 설치에서 다른 값(`"shell"` 등)이 오면
+  T1/T2 트리거가 발화하지 않아 **게이트가 무력화(fail-open)** 될 수 있다.
+  설치 후 반드시 실측하고 필요시 `BATHOS_GATE_SRC_ERE`/matcher를 조정할 것.
+- **Windows 네이티브 미지원** — macOS/Linux/WSL만 지원(bash 3.2+ 호환 작성).
+  `.ps1` 포트는 P4 범위 밖. Windows 사용자는 WSL에서 Codex 구동을 권장
+  (`scripts/wsl-setup.sh`).
+
+## 테스트
+
+```bash
+bash codex-adapter/hooks/_test-codex-hooks.sh
+```
+
+실제 Codex 설치나 실제 `bathos` 빌드 없이도 동작한다(스텁 `bathos`를
+`mktemp` 디렉터리에 생성해 `gate show`/`state show` 출력을 재생). 14개
+설계 테스트 케이스(B-1~B-14)를 세분화한 assertion으로 검증하며, 전부 통과 시
+`전체 통과` + exit 0으로 끝난다.
+
+추가로 실제 `bathos` 바이너리(`core/target/release/bathos`)를 빌드해 두면
+두 훅을 실제 프로젝트 state 사본에 대해 수동으로 돌려 통합 확인도 가능하다
+(위 §동작 요약의 verdict 우선순위·원자적 저장이 실물로 동작함을 확인 완료
+— 구현 노트 참고).
+
+## 환경변수
+
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
+| `BATHOS_BIN` | (자동 탐지) | `bathos` 바이너리 절대경로 강제 지정 |
+| `BATHOS_STATE_DIR` | `<project>/.agent-team/_state` | state 디렉터리 강제 지정 |
+| `BATHOS_PROJECT_DIR` | stdin의 `cwd` | 프로젝트 루트 강제 지정 |
+| `BATHOS_GATE_SRC_ERE` | (§B2 기본 ERE) | pretooluse-gate.sh T1 소스 경로 패턴 오버라이드 |
+| `BATHOS_STOP_SAVE_DEBOUNCE` | `10` | stop-save.sh 디바운스 초(0=끔) |
+
+## 출처·근거
+
+- 설계: `.agent-team/04-architecture/w2-runtime-p4-design-kr.md`
+- 상위 포팅 판단: `docs/PORTABILITY-kr.md`, `docs/codex-adapter-kr.md`
+- 스타일 정본: `.claude/hooks/{gate-enforce,careful-guard,session-start}.sh`
+- Codex hooks 공식(이벤트·stdin 스키마·exit 2·config 문법 — 2026-07-16 확인):
+  https://developers.openai.com/codex/hooks , https://learn.chatgpt.com/docs/hooks

--- a/codex-adapter/config.toml.example
+++ b/codex-adapter/config.toml.example
@@ -1,0 +1,54 @@
+# =============================================================================
+# BATHOS codex-adapter 훅 등록 예시 (2026-07 문서 기준 [문서] · 설치 시 재확인 ⚠️)
+# 복사 대상: ~/.codex/config.toml  (hooks.json 병용 시 병합·경고됨 [문서])
+# <BATHOS_ROOT>를 실제 절대경로로 치환할 것. 예: /Users/you/dev/bathos-dynamis
+#
+# 설치 후 첫 검증 항목(재확인 필요 — w2-runtime-p4-design-kr.md §B0/§B4):
+#   1. ⚠️[추정] tool_name 실측값 — 문서 예시는 "Bash"·"apply_patch"·MCP 이름뿐.
+#      실제 설치 후 PostToolUse(또는 이 훅의 stderr 로깅)로 tool_name을 실측해
+#      matcher를 좁히는 것을 권장(넓어도 스크립트 자체 트리거 판정으로 안전 —
+#      지연만 소폭 발생).
+#   2. ⚠️[추정] hooks.Stop의 matcher 생략 가능 여부 — 문서에 명시가 없어 아래는
+#      matcher 없이 등록(전체 매치를 가정). 등록 실패 시 matcher = ".*" 추가.
+#   3. ⚠️[추정] 훅 timeout(20s) 초과 시 Codex의 기본 처리(차단/통과)가 불명 —
+#      pretooluse-gate.sh는 로컬 파일 I/O만 하므로 실제로는 ms 단위로 끝난다
+#      ([실측 체감], NFS 등 특수 환경 제외).
+#   4. [features] hooks가 기본 활성인지 버전별로 다를 수 있음(P3 문서는
+#      "실험적"이라 했으나 이번 재확인은 "기본 활성"으로 나옴 — 상충, 재확인 요).
+# =============================================================================
+
+# --- W3 게이트: 소스 쓰기 + Bash 웨이브 진입 명령 인터셉트 ---
+[[hooks.PreToolUse]]
+matcher = "^(Bash|shell|local_shell|exec_command|apply_patch|write_file|edit|create_file)$"
+# ⚠️ tool_name 실측값에 맞게 축소 권장(위 항목 1). matcher가 넓어도 스크립트가
+#    자체 트리거 판정(T1/T2)으로 즉시 통과시키므로 안전(지연만 소폭).
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = '/bin/bash "<BATHOS_ROOT>/codex-adapter/hooks/pretooluse-gate.sh"'
+timeout = 20
+statusMessage = "BATHOS W3 gate check"
+# commandWindows = 'powershell -File "<BATHOS_ROOT>\\codex-adapter\\hooks\\pretooluse-gate.ps1"'
+#   .ps1 포트는 P4 범위 밖(README.md "Windows 공백" 참고). 필드 자체는 문서에 존재[문서].
+
+# --- SessionEnd 근사: 턴 종료마다 증분 저장 ---
+[[hooks.Stop]]
+# matcher 생략 가능 여부 ⚠️[추정](위 항목 2) — 등록 실패 시 matcher = ".*" 추가.
+
+[[hooks.Stop.hooks]]
+type = "command"
+command = '/bin/bash "<BATHOS_ROOT>/codex-adapter/hooks/stop-save.sh"'
+timeout = 20
+statusMessage = "BATHOS incremental save"
+
+# --- 선택 환경변수(둘 다 훅 스크립트가 자동 탐지하므로 보통 불필요) ---
+# BATHOS_BIN              = bathos 바이너리 절대경로 강제 지정
+# BATHOS_STATE_DIR        = _state 디렉터리 강제 지정
+# BATHOS_PROJECT_DIR      = 프로젝트 루트 강제 지정(기본: stdin의 cwd)
+# BATHOS_GATE_SRC_ERE     = pretooluse-gate.sh의 T1(소스 경로) 패턴 오버라이드
+# BATHOS_STOP_SAVE_DEBOUNCE = stop-save.sh 디바운스 초(기본 10, 0=끔)
+
+# 참고: 프로젝트별 state를 쓰므로 훅 스크립트는 stdin의 "cwd" 필드로 프로젝트를
+# 찾는다(w2-runtime-p4-design-kr.md §B1) — 이 config.toml이 유저 레벨(~/.codex/)
+# 이어도 여러 프로젝트를 오가며 안전하게 동작한다. _state가 없는 cwd(=비-BATHOS
+# 프로젝트)에서는 두 훅 모두 조용히 통과한다.

--- a/codex-adapter/hooks/_test-codex-hooks.sh
+++ b/codex-adapter/hooks/_test-codex-hooks.sh
@@ -1,0 +1,328 @@
+#!/usr/bin/env bash
+# =============================================================================
+# BATHOS P4 — codex-adapter/hooks/_test-codex-hooks.sh
+# 시뮬레이션 테스트 하네스: pretooluse-gate.sh · stop-save.sh를 실제 Codex
+# 설치 없이 검증한다. 가짜 stdin JSON을 파이프하고, 스텁 bathos로 verdict를
+# 재생해 exit code·stderr·부수효과(파일)를 단정(assert)한다.
+#
+# 설계 원본: .agent-team/04-architecture/w2-runtime-p4-design-kr.md §B5 (James)
+# 자리매김: .claude/hooks/_test-hooks.sh와 동일(수동 실행 검증 스크립트).
+# bash 3.2 호환(카운터 변수 + 함수, 연관배열 금지).
+#
+# 실행: bash codex-adapter/hooks/_test-codex-hooks.sh
+# =============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOKS_DIR="$SCRIPT_DIR"
+
+TMPDIR_BASE="$(mktemp -d)"
+cleanup() { rm -rf "$TMPDIR_BASE"; }
+trap cleanup EXIT
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_exit() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$actual" -eq "$expected" ] 2>/dev/null; then
+    printf "${GREEN}[PASS]${NC} %s (exit=%d)\n" "$desc" "$actual"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    printf "${RED}[FAIL]${NC} %s — 예상 exit=%d, 실제 exit=%d\n" "$desc" "$expected" "$actual"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+assert_true() {
+  # $1=desc $2=condition(0/1, already-evaluated as shell truthiness via [ ] outside)
+  local desc="$1" ok="$2"
+  if [ "$ok" = "1" ]; then
+    printf "${GREEN}[PASS]${NC} %s\n" "$desc"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    printf "${RED}[FAIL]${NC} %s\n" "$desc"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+# --------------------------------------------------------------------------
+# 스텁 bathos 생성 헬퍼 — $1=STUB_DIR $2=verdict("PASS"|"CONCERNS"|"FAIL"|"EMPTY")
+# --------------------------------------------------------------------------
+make_stub_bathos() {
+  local stub_dir="$1" verdict="$2"
+  mkdir -p "$stub_dir"
+  printf '%s' "$verdict" > "$stub_dir/verdict"
+  cat > "$stub_dir/bathos" <<'STUB_EOF'
+#!/usr/bin/env bash
+# 스텁 bathos — 호출 기록 + verdict 재생 (실제 Codex/BATHOS 빌드 불요)
+STUB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+echo "$*" >> "$STUB_DIR/calls.log"
+case "$*" in
+  *"gate show"*)
+     V="$(cat "$STUB_DIR/verdict" 2>/dev/null)"
+     if [ "$V" = "EMPTY" ]; then exit 0; fi
+     printf '{"decided":"2026-07-16T00:00:00Z","facilitator":"Paul","gate_type":"Implementation","issues_critical":0,"issues_total":1,"verdict":"%s","wave_id":"W3"}\n' "$V"
+     ;;
+  *"state show"*)
+     printf '{"project_id":"stub","stub":true}\n'
+     ;;
+  *"audit append"*)
+     exit 0
+     ;;
+esac
+exit 0
+STUB_EOF
+  chmod +x "$stub_dir/bathos"
+}
+
+# --------------------------------------------------------------------------
+# 픽스처 프로젝트 디렉터리 생성 — $1=이름 -> stdout에 절대경로
+# --------------------------------------------------------------------------
+make_fixture_project() {
+  local name="$1"
+  local dir="$TMPDIR_BASE/proj-$name"
+  mkdir -p "$dir/.agent-team/_state"
+  printf '# seed\n' > "$dir/.agent-team/_state/SESSION-SNAPSHOT.md"
+  printf '%s' "$dir"
+}
+
+# --------------------------------------------------------------------------
+# 훅 실행 헬퍼 — $1=hook_script $2=stdin_json (env는 호출부에서 export)
+# 표준출력에 "EXIT<tab>STDERR_B64" 형태로 반환(멀티라인 stderr 보존 위해 base64).
+# --------------------------------------------------------------------------
+run_hook() {
+  local hook="$1" stdin_json="$2"
+  local out ec
+  out="$(printf '%s' "$stdin_json" | bash "$hook" 2>&1 1>/dev/null)"
+  ec=$?
+  printf '%d\t%s' "$ec" "$(printf '%s' "$out" | base64 | tr -d '\n')"
+}
+
+get_exit() { printf '%s' "$1" | cut -f1; }
+get_stderr() { printf '%s' "$1" | cut -f2- | base64 -d 2>/dev/null; }
+
+# ==========================================================================
+# 픽스처 stdin JSON (하네스 내 printf 상수, <TMP_PROJ>를 실경로로 치환)
+# ==========================================================================
+json_write_src() {
+  printf '{"session_id":"s1","turn_id":"t1","hook_event_name":"PreToolUse","tool_name":"apply_patch","cwd":"%s","tool_input":{"patch":"*** Update File: core/crates/bathos-cli/src/main.rs"}}' "$1"
+}
+json_bash_wave() {
+  printf '{"session_id":"s1","turn_id":"t1","hook_event_name":"PreToolUse","tool_name":"Bash","cwd":"%s","tool_input":{"command":"bathos wave advance --to W5"}}' "$1"
+}
+json_bash_benign() {
+  printf '{"session_id":"s1","turn_id":"t1","hook_event_name":"PreToolUse","tool_name":"Bash","cwd":"%s","tool_input":{"command":"ls -la"}}' "$1"
+}
+json_write_docs() {
+  printf '{"session_id":"s1","turn_id":"t1","hook_event_name":"PreToolUse","tool_name":"apply_patch","cwd":"%s","tool_input":{"patch":"*** Update File: .agent-team/08-impl-notes/backend.md"}}' "$1"
+}
+json_stop() {
+  printf '{"session_id":"s1","turn_id":"t9","hook_event_name":"Stop","stop_hook_active":false,"cwd":"%s","last_assistant_message":"done"}' "$1"
+}
+json_stop_active() {
+  printf '{"session_id":"s1","turn_id":"t9","hook_event_name":"Stop","stop_hook_active":true,"cwd":"%s","last_assistant_message":"done"}' "$1"
+}
+JSON_GARBAGE='not json at all'
+
+# ==========================================================================
+# B-1 ~ B-10: pretooluse-gate.sh
+# ==========================================================================
+printf '\n=== pretooluse-gate.sh (B-1 ~ B-10) ===\n'
+
+# --- B-1: J_WRITE_SRC, verdict=PASS -> exit 0, stderr에 BLOCKED 없음 ---
+P1="$(make_fixture_project b1)"
+STUB1="$TMPDIR_BASE/stub-b1"; make_stub_bathos "$STUB1" "PASS"
+RES="$(BATHOS_BIN="$STUB1/bathos" run_hook "$HOOKS_DIR/pretooluse-gate.sh" "$(json_write_src "$P1")")"
+EC="$(get_exit "$RES")"; ERR="$(get_stderr "$RES")"
+assert_exit "B-1 소스쓰기 + PASS -> 통과" 0 "$EC"
+if printf '%s' "$ERR" | grep -q 'BLOCKED'; then
+  assert_true "B-1 stderr에 BLOCKED 없음" 0
+else
+  assert_true "B-1 stderr에 BLOCKED 없음" 1
+fi
+
+# --- B-2: J_WRITE_SRC, verdict=FAIL -> exit 2, stderr에 BLOCKED·FAIL ---
+P2="$(make_fixture_project b2)"
+STUB2="$TMPDIR_BASE/stub-b2"; make_stub_bathos "$STUB2" "FAIL"
+RES="$(BATHOS_BIN="$STUB2/bathos" run_hook "$HOOKS_DIR/pretooluse-gate.sh" "$(json_write_src "$P2")")"
+EC="$(get_exit "$RES")"; ERR="$(get_stderr "$RES")"
+assert_exit "B-2 소스쓰기 + FAIL -> 차단(exit 2)" 2 "$EC"
+if printf '%s' "$ERR" | grep -q 'BLOCKED' && printf '%s' "$ERR" | grep -q 'FAIL'; then
+  assert_true "B-2 stderr에 BLOCKED·FAIL 포함" 1
+else
+  assert_true "B-2 stderr에 BLOCKED·FAIL 포함" 0
+fi
+
+# --- B-3: J_BASH_WAVE, verdict=FAIL -> exit 2, stderr에 wave-entry-command ---
+P3="$(make_fixture_project b3)"
+STUB3="$TMPDIR_BASE/stub-b3"; make_stub_bathos "$STUB3" "FAIL"
+RES="$(BATHOS_BIN="$STUB3/bathos" run_hook "$HOOKS_DIR/pretooluse-gate.sh" "$(json_bash_wave "$P3")")"
+EC="$(get_exit "$RES")"; ERR="$(get_stderr "$RES")"
+assert_exit "B-3 웨이브진입명령 + FAIL -> 차단(exit 2)" 2 "$EC"
+if printf '%s' "$ERR" | grep -q 'wave-entry-command'; then
+  assert_true "B-3 stderr에 wave-entry-command 포함" 1
+else
+  assert_true "B-3 stderr에 wave-entry-command 포함" 0
+fi
+
+# --- B-4: J_WRITE_SRC, verdict=CONCERNS -> exit 0, stderr에 CONCERNS ---
+P4="$(make_fixture_project b4)"
+STUB4="$TMPDIR_BASE/stub-b4"; make_stub_bathos "$STUB4" "CONCERNS"
+RES="$(BATHOS_BIN="$STUB4/bathos" run_hook "$HOOKS_DIR/pretooluse-gate.sh" "$(json_write_src "$P4")")"
+EC="$(get_exit "$RES")"; ERR="$(get_stderr "$RES")"
+assert_exit "B-4 소스쓰기 + CONCERNS -> 통과" 0 "$EC"
+if printf '%s' "$ERR" | grep -q 'CONCERNS'; then
+  assert_true "B-4 stderr에 CONCERNS 포함" 1
+else
+  assert_true "B-4 stderr에 CONCERNS 포함" 0
+fi
+
+# --- B-5: J_BASH_BENIGN, verdict=FAIL(스텁) -> exit 0, calls.log 비어있음(비트리거는 bathos 미호출) ---
+P5="$(make_fixture_project b5)"
+STUB5="$TMPDIR_BASE/stub-b5"; make_stub_bathos "$STUB5" "FAIL"
+RES="$(BATHOS_BIN="$STUB5/bathos" run_hook "$HOOKS_DIR/pretooluse-gate.sh" "$(json_bash_benign "$P5")")"
+EC="$(get_exit "$RES")"
+assert_exit "B-5 무해 Bash -> 통과" 0 "$EC"
+if [ ! -s "$STUB5/calls.log" ]; then
+  assert_true "B-5 calls.log 비어있음(bathos 미호출)" 1
+else
+  assert_true "B-5 calls.log 비어있음(bathos 미호출)" 0
+fi
+
+# --- B-6: J_WRITE_SRC, BATHOS_BIN=/nonexistent + manifest/report도 없음 -> exit 0, fail-safe 경고 ---
+P6="$(make_fixture_project b6)"
+RES="$(BATHOS_BIN=/nonexistent run_hook "$HOOKS_DIR/pretooluse-gate.sh" "$(json_write_src "$P6")")"
+EC="$(get_exit "$RES")"; ERR="$(get_stderr "$RES")"
+assert_exit "B-6 bathos 없음 -> fail-safe 통과" 0 "$EC"
+if printf '%s' "$ERR" | grep -q '확인 불가'; then
+  assert_true "B-6 stderr에 fail-safe 경고" 1
+else
+  assert_true "B-6 stderr에 fail-safe 경고" 0
+fi
+
+# --- B-7: J_WRITE_SRC, verdict=EMPTY(게이트 미존재) -> exit 0, stderr에 "verdict 확인 불가" ---
+P7="$(make_fixture_project b7)"
+STUB7="$TMPDIR_BASE/stub-b7"; make_stub_bathos "$STUB7" "EMPTY"
+RES="$(BATHOS_BIN="$STUB7/bathos" run_hook "$HOOKS_DIR/pretooluse-gate.sh" "$(json_write_src "$P7")")"
+EC="$(get_exit "$RES")"; ERR="$(get_stderr "$RES")"
+assert_exit "B-7 게이트 미존재(EMPTY) -> 통과" 0 "$EC"
+if printf '%s' "$ERR" | grep -q '확인 불가'; then
+  assert_true "B-7 stderr에 verdict 확인 불가" 1
+else
+  assert_true "B-7 stderr에 verdict 확인 불가" 0
+fi
+
+# --- B-8: J_WRITE_DOCS, verdict=FAIL -> exit 0, .agent-team/ 전용 쓰기는 비트리거 ---
+P8="$(make_fixture_project b8)"
+STUB8="$TMPDIR_BASE/stub-b8"; make_stub_bathos "$STUB8" "FAIL"
+RES="$(BATHOS_BIN="$STUB8/bathos" run_hook "$HOOKS_DIR/pretooluse-gate.sh" "$(json_write_docs "$P8")")"
+EC="$(get_exit "$RES")"
+assert_exit "B-8 .agent-team/ 전용 쓰기 -> 비트리거 통과" 0 "$EC"
+
+# --- B-9: J_GARBAGE, verdict=FAIL -> exit 0, 파싱 실패 fail-safe ---
+STUB9="$TMPDIR_BASE/stub-b9"; make_stub_bathos "$STUB9" "FAIL"
+RES="$(BATHOS_BIN="$STUB9/bathos" run_hook "$HOOKS_DIR/pretooluse-gate.sh" "$JSON_GARBAGE")"
+EC="$(get_exit "$RES")"
+assert_exit "B-9 비-JSON 입력 -> fail-safe 통과" 0 "$EC"
+
+# --- B-10: J_WRITE_SRC, _state 없는 cwd -> exit 0, 비-BATHOS 프로젝트 통과 ---
+NO_STATE_DIR="$TMPDIR_BASE/proj-b10-no-state"
+mkdir -p "$NO_STATE_DIR"
+STUB10="$TMPDIR_BASE/stub-b10"; make_stub_bathos "$STUB10" "FAIL"
+RES="$(BATHOS_BIN="$STUB10/bathos" run_hook "$HOOKS_DIR/pretooluse-gate.sh" "$(json_write_src "$NO_STATE_DIR")")"
+EC="$(get_exit "$RES")"
+assert_exit "B-10 _state 없는 cwd -> 비-BATHOS 프로젝트 통과" 0 "$EC"
+
+# ==========================================================================
+# B-11 ~ B-14: stop-save.sh
+# ==========================================================================
+printf '\n=== stop-save.sh (B-11 ~ B-14) ===\n'
+
+# --- B-11: J_STOP -> session-state.json 존재·유효 JSON, 로그 dump=ok, 스냅샷 아카이브 생성 ---
+P11="$(make_fixture_project b11)"
+STUB11="$TMPDIR_BASE/stub-b11"; make_stub_bathos "$STUB11" "PASS"
+RES="$(BATHOS_BIN="$STUB11/bathos" run_hook "$HOOKS_DIR/stop-save.sh" "$(json_stop "$P11")")"
+EC="$(get_exit "$RES")"
+assert_exit "B-11 Stop 저장 -> exit 0" 0 "$EC"
+
+STATE_DIR_11="$P11/.agent-team/_state"
+if [ -f "$STATE_DIR_11/session-state.json" ] && head -c1 "$STATE_DIR_11/session-state.json" | grep -q '{'; then
+  assert_true "B-11 session-state.json 존재·유효 JSON({로 시작)" 1
+else
+  assert_true "B-11 session-state.json 존재·유효 JSON({로 시작)" 0
+fi
+if grep -q 'dump=ok' "$STATE_DIR_11/codex-stop-save.log" 2>/dev/null; then
+  assert_true "B-11 codex-stop-save.log에 dump=ok" 1
+else
+  assert_true "B-11 codex-stop-save.log에 dump=ok" 0
+fi
+TODAY="$(date '+%Y-%m-%d')"
+if [ -f "$STATE_DIR_11/SESSION-SNAPSHOT-$TODAY.md" ]; then
+  assert_true "B-11 스냅샷 날짜 아카이브 생성" 1
+else
+  assert_true "B-11 스냅샷 날짜 아카이브 생성" 0
+fi
+
+# --- B-12: J_STOP, BATHOS_BIN=/nonexistent -> 로그 dump=no-bathos, session-state.json 미생성(기존본 미파괴) ---
+P12="$(make_fixture_project b12)"
+RES="$(BATHOS_BIN=/nonexistent run_hook "$HOOKS_DIR/stop-save.sh" "$(json_stop "$P12")")"
+EC="$(get_exit "$RES")"
+assert_exit "B-12 bathos 없음 -> exit 0" 0 "$EC"
+STATE_DIR_12="$P12/.agent-team/_state"
+if grep -q 'dump=no-bathos' "$STATE_DIR_12/codex-stop-save.log" 2>/dev/null; then
+  assert_true "B-12 로그에 dump=no-bathos" 1
+else
+  assert_true "B-12 로그에 dump=no-bathos" 0
+fi
+if [ ! -f "$STATE_DIR_12/session-state.json" ]; then
+  assert_true "B-12 session-state.json 미생성(기존본 미파괴)" 1
+else
+  assert_true "B-12 session-state.json 미생성(기존본 미파괴)" 0
+fi
+
+# --- B-13: J_STOP 2회 연속(디바운스 10s) -> 0,0 / 2회차 로그 dump=skip ---
+P13="$(make_fixture_project b13)"
+STUB13="$TMPDIR_BASE/stub-b13"; make_stub_bathos "$STUB13" "PASS"
+RES1="$(BATHOS_BIN="$STUB13/bathos" run_hook "$HOOKS_DIR/stop-save.sh" "$(json_stop "$P13")")"
+EC1="$(get_exit "$RES1")"
+RES2="$(BATHOS_BIN="$STUB13/bathos" run_hook "$HOOKS_DIR/stop-save.sh" "$(json_stop "$P13")")"
+EC2="$(get_exit "$RES2")"
+assert_exit "B-13 1회차 -> exit 0" 0 "$EC1"
+assert_exit "B-13 2회차(디바운스 내) -> exit 0" 0 "$EC2"
+STATE_DIR_13="$P13/.agent-team/_state"
+LAST_LINE="$(tail -1 "$STATE_DIR_13/codex-stop-save.log" 2>/dev/null)"
+if printf '%s' "$LAST_LINE" | grep -q 'dump=skip'; then
+  assert_true "B-13 2회차 로그 dump=skip" 1
+else
+  assert_true "B-13 2회차 로그 dump=skip (실제: $LAST_LINE)" 0
+fi
+
+# --- B-14: J_STOP_ACTIVE -> exit 0, 아무 파일도 변경 없음(루프 가드) ---
+P14="$(make_fixture_project b14)"
+STUB14="$TMPDIR_BASE/stub-b14"; make_stub_bathos "$STUB14" "PASS"
+STATE_DIR_14="$P14/.agent-team/_state"
+BEFORE_LISTING="$(ls -la "$STATE_DIR_14" 2>/dev/null)"
+RES="$(BATHOS_BIN="$STUB14/bathos" run_hook "$HOOKS_DIR/stop-save.sh" "$(json_stop_active "$P14")")"
+EC="$(get_exit "$RES")"
+AFTER_LISTING="$(ls -la "$STATE_DIR_14" 2>/dev/null)"
+assert_exit "B-14 stop_hook_active=true -> exit 0" 0 "$EC"
+if [ "$BEFORE_LISTING" = "$AFTER_LISTING" ]; then
+  assert_true "B-14 아무 파일도 변경 없음(루프 가드)" 1
+else
+  assert_true "B-14 아무 파일도 변경 없음(루프 가드)" 0
+fi
+
+# ==========================================================================
+# 요약
+# ==========================================================================
+printf '\n=== 요약 ===\n'
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+printf 'PASS %d/%d\n' "$PASS_COUNT" "$TOTAL"
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  printf "${RED}FAIL 있음: %d건${NC}\n" "$FAIL_COUNT"
+  exit 1
+fi
+printf "${GREEN}전체 통과${NC}\n"
+exit 0

--- a/codex-adapter/hooks/pretooluse-gate.sh
+++ b/codex-adapter/hooks/pretooluse-gate.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# =============================================================================
+# BATHOS P4 — codex-adapter/hooks/pretooluse-gate.sh
+# Codex PreToolUse 훅: W3 Implementation 게이트가 FAIL인 동안 "구현 웨이브(W5)
+# 진입"을 뜻하는 도구 호출만 exit 2로 물리 차단한다. 그 외 모든 상황은 통과.
+#
+# 설계 원본: .agent-team/04-architecture/w2-runtime-p4-design-kr.md §B2 (James)
+# 의미론은 .claude/hooks/gate-enforce.sh(Claude Code용)와 문자 그대로 동일하게
+# 유지한다(ADR-P4-2) — 런타임이 달라도 게이트 정책은 하나다.
+#
+# stdin/stdout/exit 계약:
+#   stdin  = Codex PreToolUse JSON 1개(session_id/turn_id/tool_name/tool_input/
+#            cwd/hook_event_name 등). 비-JSON/빈 입력 -> fail-safe exit 0.
+#   stdout = 사용 안 함(비움 유지 — exit 0에서 무출력=성공).
+#   stderr = 차단 사유·경고만.
+#   exit   = 0(통과) | 2(차단). 그 외 코드는 절대 사용하지 않는다 — 내부 오류도
+#            0으로 수렴(훅 오류가 개발 전체를 막으면 안 된다는 careful 원칙).
+#
+# 트리거는 "모든 도구 호출마다 게이트를 조회"하지 않는다(불필요한 지연·감사
+# 소음) — T1(제품 소스 쓰기) 또는 T2(웨이브 진입 명령) 감지 시에만 bathos를
+# 호출한다(ADR-P4-1). 비트리거는 아래 §3에서 bathos 호출 전에 즉시 exit 0.
+# =============================================================================
+set -uo pipefail
+
+PROG="pretooluse-gate.sh"
+
+# --------------------------------------------------------------------------
+# 1. stdin 전량 읽기 + 평탄화 (E-B1: 멀티라인/CRLF stdin 대응)
+# --------------------------------------------------------------------------
+INPUT="$(cat 2>/dev/null || true)"
+INPUT_FLAT="$(printf '%s' "$INPUT" | tr '\n\r' '  ')"
+
+# --------------------------------------------------------------------------
+# 2. 공통 JSON 파싱 함수 (§C0 — jq 금지, 네이티브 grep/sed만)
+# --------------------------------------------------------------------------
+# 최상위 문자열 필드 추출. 값 내 이스케이프 따옴표(\")는 미지원(알려진 한계) —
+# 우리가 읽는 필드(hook_event_name/tool_name/cwd)는 런타임 생성 식별자·경로라
+# 이스케이프 포함 가능성이 사실상 없다. 오파싱 시에도 fail-safe 통과로
+# 수렴하므로(차단 아님) 안전한 방향이다.
+_jstr() {
+  printf '%s' "$INPUT_FLAT" | grep -o "\"$1\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" \
+    | head -1 | sed 's/.*:[[:space:]]*"\(.*\)"$/\1/'
+}
+
+EVENT="$(_jstr hook_event_name)"
+TOOL="$(_jstr tool_name)"
+CWD="$(_jstr cwd)"
+
+# 잘못 배선돼도(다른 이벤트에 물려도) 무해하게 통과.
+if [ -n "$EVENT" ] && [ "$EVENT" != "PreToolUse" ]; then
+  exit 0
+fi
+
+# --------------------------------------------------------------------------
+# 3. 경로 해석 (§B1 — Codex는 CLAUDE_PROJECT_DIR을 주지 않으므로 stdin cwd 사용)
+# --------------------------------------------------------------------------
+PROJECT_DIR="${BATHOS_PROJECT_DIR:-${CWD:-$PWD}}"
+STATE_DIR="${BATHOS_STATE_DIR:-$PROJECT_DIR/.agent-team/_state}"
+
+# BATHOS 프로젝트가 아니면(=_state 없음) 조용히 통과 — 다른 프로젝트에서
+# Codex를 써도 이 훅이 방해하지 않는다(session-start.sh와 동일 원칙).
+if [ ! -d "$STATE_DIR" ]; then
+  exit 0
+fi
+
+# bathos 바이너리 후보 순회 — 첫 실행가능 파일을 채택.
+BATHOS_BIN="${BATHOS_BIN:-}"
+if [ -z "$BATHOS_BIN" ]; then
+  for cand in \
+    "$PROJECT_DIR/core/target/release/bathos" \
+    "$PROJECT_DIR/core/target/debug/bathos"
+  do
+    if [ -x "$cand" ]; then BATHOS_BIN="$cand"; break; fi
+  done
+  if [ -z "$BATHOS_BIN" ] && command -v bathos >/dev/null 2>&1; then
+    BATHOS_BIN="$(command -v bathos)"
+  fi
+fi
+
+# --------------------------------------------------------------------------
+# 4. 트리거 판정 (bathos 호출 전, 저비용 — T1: 소스 쓰기 / T2: 웨이브 진입 명령)
+# --------------------------------------------------------------------------
+# T1 소스 경로 패턴(env로 오버라이드 가능). ".agent-team/" 전용 언급은 제외
+# (문서·산출물 쓰기는 게이트 대상이 아니다).
+SRC_ERE="${BATHOS_GATE_SRC_ERE:-(^|[^A-Za-z0-9_./-])(src|core/crates|core/src|codex-adapter/hooks)/}"
+
+# T2 웨이브 진입 명령 ERE (gate-enforce.sh is_w5_entry와 정렬).
+W5_ENTRY_ERE='bathos[[:space:]]+wave[[:space:]]+(advance|start|enter)|wave.?5|wave.?4-implement|W5.*(진입|시작)|implement(ation)?[[:space:]]+(start|begin)'
+
+TRIGGER=""
+
+case "$TOOL" in
+  apply_patch|write_file|edit|create_file)
+    # 예외: ".agent-team/" 만 언급되면 트리거 아님(문서·산출물 쓰기는 게이트
+    # 대상이 아니다) — ".agent-team/<...>" 경로 세그먼트를 원문에서 지운 뒤에도
+    # SRC_ERE가 매치되면, 그 매치는 .agent-team/ 바깥의 진짜 소스 경로라는 뜻.
+    # 과탐(문서 안에 우연히 "src/" 문자열)은 FAIL 상태에서만 영향이 있으므로
+    # careful 원칙(과차단 > 놓침)에 따라 수용한다(ADR-P4-1).
+    NON_AGENT_TEAM_FLAT="$(printf '%s' "$INPUT_FLAT" | sed -E 's#\.agent-team/[A-Za-z0-9_./-]*##g')"
+    if printf '%s' "$NON_AGENT_TEAM_FLAT" | grep -Eq "$SRC_ERE"; then
+      TRIGGER="source-write"
+    fi
+    ;;
+esac
+
+if [ -z "$TRIGGER" ]; then
+  case "$TOOL" in
+    Bash|bash|shell|local_shell|exec_command)
+      if printf '%s' "$INPUT_FLAT" | grep -Eiq "$W5_ENTRY_ERE"; then
+        TRIGGER="wave-entry-command"
+      fi
+      ;;
+  esac
+fi
+
+# 비트리거 -> 즉시 exit 0, bathos를 호출하지 않는다(불필요한 프로세스 스폰·
+# 감사 소음 방지 — 테스트 B-5가 이를 계약화한다).
+if [ -z "$TRIGGER" ]; then
+  exit 0
+fi
+
+# --------------------------------------------------------------------------
+# 5. verdict 3단 조회 (gate-enforce.sh §4와 동일 우선순위)
+# --------------------------------------------------------------------------
+W3_VERDICT=""
+VERDICT_SOURCE=""
+
+# 5-a. bathos gate show — 1순위(바이너리 SSOT)
+if [ -n "$BATHOS_BIN" ] && [ -x "$BATHOS_BIN" ]; then
+  GATE_OUTPUT="$("$BATHOS_BIN" -s "$STATE_DIR" gate show 2>/dev/null || true)"
+  if [ -n "$GATE_OUTPUT" ]; then
+    W3_VERDICT="$(printf '%s' "$GATE_OUTPUT" \
+      | grep -o '"verdict"[[:space:]]*:[[:space:]]*"[^"]*"' \
+      | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
+    [ -n "$W3_VERDICT" ] && VERDICT_SOURCE="bathos gate show"
+  fi
+fi
+
+# 5-b. manifest.json — jq 없이는 gates[]에서 "마지막 Implementation" 선택이
+# 신뢰 불가하므로 비단순 파싱은 하지 않는다(설계 결정: 부정확한 파싱으로
+# 오차단하느니 fail-safe). "gate_type":"Implementation" 존재 시에만 그
+# 언저리의 verdict를 보수적으로 시도하고, 애매하면 포기(빈 값)한다.
+MANIFEST="$STATE_DIR/manifest.json"
+if [ -z "$W3_VERDICT" ] && [ -f "$MANIFEST" ] && [ -r "$MANIFEST" ]; then
+  if grep -q '"gate_type"[[:space:]]*:[[:space:]]*"Implementation"' "$MANIFEST" 2>/dev/null; then
+    CAND="$(tr -d '\n' < "$MANIFEST" \
+      | grep -o '"gate_type"[[:space:]]*:[[:space:]]*"Implementation"[^}]*"verdict"[[:space:]]*:[[:space:]]*"[^"]*"' \
+      | head -1 \
+      | grep -o '"verdict"[[:space:]]*:[[:space:]]*"[^"]*"' \
+      | tail -1 \
+      | sed 's/.*"\([^"]*\)"$/\1/' || true)"
+    if printf '%s' "$CAND" | grep -Eq '^(PASS|CONCERNS|FAIL)$'; then
+      W3_VERDICT="$CAND"
+      VERDICT_SOURCE="manifest.json"
+    fi
+  fi
+fi
+
+# 5-c. readiness-report-kr.md 프론트매터 — 최후 수단(gate-enforce.sh §4-c와 동일 sed)
+READINESS_REPORT="$PROJECT_DIR/.agent-team/03-story-engineering/readiness-report-kr.md"
+if [ -z "$W3_VERDICT" ] && [ -f "$READINESS_REPORT" ] && [ -r "$READINESS_REPORT" ]; then
+  W3_VERDICT="$(grep -m1 'verdict:[[:space:]]*' "$READINESS_REPORT" 2>/dev/null \
+    | sed 's/.*verdict:[[:space:]]*["'"'"']*\([A-Z]*\)["'"'"']*.*/\1/' \
+    | grep -E '^(PASS|CONCERNS|FAIL)$' || true)"
+  [ -n "$W3_VERDICT" ] && VERDICT_SOURCE="readiness-report-kr.md"
+fi
+
+# --------------------------------------------------------------------------
+# 6. 감사 로그 append 헬퍼 (FAIL 차단 시에만, best-effort — careful-guard.sh §5 패턴 재사용)
+# --------------------------------------------------------------------------
+_append_audit_block() {
+  [ -n "$BATHOS_BIN" ] && [ -x "$BATHOS_BIN" ] || return 0
+  "$BATHOS_BIN" -s "$STATE_DIR" audit append \
+    --actor "hook:codex-gate" \
+    --action "block" \
+    --target "$TRIGGER:$TOOL" 2>/dev/null || true
+}
+
+# --------------------------------------------------------------------------
+# 7. verdict 부재 시 fail-safe
+# --------------------------------------------------------------------------
+if [ -z "$W3_VERDICT" ]; then
+  printf '[codex-gate] verdict 확인 불가 — fail-safe 통과 (bathos/state/report 미존재)\n' >&2
+  exit 0
+fi
+
+# --------------------------------------------------------------------------
+# 8. verdict 기반 판정 (ADR-P4-2: FAIL만 차단, 그 외 전부 fail-safe 통과)
+# --------------------------------------------------------------------------
+case "$W3_VERDICT" in
+  PASS)
+    printf '[codex-gate] W3 게이트 PASS (%s) — 구현 웨이브 진입 허용\n' "$VERDICT_SOURCE" >&2
+    exit 0
+    ;;
+  CONCERNS)
+    printf '[codex-gate] W3 CONCERNS(%s) — 비차단 리스크, _state/ 확인\n' "$VERDICT_SOURCE" >&2
+    exit 0
+    ;;
+  FAIL)
+    _append_audit_block
+    cat >&2 <<EOF
+[bathos codex-gate] BLOCKED: W3 Implementation gate is FAIL (source: $VERDICT_SOURCE).
+Trigger: $TRIGGER (tool: $TOOL)
+구현 웨이브(W5) 진입이 차단되었습니다.
+1) .agent-team/03-story-engineering/readiness-report-kr.md의 critical issues 확인
+2) W2 산출물 보완 후 재게이트 (bathos gate verdict ...)
+3) 재게이트 PASS/CONCERNS 후 이 작업을 다시 시도
+참고: w3-story-engine-design.md §5 · exceptions.md §1 E-GATE-FAIL
+EOF
+    exit 2
+    ;;
+  *)
+    printf '[codex-gate] 미지 verdict "%s" — 보수적 통과\n' "$W3_VERDICT" >&2
+    exit 0
+    ;;
+esac

--- a/codex-adapter/hooks/stop-save.sh
+++ b/codex-adapter/hooks/stop-save.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# =============================================================================
+# BATHOS P4 — codex-adapter/hooks/stop-save.sh
+# Codex Stop 훅: SessionEnd가 없는 Codex에서 "세션 종료 시 1회 저장"(CLAUDE.md
+# §9)을 물리적으로 재현할 수 없으므로, 매 턴 종료(Stop)마다 증분 저장으로
+# 근사한다.
+#
+# 설계 원본: .agent-team/04-architecture/w2-runtime-p4-design-kr.md §B3 (James)
+#
+# 정직한 한계(문서·출력 양쪽에 명시):
+#   - 이 근사가 주는 것: 세션이 어떻게 죽어도(크래시 포함) 마지막 완료 턴
+#     시점의 상태 덤프는 남는다 — 사실상 SessionEnd보다 유실 창이 좁다
+#     (턴 단위 vs 세션 단위).
+#   - 이 근사가 못 주는 것:
+#     (a) "종료 직전" 정확 시점 스냅샷이 아니다.
+#     (b) LLM 서술 스냅샷(SESSION-SNAPSHOT.md "★ 현재 상태") 생성 불가 —
+#         훅에는 모델 턴이 없다. Codex에서도 `/save-session` 상당(프롬프트)
+#         수동 실행 병행이 정답이다.
+#     (c) HTML 태스크리포트 생성은 이 훅 범위 밖(session-report.sh 이식은
+#         P4 스코프 아님).
+#
+# stdin/stdout/exit 계약:
+#   stdin  = Codex Stop JSON(session_id/turn_id/stop_hook_active/cwd 등).
+#   stdout = 사용 안 함. stderr = 경고만(선택).
+#   exit   = 항상 0. Stop 훅에서 비-0(특히 2)은 "턴 종료 차단 -> 강제 계속"
+#            의미가 될 수 있어(⚠️[추정], Claude Code Stop 의미론 유추) 무한
+#            루프 위험이 있다 — 어떤 내부 실패도 0으로 수렴시킨다.
+# =============================================================================
+set +e
+# session-start.sh 스타일: 이 훅은 절대 세션 진행을 방해하지 않는다.
+
+PROG="stop-save.sh"
+
+# --------------------------------------------------------------------------
+# 1. stdin 읽기 + 평탄화
+# --------------------------------------------------------------------------
+INPUT="$(cat 2>/dev/null)"
+INPUT_FLAT="$(printf '%s' "$INPUT" | tr '\n\r' '  ')"
+
+_jstr() {
+  printf '%s' "$INPUT_FLAT" | grep -o "\"$1\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" \
+    | head -1 | sed 's/.*:[[:space:]]*"\(.*\)"$/\1/'
+}
+_jbool() {
+  printf '%s' "$INPUT_FLAT" | grep -o "\"$1\"[[:space:]]*:[[:space:]]*\(true\|false\)" \
+    | head -1 | grep -Eo '(true|false)$'
+}
+
+STOP_HOOK_ACTIVE="$(_jbool stop_hook_active)"
+SESSION_ID="$(_jstr session_id)"
+TURN_ID="$(_jstr turn_id)"
+CWD="$(_jstr cwd)"
+
+# 루프 이중 안전장치: stop_hook_active=true면 즉시 통과(아무 파일도 건드리지
+# 않는다 — B-14가 이를 계약화).
+if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+  exit 0
+fi
+
+# --------------------------------------------------------------------------
+# 2. 경로 해석 (§B1과 동일 우선순위)
+# --------------------------------------------------------------------------
+PROJECT_DIR="${BATHOS_PROJECT_DIR:-${CWD:-$PWD}}"
+STATE_DIR="${BATHOS_STATE_DIR:-$PROJECT_DIR/.agent-team/_state}"
+
+[ -d "$STATE_DIR" ] || exit 0
+
+BATHOS_BIN="${BATHOS_BIN:-}"
+if [ -z "$BATHOS_BIN" ]; then
+  for cand in \
+    "$PROJECT_DIR/core/target/release/bathos" \
+    "$PROJECT_DIR/core/target/debug/bathos"
+  do
+    if [ -x "$cand" ]; then BATHOS_BIN="$cand"; break; fi
+  done
+  if [ -z "$BATHOS_BIN" ] && command -v bathos >/dev/null 2>&1; then
+    BATHOS_BIN="$(command -v bathos)"
+  fi
+fi
+
+# --------------------------------------------------------------------------
+# 3. 디바운스 판정 (§B3-4 — find -newermt 금지, 플랫폼 분기 없는 자기기록 방식)
+# --------------------------------------------------------------------------
+# 마커 파일 형식: 1행 = 마지막 heavy-save epoch(자기 기록), 2행~ = 사람이
+# 읽는 로그(500줄 초과 시 tail -n 500으로 롤링, 1행은 항상 보존).
+MARKER="$STATE_DIR/codex-stop-save.log"
+DEBOUNCE="${BATHOS_STOP_SAVE_DEBOUNCE:-10}"
+
+NOW_EPOCH="$(date +%s 2>/dev/null || echo 0)"
+LAST_EPOCH=0
+if [ -f "$MARKER" ]; then
+  FIRST_LINE="$(head -1 "$MARKER" 2>/dev/null || echo 0)"
+  # 숫자가 아니면(레거시/손상 마커) 0으로 취급 — heavy 경로로 강제 진행.
+  if printf '%s' "$FIRST_LINE" | grep -Eq '^[0-9]+$'; then
+    LAST_EPOCH="$FIRST_LINE"
+  fi
+fi
+
+HEAVY=1
+if [ "$DEBOUNCE" -gt 0 ] 2>/dev/null; then
+  DELTA=$(( NOW_EPOCH - LAST_EPOCH ))
+  if [ "$DELTA" -lt "$DEBOUNCE" ]; then
+    HEAVY=0
+  fi
+fi
+
+# --------------------------------------------------------------------------
+# 4. SSOT 덤프 (원자적 tmp -> mv, heavy일 때만)
+# --------------------------------------------------------------------------
+DUMP_STATUS="no-bathos"
+if [ "$HEAVY" = "1" ]; then
+  if [ -n "$BATHOS_BIN" ] && [ -x "$BATHOS_BIN" ]; then
+    TMP_STATE="$(mktemp "$STATE_DIR/session-state.json.tmp.XXXXXX" 2>/dev/null || echo "$STATE_DIR/session-state.json.tmp")"
+    if "$BATHOS_BIN" -s "$STATE_DIR" state show > "$TMP_STATE" 2>/dev/null && [ -s "$TMP_STATE" ]; then
+      # E-B6: 새 덤프가 비었으면 교체하지 않는다(기존본 보호) — 위 [ -s ] 검사가
+      # 이를 보장한다. 성공 시에만 원자 교체.
+      mv "$TMP_STATE" "$STATE_DIR/session-state.json" 2>/dev/null && DUMP_STATUS="ok"
+    fi
+    rm -f "$TMP_STATE" 2>/dev/null
+  fi
+else
+  DUMP_STATUS="skip"
+fi
+
+# --------------------------------------------------------------------------
+# 5. 스냅샷 날짜 아카이브 (있을 때만 — 훅은 서술을 생성하지 않는다, heavy일 때만)
+# --------------------------------------------------------------------------
+if [ "$HEAVY" = "1" ]; then
+  SNAPSHOT="$STATE_DIR/SESSION-SNAPSHOT.md"
+  if [ -f "$SNAPSHOT" ]; then
+    TODAY="$(date '+%Y-%m-%d' 2>/dev/null || echo unknown-date)"
+    ARCHIVE="$STATE_DIR/SESSION-SNAPSHOT-$TODAY.md"
+    # 아카이브가 없거나 원본이 더 새로우면 복사(session-end.sh 아카이브 동작 근사).
+    if [ ! -f "$ARCHIVE" ] || [ "$SNAPSHOT" -nt "$ARCHIVE" ]; then
+      cp "$SNAPSHOT" "$ARCHIVE" 2>/dev/null || true
+    fi
+  fi
+fi
+
+# --------------------------------------------------------------------------
+# 6. 마커 로그 append + 500줄 롤링 (1행 epoch 보존)
+# --------------------------------------------------------------------------
+LOG_LINE="$(date '+%Y-%m-%d %H:%M:%S %z' 2>/dev/null || echo unknown-time) | session=${SESSION_ID:-unknown} | turn=${TURN_ID:-unknown} | dump=$DUMP_STATUS"
+
+if [ ! -f "$MARKER" ]; then
+  {
+    printf '%s\n' "$NOW_EPOCH"
+    printf '%s\n' "$LOG_LINE"
+  } > "$MARKER" 2>/dev/null
+else
+  # heavy 저장을 실제로 수행했을 때만 1행의 epoch을 갱신한다(디바운스 스킵 시엔
+  # 기존 LAST_EPOCH을 그대로 보존해야 다음 판정이 정확하다).
+  NEW_FIRST="$LAST_EPOCH"
+  [ "$HEAVY" = "1" ] && NEW_FIRST="$NOW_EPOCH"
+  TMP_MARKER="$(mktemp "$STATE_DIR/codex-stop-save.log.tmp.XXXXXX" 2>/dev/null || echo "$STATE_DIR/codex-stop-save.log.tmp")"
+  # 1행(epoch)은 별도로 항상 보존하고, 본문(2행~)만 500줄로 롤링한다 — 본문이
+  # 500줄을 넘겨도 1행이 tail에 밀려 유실되지 않도록 두 스트림을 분리 처리.
+  {
+    tail -n +2 "$MARKER" 2>/dev/null
+    printf '%s\n' "$LOG_LINE"
+  } | tail -n 500 > "${TMP_MARKER}.body" 2>/dev/null
+  {
+    printf '%s\n' "$NEW_FIRST"
+    cat "${TMP_MARKER}.body" 2>/dev/null
+  } > "$TMP_MARKER" 2>/dev/null
+  if [ -s "$TMP_MARKER" ]; then
+    mv "$TMP_MARKER" "$MARKER" 2>/dev/null
+  fi
+  rm -f "$TMP_MARKER" "${TMP_MARKER}.body" 2>/dev/null
+fi
+
+exit 0

--- a/docs/codex-adapter-kr.md
+++ b/docs/codex-adapter-kr.md
@@ -58,7 +58,14 @@ Codex 훅은 실험적(첫 도입 2026-03)·Windows 미지원 가능성 ⚠️. 
 ---
 
 ## 5. 남은 단계 (후속)
-- P4: (a)(b) 훅 재설계 실제 구현 + 검증 하네스.
+- **P4: 완료(2026-07-16, Phillip)** — (a)(b) 훅 재설계가 `codex-adapter/`에
+  실구현되었다: `hooks/pretooluse-gate.sh`(W3 게이트 exit-2) ·
+  `hooks/stop-save.sh`(Stop 증분 저장) · `hooks/_test-codex-hooks.sh`(14케이스
+  시뮬레이션, 실 Codex 불요 — 전부 통과) · `config.toml.example`. 상세는
+  `codex-adapter/README.md`와 `.agent-team/08-impl-notes/backend.md` 참고.
+  **미해소:** 실 Codex 미설치 상태라 `tool_name` 실측값(§3-a 트리거 매칭의
+  전제)은 여전히 문서 예시(`Bash`·`apply_patch`) 기준 ⚠️[추정]이다 — 설치
+  후 최우선 재확인 필요(fail-open 리스크).
 - P5: Codex+GLM 프록시 연동, 커맨드→skills 마이그레이션(공식 방향).
 - P6: `bathos runtime` 추상화(런타임 감지→어댑터 자동 선택).
 

--- a/docs/glm-backend-kr.md
+++ b/docs/glm-backend-kr.md
@@ -55,6 +55,21 @@ BATHOS 에이전트 정의(`.claude/agents/_base/*.md`)의 `model` 필드는 **`
 unset ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN API_TIMEOUT_MS
 ```
 
+## 상태 — 실연결 검증 하네스 (2026-07-16, Phillip)
+
+`scripts/glm-smoke-test.sh`가 이 문서의 "환경변수 2개면 GLM으로 구동된다"는
+주장을 curl로 직접 검증하는 스모크 테스트다(`--dry-run`으로 키 없이 요청
+구성만 볼 수도 있음). 실키 없이 실증한 범위:
+
+- **인증 재시도 경로(ADR-P4-3) 실서버 확인:** 가짜 키로 `https://api.z.ai/api/anthropic/v1/messages`에
+  요청 시 `Authorization: Bearer` 헤더가 401을 받고, `x-api-key` 헤더로
+  1회 재시도해도 401(`"token expired or incorrect"`)이 옴을 실측했다 —
+  즉 엔드포인트 자체는 살아있고 두 인증 방식 모두 서버가 인지한다.
+- **유효 키로의 성공 여부(V1~V7, 어떤 auth 방식이 실제 통과하는지, 응답
+  model 필드 echo 값)는 아직 미실증** — 유효 키 확보 후
+  `scripts/glm-smoke-test.sh --tool-use`를 1회 실행해 이 섹션에 결과를
+  추가할 것(설계 문서 리스크 R4, `.agent-team/04-architecture/w2-runtime-p4-design-kr.md` §D).
+
 ## 출처
 - Z.ai × Claude Code 공식 가이드: https://docs.z.ai/scenario-example/develop-tools/claude
 - GLM Coding Plan × Claude Code: https://codingplan.run/guides/claude-code-with-glm

--- a/scripts/glm-smoke-test.sh
+++ b/scripts/glm-smoke-test.sh
@@ -1,0 +1,385 @@
+#!/usr/bin/env bash
+# =============================================================================
+# BATHOS P4 — scripts/glm-smoke-test.sh
+# GLM(Z.ai) 실연결 스모크 테스트: Claude Code를 띄우지 않고 curl로 직접
+# Z.ai의 Anthropic 호환 엔드포인트(`POST /v1/messages`)를 두드려 연결·인증·
+# 응답 형태를 검증하는 읽기성(read-only) 테스트다.
+#
+# 설계 원본: .agent-team/04-architecture/w2-runtime-p4-design-kr.md §A (James, 2026-07-16)
+# 상태 변경 없음(라이브 모드는 소량 토큰을 소비함 — max_tokens<=64, 0은 아님).
+#
+# 사용법:
+#   scripts/glm-smoke-test.sh --dry-run                 # 키 불요, 요청 구성만 출력
+#   Z_AI_API_KEY=<키> scripts/glm-smoke-test.sh          # 라이브 텍스트 검증
+#   Z_AI_API_KEY=<키> scripts/glm-smoke-test.sh --tool-use
+#
+# 종료 코드 규약(설계 §A4 — 서로 겹치지 않게 유지, CI 원인 분기용):
+#   0 = 통과(dry-run 포함)      1 = HTTP 200이나 응답 검증 실패
+#   2 = HTTP 비-200             3 = 키 없음(라이브 모드)
+#   4 = 네트워크/전송 오류       5 = curl 미설치
+# =============================================================================
+set -uo pipefail
+# `set -e`는 쓰지 않는다 — curl 비-0 종료(exit 4 분기)를 우리가 직접 처리해야
+# 하고, set -e 하에서는 `HTTP="$(curl ...)"` 같은 명령 치환의 실패가 스크립트를
+# 조기 종료시켜 원인별 메시지를 낼 기회를 잃는다(기존 훅과 동일한 이유).
+
+PROG="glm-smoke-test.sh"
+
+# --------------------------------------------------------------------------
+# 0. 옵션 기본값 + 인자 파싱
+# --------------------------------------------------------------------------
+OPT_DRY_RUN=0
+OPT_TOOL_USE=0
+OPT_MODEL=""
+OPT_BASE_URL=""
+OPT_TIMEOUT=""
+OPT_VERBOSE=0
+
+usage() {
+  cat <<'EOF'
+사용법: scripts/glm-smoke-test.sh [옵션]
+
+옵션:
+  --dry-run           요청을 구성만 하고 전송하지 않는다(키 불요). 구성 결과 출력 후 exit 0.
+  --tool-use          텍스트 검증에 더해 tool-use 호출 검증을 추가 수행(선택 2차 요청).
+  --model <id>        요청 model 필드 (기본: 환경 GLM_SMOKE_MODEL > "glm-4.7")
+  --base-url <url>    엔드포인트 (기본: 환경 ANTHROPIC_BASE_URL > "https://api.z.ai/api/anthropic")
+  --timeout <sec>     curl --max-time (기본: 60)
+  --verbose           요청/응답 원문(키 마스킹) 출력
+  -h | --help         도움말
+
+환경변수:
+  ANTHROPIC_AUTH_TOKEN   1순위 키 (glm-env.sh가 export하는 그 변수)
+  Z_AI_API_KEY           2순위 키 (glm-env.sh 주입 규약과 동일)
+  ANTHROPIC_BASE_URL     엔드포인트 오버라이드
+  GLM_SMOKE_MODEL        모델 오버라이드
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) OPT_DRY_RUN=1; shift ;;
+    --tool-use) OPT_TOOL_USE=1; shift ;;
+    --model) OPT_MODEL="${2:-}"; shift 2 ;;
+    --base-url) OPT_BASE_URL="${2:-}"; shift 2 ;;
+    --timeout) OPT_TIMEOUT="${2:-}"; shift 2 ;;
+    --verbose) OPT_VERBOSE=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      printf '%s: 알 수 없는 옵션: %s\n' "$PROG" "$1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+# --------------------------------------------------------------------------
+# 1. curl 존재 확인 (exit 5)
+# --------------------------------------------------------------------------
+if ! command -v curl >/dev/null 2>&1; then
+  printf '[%s] curl이 설치되어 있지 않습니다. RESULT: FAIL (curl 미설치)\n' "$PROG" >&2
+  exit 5
+fi
+
+# --------------------------------------------------------------------------
+# 2. 설정 해석 (옵션 > 환경 > 기본값)
+# --------------------------------------------------------------------------
+BASE_URL="${OPT_BASE_URL:-${ANTHROPIC_BASE_URL:-https://api.z.ai/api/anthropic}}"
+MODEL="${OPT_MODEL:-${GLM_SMOKE_MODEL:-glm-4.7}}"
+TIMEOUT="${OPT_TIMEOUT:-60}"
+# 정규화: trailing slash 제거 후 /v1/messages를 붙인다(E-A1 — "//v1/messages" 방지).
+URL="${BASE_URL%/}/v1/messages"
+
+# 모델 값 검증(A-10): 인젝션 표면을 없애기 위해 안전 문자만 허용.
+# printf 조립 시 유일한 변수 삽입 지점이 이 값이므로, 여기를 통과하면 본문
+# 조립은 안전하다고 간주할 수 있다(그 외 필드는 고정 리터럴).
+if ! printf '%s' "$MODEL" | grep -Eq '^[A-Za-z0-9._-]+$'; then
+  printf '[%s] 모델 ID에 허용되지 않은 문자가 포함되어 있습니다: %s\n' "$PROG" "$MODEL" >&2
+  printf '[%s] 허용 문자: A-Z a-z 0-9 . _ -\n' "$PROG" >&2
+  printf 'RESULT: FAIL (모델 ID 검증 실패)\n'
+  exit 1
+fi
+
+# 키 우선순위: ANTHROPIC_AUTH_TOKEN(Claude Code가 실제 export하는 변수) > Z_AI_API_KEY.
+KEY="${ANTHROPIC_AUTH_TOKEN:-${Z_AI_API_KEY:-}}"
+
+# 키 마스킹 헬퍼(로그에 실키가 절대 노출되지 않도록 --verbose에서도 사용).
+_mask_key() {
+  local k="$1"
+  if [ -z "$k" ]; then
+    printf '<미설정>'
+  else
+    printf '***(%s자)' "${#k}"
+  fi
+}
+
+# --------------------------------------------------------------------------
+# 3. 요청 본문 조립 (printf, heredoc 미사용 — 변수 삽입 지점은 MODEL 하나뿐)
+# --------------------------------------------------------------------------
+build_text_request() {
+  printf '{"model":"%s","max_tokens":64,"messages":[{"role":"user","content":"Reply with exactly this token and nothing else: BATHOS-GLM-OK"}]}' "$1"
+}
+
+build_tool_request() {
+  printf '{"model":"%s","max_tokens":128,"tools":[{"name":"echo_token","description":"Echo the given token back verbatim.","input_schema":{"type":"object","properties":{"token":{"type":"string"}},"required":["token"]}}],"tool_choice":{"type":"tool","name":"echo_token"},"messages":[{"role":"user","content":"Call echo_token with token=BATHOS-TOOL-OK"}]}' "$1"
+}
+
+REQ_JSON="$(build_text_request "$MODEL")"
+
+# --------------------------------------------------------------------------
+# 4. --dry-run: 키 없이도 동작. 구성 결과만 출력하고 exit 0.
+# --------------------------------------------------------------------------
+if [ "$OPT_DRY_RUN" = "1" ]; then
+  printf '[%s] --- dry-run: 요청 구성만 출력합니다(전송하지 않음) ---\n' "$PROG"
+  printf '[%s] URL: %s\n' "$PROG" "$URL"
+  printf '[%s] 헤더: Authorization: Bearer %s\n' "$PROG" "$(_mask_key "$KEY")"
+  printf '[%s] 헤더: Content-Type: application/json\n' "$PROG"
+  printf '[%s] 헤더: anthropic-version: 2023-06-01\n' "$PROG"
+  printf '[%s] 본문(텍스트): %s\n' "$PROG" "$REQ_JSON"
+  if [ "$OPT_TOOL_USE" = "1" ]; then
+    printf '[%s] 본문(tool-use): %s\n' "$PROG" "$(build_tool_request "$MODEL")"
+  fi
+  printf '[%s] 미전송(dry-run). 라이브 검증엔 키(ANTHROPIC_AUTH_TOKEN 또는 Z_AI_API_KEY)가 필요합니다.\n' "$PROG"
+  printf 'RESULT: PASS — dry-run 구성 완료 (전송 없음)\n'
+  exit 0
+fi
+
+# --------------------------------------------------------------------------
+# 5. 라이브 모드: 키 확인 (exit 3)
+# --------------------------------------------------------------------------
+if [ -z "$KEY" ]; then
+  printf '[%s] ANTHROPIC_AUTH_TOKEN 또는 Z_AI_API_KEY 필요.\n' "$PROG" >&2
+  printf '[%s] 사용: Z_AI_API_KEY=<키> scripts/glm-smoke-test.sh\n' "$PROG" >&2
+  printf '[%s] 키 없이 요청 구성만 보려면 --dry-run\n' "$PROG" >&2
+  printf 'RESULT: FAIL (키 없음)\n'
+  exit 3
+fi
+
+# --------------------------------------------------------------------------
+# 6. 임시 파일 + 정리 트랩 (§A7)
+# --------------------------------------------------------------------------
+BODY_FILE="$(mktemp)"
+ERR_FILE="$(mktemp)"
+BODY_FILE2="$(mktemp)"
+ERR_FILE2="$(mktemp)"
+trap 'rm -f "$BODY_FILE" "$ERR_FILE" "$BODY_FILE2" "$ERR_FILE2"' EXIT INT TERM
+
+# --------------------------------------------------------------------------
+# 7. curl 실행 헬퍼 — auth_style: bearer | x-api-key
+# --------------------------------------------------------------------------
+# $1=auth_style  $2=요청 본문 JSON  $3=본문 저장 파일  $4=stderr 저장 파일
+# stdout으로 "HTTP_CODE CURL_EXIT"를 출력(공백 구분, 두 값 모두 항상 존재).
+do_request() {
+  local auth_style="$1" body="$2" body_file="$3" err_file="$4"
+  local auth_header http_code curl_exit
+  if [ "$auth_style" = "bearer" ]; then
+    auth_header="Authorization: Bearer $KEY"
+  else
+    auth_header="x-api-key: $KEY"
+  fi
+  http_code="$(curl -sS -o "$body_file" -w '%{http_code}' \
+    --connect-timeout 10 --max-time "$TIMEOUT" \
+    -H "Content-Type: application/json" \
+    -H "anthropic-version: 2023-06-01" \
+    -H "$auth_header" \
+    -X POST "$URL" \
+    --data "$body" 2>"$err_file")"
+  curl_exit=$?
+  printf '%s %s' "${http_code:-}" "$curl_exit"
+}
+
+# curl exit code -> 사람이 읽는 원인 메시지 (§A4 exit 4 분기)
+_curl_exit_reason() {
+  case "$1" in
+    6) echo "DNS 해석 실패(오프라인?)" ;;
+    7) echo "연결 거부" ;;
+    28) echo "타임아웃(--timeout 증가 시도)" ;;
+    35) echo "TLS 협상 실패" ;;
+    *) echo "curl exit $1" ;;
+  esac
+}
+
+# --------------------------------------------------------------------------
+# 8. 2단 인증 전략 (ADR-P4-3): Bearer 1차 -> 401/403 시 x-api-key 1회 재시도
+# --------------------------------------------------------------------------
+if [ "$OPT_VERBOSE" = "1" ]; then
+  printf '[%s] 요청 URL: %s\n' "$PROG" "$URL" >&2
+  printf '[%s] 요청 본문: %s\n' "$PROG" "$REQ_JSON" >&2
+fi
+
+READ_OUT="$(do_request bearer "$REQ_JSON" "$BODY_FILE" "$ERR_FILE")"
+HTTP_CODE="${READ_OUT%% *}"
+CURL_EXIT="${READ_OUT##* }"
+AUTH_USED="bearer"
+
+if [ "$CURL_EXIT" != "0" ]; then
+  REASON="$(_curl_exit_reason "$CURL_EXIT")"
+  printf '[%s] curl 전송 실패(exit %s): %s\n' "$PROG" "$CURL_EXIT" "$REASON" >&2
+  [ -s "$ERR_FILE" ] && printf '[%s] curl stderr: %s\n' "$PROG" "$(head -c 300 "$ERR_FILE")" >&2
+  printf 'RESULT: FAIL (네트워크/전송 오류 — %s)\n' "$REASON"
+  exit 4
+fi
+
+if [ "$HTTP_CODE" = "401" ] || [ "$HTTP_CODE" = "403" ]; then
+  printf '[%s] Bearer 인증 %s — x-api-key 헤더로 1회 재시도합니다.\n' "$PROG" "$HTTP_CODE" >&2
+  READ_OUT2="$(do_request x-api-key "$REQ_JSON" "$BODY_FILE2" "$ERR_FILE2")"
+  HTTP_CODE2="${READ_OUT2%% *}"
+  CURL_EXIT2="${READ_OUT2##* }"
+  if [ "$CURL_EXIT2" != "0" ]; then
+    REASON="$(_curl_exit_reason "$CURL_EXIT2")"
+    printf '[%s] curl 전송 실패(exit %s, x-api-key 재시도): %s\n' "$PROG" "$CURL_EXIT2" "$REASON" >&2
+    printf 'RESULT: FAIL (네트워크/전송 오류 — %s)\n' "$REASON"
+    exit 4
+  fi
+  if [ "$HTTP_CODE2" = "200" ]; then
+    printf '[%s] 참고: Bearer 미지원, x-api-key로 성공 — docs/glm-backend-kr.md 갱신 근거.\n' "$PROG" >&2
+    HTTP_CODE="$HTTP_CODE2"
+    BODY_FILE="$BODY_FILE2"
+    AUTH_USED="x-api-key"
+  else
+    # 재시도도 실패 — 최종 상태코드/본문은 재시도(x-api-key) 응답 기준으로 보고.
+    HTTP_CODE="$HTTP_CODE2"
+    BODY_FILE="$BODY_FILE2"
+  fi
+fi
+
+# --------------------------------------------------------------------------
+# 9. HTTP 상태코드 판정 (문자열 비교 — 산술 강제 금지, §A5 지시)
+# --------------------------------------------------------------------------
+if [ "$HTTP_CODE" != "200" ]; then
+  BODY_EXCERPT="$(head -c 300 "$BODY_FILE" 2>/dev/null || true)"
+  case "$HTTP_CODE" in
+    401|403)
+      printf '[%s] 키 무효·만료 — Z.ai 콘솔에서 키 재확인 (Bearer/x-api-key 둘 다 %s)\n' "$PROG" "$HTTP_CODE" >&2
+      ;;
+    404)
+      printf '[%s] 엔드포인트 경로 확인(--base-url) — HTTP 404\n' "$PROG" >&2
+      ;;
+    429)
+      printf '[%s] 티어 할당량 초과(Lite/Pro/Max) — HTTP 429\n' "$PROG" >&2
+      ;;
+    400)
+      printf '[%s] HTTP 400 — 모델 ID 미지원 가능. --model glm-4.6 또는 claude 별칭 시도\n' "$PROG" >&2
+      printf '[%s] 응답 본문: %s\n' "$PROG" "$BODY_EXCERPT" >&2
+      ;;
+    5*)
+      printf '[%s] Z.ai 서버 측 오류(HTTP %s) — 재시도\n' "$PROG" "$HTTP_CODE" >&2
+      ;;
+    *)
+      printf '[%s] 예기치 않은 HTTP 상태코드: %s\n' "$PROG" "$HTTP_CODE" >&2
+      ;;
+  esac
+  printf '[%s] 응답 본문(앞 300자): %s\n' "$PROG" "$BODY_EXCERPT" >&2
+  printf 'RESULT: FAIL (HTTP %s)\n' "$HTTP_CODE"
+  exit 2
+fi
+
+# --------------------------------------------------------------------------
+# 10. 응답 검증 V2~V5 (jq 없이 grep/sed — §A3)
+# --------------------------------------------------------------------------
+RESP_BODY="$(cat "$BODY_FILE" 2>/dev/null || true)"
+RESP_FLAT="$(printf '%s' "$RESP_BODY" | tr '\n\r' '  ')"
+
+_die_v() {
+  # $1=검증 실패 사유
+  printf '[%s] 응답 검증 실패: %s\n' "$PROG" "$1" >&2
+  printf '[%s] 응답 본문(앞 300자): %s\n' "$PROG" "$(printf '%s' "$RESP_BODY" | head -c 300)" >&2
+  printf 'RESULT: FAIL (%s)\n' "$1"
+  exit 1
+}
+
+# E-A3: 강제 스트리밍 감지 — SSE 'event:' 라인이 보이면 비지원으로 처리.
+if printf '%s' "$RESP_FLAT" | grep -Eq '^event:|"event:"'; then
+  _die_v "스트리밍 응답 감지 — 비지원(단일 JSON 응답 가정)"
+fi
+
+# V2: 에러 본문 아님
+if printf '%s' "$RESP_FLAT" | grep -Eq '"type"[[:space:]]*:[[:space:]]*"error"'; then
+  _die_v "V2 실패 — 응답이 에러 본문(\"type\":\"error\")"
+fi
+
+# V3: content 존재 + text 블록 존재
+if ! printf '%s' "$RESP_FLAT" | grep -Eq '"content"'; then
+  _die_v "V3 실패 — content 키 없음"
+fi
+if ! printf '%s' "$RESP_FLAT" | grep -Eq '"type"[[:space:]]*:[[:space:]]*"text"'; then
+  _die_v "V3 실패 — text 타입 블록 없음"
+fi
+
+# V4: 텍스트 비어있지 않음 (표시용 best-effort 추출 — E-A4: 이스케이프 포함 시 잘릴 수 있음, 판정은 "존재 여부"만)
+TEXT_MATCH="$(printf '%s' "$RESP_FLAT" | grep -o '"text":"[^"]*"' | head -1)"
+if [ -z "$TEXT_MATCH" ]; then
+  _die_v "V4 실패 — 비어있지 않은 text 값 없음"
+fi
+TEXT_VALUE="$(printf '%s' "$TEXT_MATCH" | sed 's/^"text":"\(.*\)"$/\1/')"
+
+# V5: 모델 echo (경고만, 비차단)
+RESP_MODEL="$(printf '%s' "$RESP_FLAT" | grep -o '"model"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*:[[:space:]]*"\([^"]*\)"$/\1/')"
+if [ -n "$RESP_MODEL" ] && [ "$RESP_MODEL" != "$MODEL" ]; then
+  printf '[%s] 참고(V5, 비차단): 요청 모델 "%s" != 응답 모델 "%s" — Z.ai 내부 재매핑일 수 있음\n' "$PROG" "$MODEL" "$RESP_MODEL" >&2
+fi
+
+printf '[%s] V1~V4 통과: HTTP 200, 정상 응답 본문, text 블록 존재.\n' "$PROG"
+printf '[%s] 응답 텍스트(표시용, 이스케이프 포함 시 잘릴 수 있음): %s\n' "$PROG" "$TEXT_VALUE"
+# 날조 금지 원칙: "연결 성공"과 "지시 이행"은 별개다 — 참고 출력만, 판정에 미사용.
+if printf '%s' "$TEXT_VALUE" | grep -q 'BATHOS-GLM-OK'; then
+  printf '[%s] 참고: 모델이 지시된 토큰(BATHOS-GLM-OK)을 포함해 응답함(참고용, 판정 기준 아님)\n' "$PROG"
+else
+  printf '[%s] 참고: 모델 응답에 지시된 토큰(BATHOS-GLM-OK)이 없음 — 연결 자체는 정상(참고용, 판정 기준 아님)\n' "$PROG"
+fi
+if [ "$AUTH_USED" = "x-api-key" ]; then
+  printf '[%s] 참고: 이 요청은 x-api-key 인증으로 성공했습니다(Bearer는 401/403).\n' "$PROG"
+fi
+
+# --------------------------------------------------------------------------
+# 11. --tool-use: 2차 요청(같은 auth_style 재사용) -> V6, V7
+# --------------------------------------------------------------------------
+if [ "$OPT_TOOL_USE" = "1" ]; then
+  TOOL_REQ_JSON="$(build_tool_request "$MODEL")"
+  BODY_FILE3="$(mktemp)"
+  ERR_FILE3="$(mktemp)"
+  trap 'rm -f "$BODY_FILE" "$ERR_FILE" "$BODY_FILE2" "$ERR_FILE2" "$BODY_FILE3" "$ERR_FILE3"' EXIT INT TERM
+
+  if [ "$OPT_VERBOSE" = "1" ]; then
+    printf '[%s] tool-use 요청 본문: %s\n' "$PROG" "$TOOL_REQ_JSON" >&2
+  fi
+
+  TOOL_OUT="$(do_request "$AUTH_USED" "$TOOL_REQ_JSON" "$BODY_FILE3" "$ERR_FILE3")"
+  TOOL_HTTP="${TOOL_OUT%% *}"
+  TOOL_CURL_EXIT="${TOOL_OUT##* }"
+
+  if [ "$TOOL_CURL_EXIT" != "0" ]; then
+    REASON="$(_curl_exit_reason "$TOOL_CURL_EXIT")"
+    printf '[%s] tool-use 요청 전송 실패(exit %s): %s\n' "$PROG" "$TOOL_CURL_EXIT" "$REASON" >&2
+    printf 'RESULT: FAIL (네트워크/전송 오류 — tool-use 요청 — %s)\n' "$REASON"
+    exit 4
+  fi
+  if [ "$TOOL_HTTP" != "200" ]; then
+    printf '[%s] tool-use 요청 HTTP %s — 응답 본문(앞 300자): %s\n' "$PROG" "$TOOL_HTTP" "$(head -c 300 "$BODY_FILE3" 2>/dev/null || true)" >&2
+    printf 'RESULT: FAIL (HTTP %s — tool-use 요청)\n' "$TOOL_HTTP"
+    exit 2
+  fi
+
+  TOOL_RESP_FLAT="$(cat "$BODY_FILE3" 2>/dev/null | tr '\n\r' '  ' || true)"
+  # V6: tool_use 블록 + echo_token 이름 존재
+  if printf '%s' "$TOOL_RESP_FLAT" | grep -Eq '"type"[[:space:]]*:[[:space:]]*"tool_use"' \
+     && printf '%s' "$TOOL_RESP_FLAT" | grep -Eq '"name"[[:space:]]*:[[:space:]]*"echo_token"'; then
+    printf '[%s] V6 통과 — tool_use 블록(echo_token) 존재\n' "$PROG"
+  else
+    printf '[%s] tool-use 응답 본문(앞 300자): %s\n' "$PROG" "$(printf '%s' "$TOOL_RESP_FLAT" | head -c 300)" >&2
+    printf 'RESULT: FAIL (V6 — tool_use 블록 없음)\n'
+    exit 1
+  fi
+  # V7: stop_reason 참고(경고만, 비차단 — 호환 레이어별 편차 가능 ⚠️[추정])
+  if printf '%s' "$TOOL_RESP_FLAT" | grep -Eq '"stop_reason"[[:space:]]*:[[:space:]]*"tool_use"'; then
+    printf '[%s] V7 참고 — stop_reason=tool_use\n' "$PROG"
+  else
+    printf '[%s] V7 참고(비차단) — stop_reason이 "tool_use"가 아니거나 없음(호환 레이어 편차 가능)\n' "$PROG"
+  fi
+fi
+
+# --------------------------------------------------------------------------
+# 12. 최종 결과
+# --------------------------------------------------------------------------
+printf 'RESULT: PASS — GLM 백엔드 실연결 확인 (model: %s -> %s)\n' "$MODEL" "${RESP_MODEL:-$MODEL}"
+exit 0


### PR DESCRIPTION
## 요약
멀티 런타임 **P4 실구현**. BATHOS 파이프라인으로 진행 — **W2 James(설계) → W5 Phillip(구현)**.

## 포함 (제품 코드)
- **GLM 실연결 스모크 테스트** `scripts/glm-smoke-test.sh` — 라이브 + `--dry-run`, 2단 auth 폴백(Bearer→401→x-api-key), exit 0~5 원인별, grep/sed only(jq 없음).
- **Codex P4 게이트** `codex-adapter/hooks/pretooluse-gate.sh` — 효과 기반 2-트리거(소스 쓰기/웨이브 진입) → `bathos gate show` → **FAIL 시에만 exit 2**(gate-enforce.sh 동일 의미론, fail-safe).
- **SessionEnd 근사** `codex-adapter/hooks/stop-save.sh` — Stop 훅에서 원자적 state 덤프 + 디바운스 마커, 항상 exit 0.
- **시뮬레이션 테스트** `_test-codex-hooks.sh` — 29 assertion(B-1~B-14), 실제 Codex/bathos 불요(stub).
- `codex-adapter/config.toml.example` + `README.md` · `docs/{glm-backend,codex-adapter}-kr.md` 상태 정직 갱신.

## 검증 (실제 실행 · macOS bash 3.2.57)
- `_test-codex-hooks.sh` → **29/29 PASS**.
- `glm-smoke-test.sh --dry-run`/키없음/연결거부 → 설계 exit code·메시지 일치.
- A-4(가짜 키 라이브) 실제 Z.ai 엔드포인트 도달 → Bearer→401→x-api-key 재시도 확인(엔드포인트 라이브·양 헤더 인식 입증).
- 실제 `bathos` 바이너리 + 실 `_state`로 훅 통합 확인(W3 CONCERNS 정독, 원자적 덤프).

## 미실증 (자격증명 부재 · 정직 표기)
- GLM **유효 키** 라이브(A-6~A-8) — 키 확보 후 1회 실행해 문서 봉인 필요.
- Codex **실 tool_name** — 실 설치 부재, 문서 예시(`Bash`/`apply_patch`) 기반 → 최상위 fail-open 리스크(README 명시).
- Windows 네이티브는 범위 밖(WSL만). 하네스는 macOS에서만 재현.

> 설계·구현 노트는 `.agent-team/`(gitignore)라 미포함. `bathos` 엔진 무변경.