### PR TITLE
fix(codex): P5 real-verification — pin gate triggers to measured tool_names

### DIFF
--- a/codex-adapter/README.md
+++ b/codex-adapter/README.md
@@ -5,6 +5,13 @@
 > `.agent-team/04-architecture/w2-runtime-p4-design-kr.md` §B (James, 2026-07-16).
 > 왜 `.claude/hooks/`가 아니라 이 디렉터리인가: freeze-guard 경로 충돌을 피하고,
 > Codex 전용 런타임 코드를 Claude Code 훅과 분리하기 위해서다.
+>
+> **P5 하드닝(2026-07-16, Phillip):** Codex CLI **v0.144.5**(macos-x86_64)를 실제
+> 설치해 바이너리 임베드 스키마를 실측했다. 문서 예시 기준 가정(`tool_name` =
+> `Bash`/`apply_patch`)이 실측과 달라(실제 값 = `shell`/`exec_command`/
+> `apply_patch`, **`Bash`는 존재하지 않음**) T1/T2 트리거가 발화하지 않고 W3
+> 게이트가 **fail-open**되는 버그가 있었다. 아래 문서·훅·config 예시는 모두
+> 이 실측값 기준으로 갱신됐다(버전 고정 v0.144.5 — 업그레이드 시 재확인 필요).
 
 ---
 
@@ -15,8 +22,8 @@ codex-adapter/
 ├── hooks/
 │   ├── pretooluse-gate.sh       # W3 Implementation 게이트: FAIL이면 구현 진입 exit 2 차단
 │   ├── stop-save.sh             # SessionEnd 근사: 턴마다 증분 저장(state show 덤프)
-│   └── _test-codex-hooks.sh     # 시뮬레이션 테스트(실제 Codex 설치 불요, 14케이스)
-└── config.toml.example          # ~/.codex/config.toml 등록 예시
+│   └── _test-codex-hooks.sh     # 시뮬레이션 테스트(실제 Codex 설치 불요, 18케이스: 게이트 B-1~B-10·B-15~B-18 + 저장 B-11~B-14, 37 assertion)
+└── config.toml.example          # ~/.codex/config.toml 등록 예시(실측 스키마)
 ```
 
 ## 설치
@@ -38,13 +45,19 @@ codex-adapter/
 
 ### `pretooluse-gate.sh` — W3 게이트
 
-- **트리거될 때만** `bathos gate show`를 호출한다(모든 도구 호출마다가 아님):
-  - **T1 소스 쓰기**: `apply_patch`/`write_file`/`edit`/`create_file` 도구가
-    `src/`·`core/crates/`·`core/src/`·`codex-adapter/hooks/` 경로를 언급.
-    `.agent-team/` 전용 언급은 제외(문서 쓰기는 게이트 대상 아님).
-  - **T2 웨이브 진입 명령**: `Bash` 계열 도구의 command가
+- **트리거될 때만** `bathos gate show`를 호출한다(모든 도구 호출마다가 아님).
+  tool_name은 **Codex v0.144.5 실측값만** 매칭한다 — `shell` / `exec_command`
+  (셸 실행) / `apply_patch`(파일 편집). ⚠️ `Bash`는 존재하지 않는 tool_name이며
+  (P4가 문서 예시만 보고 가정했던 값 — 실측으로 폐기), 케이스문에서 완전히
+  제거했다:
+  - **T1 소스 쓰기**: `apply_patch`가 `src/`·`core/crates/`·`core/src/`·
+    `codex-adapter/hooks/` 경로를 언급하거나, `shell`/`exec_command`가
+    (`sed -i`/`tee`/`cp`/`mv` 등으로) 같은 경로에 직접 쓸 때. `.agent-team/`
+    전용 언급은 제외(문서 쓰기는 게이트 대상 아님).
+  - **T2 웨이브 진입 명령**: `shell`/`exec_command`의 명령 문자열이
     `bathos wave advance|start|enter`, `wave5`, `wave4-implement`,
-    `W5 진입/시작`, `implementation start` 등에 매치.
+    `W5 진입/시작`, `implementation start` 등에 매치. (`apply_patch`는 명령
+    실행이 아니므로 T2 대상이 아니다.)
 - verdict가 **FAIL**일 때만 `exit 2` + stderr 사유로 차단한다. PASS/CONCERNS/
   verdict 확인 불가(bathos·state·report 모두 없음)는 전부 `exit 0`(fail-safe).
 - verdict 조회 우선순위: `bathos gate show` > `manifest.json` 보수적 파싱 >
@@ -74,13 +87,27 @@ codex-adapter/
   스코프가 아니다.
 - **저장 손실 창** — 최대 "1턴 + 디바운스(기본 10초)". SessionEnd 방식보다
   좁지만(세션 단위가 아니라 턴 단위) 0은 아니다.
-- **Codex `tool_name` 실측값 미확인(⚠️ 최대 리스크)** — 공식 문서 예시는
-  `"Bash"`·`"apply_patch"`뿐이라, 실제 설치에서 다른 값(`"shell"` 등)이 오면
-  T1/T2 트리거가 발화하지 않아 **게이트가 무력화(fail-open)** 될 수 있다.
-  설치 후 반드시 실측하고 필요시 `BATHOS_GATE_SRC_ERE`/matcher를 조정할 것.
+- **Codex `tool_name` fail-open 리스크 — P5(2026-07-16)에서 해소됨** — P4는
+  공식 문서 예시(`"Bash"`·`"apply_patch"`)만 보고 매칭했으나, 실제 설치에서
+  `tool_name`이 다른 값(`shell`/`exec_command`)으로 와 T1/T2가 발화하지 않고
+  게이트가 무력화되는 버그가 실측으로 확정됐다. `pretooluse-gate.sh`를
+  실측 3종 tool_name(`shell`/`exec_command`/`apply_patch`)으로 갱신하고
+  `_test-codex-hooks.sh`에 회귀 케이스(B-15~B-18)를 추가해 재발을 감시한다.
+  **단, 이 해소는 v0.144.5(macos-x86_64) 기준이다 — 다른 버전/플랫폼으로
+  업그레이드하면 `codex features list`·PreToolUse stdin을 재실측할 것.**
+- **라이브 인증 세션 미실행(남은 미실증)** — 이번 실측은 로컬 API 키 없이
+  진행되어 `codex` 바이너리의 스키마·계약(이벤트명·필드·tool_name·exit 코드
+  의미론)만 확인했다. 실제 인증된 세션에서 훅이 배선대로 호출되는지(config
+  등록 반영·타이밍 등)는 아직 라이브로 실행해 보지 못했다 — 다음 실사용
+  시 최우선 확인 항목으로 남긴다.
 - **Windows 네이티브 미지원** — macOS/Linux/WSL만 지원(bash 3.2+ 호환 작성).
-  `.ps1` 포트는 P4 범위 밖. Windows 사용자는 WSL에서 Codex 구동을 권장
+  `.ps1` 포트는 이번 스코프 밖이나, `commandWindows` 필드가 실측 스키마에
+  존재함을 확인했다(Windows 네이티브 경로가 실제로 있다는 뜻 — 포트 시
+  참고). Windows 사용자는 현재로선 WSL에서 Codex 구동을 권장
   (`scripts/wsl-setup.sh`).
+- **네이티브 마이그레이션 대안(미검토)** — Codex는 외부 config(AGENTS_MD/
+  HOOKS/COMMANDS/SUBAGENTS/MCP)의 네이티브 import를 지원한다. `to-codex.sh`
+  스캐폴드 변환 대신 이 경로를 쓰는 방안은 아직 검토하지 않았다(후속 과제).
 
 ## 테스트
 
@@ -89,9 +116,13 @@ bash codex-adapter/hooks/_test-codex-hooks.sh
 ```
 
 실제 Codex 설치나 실제 `bathos` 빌드 없이도 동작한다(스텁 `bathos`를
-`mktemp` 디렉터리에 생성해 `gate show`/`state show` 출력을 재생). 14개
-설계 테스트 케이스(B-1~B-14)를 세분화한 assertion으로 검증하며, 전부 통과 시
-`전체 통과` + exit 0으로 끝난다.
+`mktemp` 디렉터리에 생성해 `gate show`/`state show` 출력을 재생). 18개
+설계 테스트 케이스(게이트 B-1~B-10·B-15~B-18, 저장 B-11~B-14)를 세분화한
+37개 assertion으로 검증하며, 전부 통과 시 `전체 통과` + exit 0으로 끝난다.
+B-15~B-18은 P5(2026-07-16) 실측 회귀 케이스로, (a) `exec_command`의 웨이브
+진입 명령 차단, (b) `shell`의 소스 직접쓰기(`sed -i`) 차단, (c) 폐기된
+`Bash` 가정이 여전히 무해함(비트리거·bathos 미호출), (d) 무관 tool_name
+통과를 계약화한다.
 
 추가로 실제 `bathos` 바이너리(`core/target/release/bathos`)를 빌드해 두면
 두 훅을 실제 프로젝트 state 사본에 대해 수동으로 돌려 통합 확인도 가능하다
@@ -113,5 +144,10 @@ bash codex-adapter/hooks/_test-codex-hooks.sh
 - 설계: `.agent-team/04-architecture/w2-runtime-p4-design-kr.md`
 - 상위 포팅 판단: `docs/PORTABILITY-kr.md`, `docs/codex-adapter-kr.md`
 - 스타일 정본: `.claude/hooks/{gate-enforce,careful-guard,session-start}.sh`
-- Codex hooks 공식(이벤트·stdin 스키마·exit 2·config 문법 — 2026-07-16 확인):
-  https://developers.openai.com/codex/hooks , https://learn.chatgpt.com/docs/hooks
+- Codex hooks 공식 문서(2026-07-16 확인): https://developers.openai.com/codex/hooks ,
+  https://learn.chatgpt.com/docs/hooks
+- **실측 SSOT(2026-07-16, P5, Phillip)**: Codex CLI **v0.144.5**
+  (macos-x86_64) 실제 설치 바이너리에서 `codex features list` + PreToolUse
+  훅 stdin/config 스키마를 직접 확인. 이 문서·훅·config 예시의 이벤트명·
+  필드명·tool_name 값은 모두 이 실측에 근거한다(문서 예시만 보고 추정한
+  것이 아님). 라이브 인증 세션은 미실행(auth 부재) — §정직한 한계 참고.

--- a/codex-adapter/config.toml.example
+++ b/codex-adapter/config.toml.example
@@ -1,44 +1,60 @@
 # =============================================================================
-# BATHOS codex-adapter 훅 등록 예시 (2026-07 문서 기준 [문서] · 설치 시 재확인 ⚠️)
-# 복사 대상: ~/.codex/config.toml  (hooks.json 병용 시 병합·경고됨 [문서])
+# BATHOS codex-adapter 훅 등록 예시
+# 실측 기반: Codex CLI v0.144.5 (macos-x86_64), 실제 설치 바이너리에서 확인
+# (2026-07-16). 하드코딩된 스키마 필드·이벤트명은 이 설치본에서 직접 확인한
+# 값이며, 문서 추정이 아니다 — 단, **버전 고정**이므로 다른 버전으로
+# 업그레이드하면 `codex features list`와 아래 항목을 재확인할 것(§재확인).
+#
+# 복사 대상: ~/.codex/config.toml  (hooks.json 병용 시 병합·경고될 수 있음)
 # <BATHOS_ROOT>를 실제 절대경로로 치환할 것. 예: /Users/you/dev/bathos-dynamis
 #
-# 설치 후 첫 검증 항목(재확인 필요 — w2-runtime-p4-design-kr.md §B0/§B4):
-#   1. ⚠️[추정] tool_name 실측값 — 문서 예시는 "Bash"·"apply_patch"·MCP 이름뿐.
-#      실제 설치 후 PostToolUse(또는 이 훅의 stderr 로깅)로 tool_name을 실측해
-#      matcher를 좁히는 것을 권장(넓어도 스크립트 자체 트리거 판정으로 안전 —
-#      지연만 소폭 발생).
-#   2. ⚠️[추정] hooks.Stop의 matcher 생략 가능 여부 — 문서에 명시가 없어 아래는
-#      matcher 없이 등록(전체 매치를 가정). 등록 실패 시 matcher = ".*" 추가.
-#   3. ⚠️[추정] 훅 timeout(20s) 초과 시 Codex의 기본 처리(차단/통과)가 불명 —
-#      pretooluse-gate.sh는 로컬 파일 I/O만 하므로 실제로는 ms 단위로 끝난다
-#      ([실측 체감], NFS 등 특수 환경 제외).
-#   4. [features] hooks가 기본 활성인지 버전별로 다를 수 있음(P3 문서는
-#      "실험적"이라 했으나 이번 재확인은 "기본 활성"으로 나옴 — 상충, 재확인 요).
+# 실측 사실 요약(설치 시 재확인 권장 — 버전 고정 v0.144.5):
+#   - hooks 기능 = stable(실험적 아님) · 기본 활성. `codex features list`에서
+#     `hooks  stable  true`로 확인됨.
+#   - 유효 이벤트(HookEventNameWire): PreToolUse, PostToolUse,
+#     PermissionRequest, PreCompact, PostCompact, SessionStart, SubagentStart,
+#     SubagentStop, Stop, UserPromptSubmit. SessionEnd는 존재하지 않는다(확정)
+#     — 아래 [[hooks.Stop]]이 그 근사다.
+#   - PreToolUse stdin 필드(snake_case, 실측): hook_event_name, tool_name,
+#     tool_input, session_id, cwd, source, transcript_path, command.
+#   - 실제 tool_name 값: shell / exec_command(셸 실행) / apply_patch(파일
+#     편집). `Bash`는 존재하지 않는다(P4가 가정했던 값 — 실측으로 폐기됨).
+#   - hook 설정 스키마 필드: matcher, command, commandWindows(Windows 전용
+#     명령 — Windows 경로가 실제로 존재함을 뜻함), timeoutSec, async,
+#     statusMessage, enabled, env, source, agent.
+#   - 차단 규약: exit 2 = 차단(+stderr 사유). JSON decision 출력도 가능
+#     (PreToolUseDecisionWire) — 이 어댑터는 exit code만 사용(단순성).
+#
+# 재확인 항목(버전 업그레이드 시):
+#   1. `codex features list`로 hooks stable/활성 여부 재확인.
+#   2. tool_name 값이 여전히 shell/exec_command/apply_patch인지(PreToolUse
+#      훅의 stderr 로깅 또는 신규 문서로).
+#   3. 라이브 인증 세션(auth)에서의 실동작은 이 설치본에서 미실증 — 키 없이
+#      스키마·계약만 확인했다(정직 표기, 날조 금지).
 # =============================================================================
 
-# --- W3 게이트: 소스 쓰기 + Bash 웨이브 진입 명령 인터셉트 ---
+# --- W3 게이트: 소스 쓰기(apply_patch) + 웨이브 진입 명령(shell/exec_command) 인터셉트 ---
+# 각 훅 항목은 [[hooks.<Event>]] 배열의 테이블 하나(matcher/command 등을 같은
+# 테이블에 직접 기술 — 실측 스키마에 별도 중첩 ".hooks" 배열은 없다).
 [[hooks.PreToolUse]]
-matcher = "^(Bash|shell|local_shell|exec_command|apply_patch|write_file|edit|create_file)$"
-# ⚠️ tool_name 실측값에 맞게 축소 권장(위 항목 1). matcher가 넓어도 스크립트가
-#    자체 트리거 판정(T1/T2)으로 즉시 통과시키므로 안전(지연만 소폭).
-
-[[hooks.PreToolUse.hooks]]
-type = "command"
+matcher = "^(shell|exec_command|apply_patch)$"
+# 실측 tool_name 3종만 매칭(Bash는 존재하지 않으므로 포함하지 않는다). matcher가
+# 이 셋 중 하나로 좁혀져 있어도 스크립트 내부에서 다시 T1/T2 트리거 여부를
+# 판정하므로 이중 안전(과탐해도 verdict FAIL 상태에서만 영향).
 command = '/bin/bash "<BATHOS_ROOT>/codex-adapter/hooks/pretooluse-gate.sh"'
-timeout = 20
+timeoutSec = 20
 statusMessage = "BATHOS W3 gate check"
+# commandWindows: Windows 환경에서 실행할 명령(필드 자체가 실측 스키마에
+# 존재함 — Windows 네이티브 경로가 있다는 뜻). .ps1 포트는 이번 스코프
+# 밖이라 아래는 주석 처리만 해 둔다(향후 포트 시 주석 해제).
 # commandWindows = 'powershell -File "<BATHOS_ROOT>\\codex-adapter\\hooks\\pretooluse-gate.ps1"'
-#   .ps1 포트는 P4 범위 밖(README.md "Windows 공백" 참고). 필드 자체는 문서에 존재[문서].
 
-# --- SessionEnd 근사: 턴 종료마다 증분 저장 ---
+# --- SessionEnd 근사: 턴 종료(Stop)마다 증분 저장 ---
+# SessionEnd는 Codex v0.144.5에 존재하지 않음(확정) — Stop이 유일한 근사 지점.
 [[hooks.Stop]]
-# matcher 생략 가능 여부 ⚠️[추정](위 항목 2) — 등록 실패 시 matcher = ".*" 추가.
-
-[[hooks.Stop.hooks]]
-type = "command"
+matcher = ".*"
 command = '/bin/bash "<BATHOS_ROOT>/codex-adapter/hooks/stop-save.sh"'
-timeout = 20
+timeoutSec = 20
 statusMessage = "BATHOS incremental save"
 
 # --- 선택 환경변수(둘 다 훅 스크립트가 자동 탐지하므로 보통 불필요) ---

--- a/codex-adapter/hooks/_test-codex-hooks.sh
+++ b/codex-adapter/hooks/_test-codex-hooks.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # =============================================================================
-# BATHOS P4 — codex-adapter/hooks/_test-codex-hooks.sh
+# BATHOS P5 — codex-adapter/hooks/_test-codex-hooks.sh
 # 시뮬레이션 테스트 하네스: pretooluse-gate.sh · stop-save.sh를 실제 Codex
 # 설치 없이 검증한다. 가짜 stdin JSON을 파이프하고, 스텁 bathos로 verdict를
 # 재생해 exit code·stderr·부수효과(파일)를 단정(assert)한다.
@@ -8,6 +8,13 @@
 # 설계 원본: .agent-team/04-architecture/w2-runtime-p4-design-kr.md §B5 (James)
 # 자리매김: .claude/hooks/_test-hooks.sh와 동일(수동 실행 검증 스크립트).
 # bash 3.2 호환(카운터 변수 + 함수, 연관배열 금지).
+#
+# P5 갱신(2026-07-16, Codex v0.144.5 macos-x86_64 실측 반영):
+# 픽스처 stdin의 tool_name을 실측값(shell/exec_command/apply_patch)으로
+# 교체하고, B-15~B-18을 추가해 "Bash는 존재하지 않는다"는 실측 사실이
+# 회귀하지 않음을 계약화한다(B-3은 이제 실측 tool_name인 shell로 웨이브
+# 진입 명령을 검증하고, B-15는 옛 P4 가정이던 Bash가 더 이상 필요/유효하지
+# 않음 — 오지 않는 값이므로 무해 통과만 확인 — 을 별도로 남겨 둔다).
 #
 # 실행: bash codex-adapter/hooks/_test-codex-hooks.sh
 # =============================================================================
@@ -105,18 +112,41 @@ get_stderr() { printf '%s' "$1" | cut -f2- | base64 -d 2>/dev/null; }
 
 # ==========================================================================
 # 픽스처 stdin JSON (하네스 내 printf 상수, <TMP_PROJ>를 실경로로 치환)
+# tool_name은 Codex v0.144.5(macos-x86_64) 실측값만 사용한다: shell,
+# exec_command, apply_patch. `Bash`는 존재하지 않는 값이며(P5에서 확정),
+# 그 사실 자체를 검증하는 픽스처는 별도로 json_legacy_bash_wave()에 둔다.
 # ==========================================================================
 json_write_src() {
   printf '{"session_id":"s1","turn_id":"t1","hook_event_name":"PreToolUse","tool_name":"apply_patch","cwd":"%s","tool_input":{"patch":"*** Update File: core/crates/bathos-cli/src/main.rs"}}' "$1"
 }
-json_bash_wave() {
-  printf '{"session_id":"s1","turn_id":"t1","hook_event_name":"PreToolUse","tool_name":"Bash","cwd":"%s","tool_input":{"command":"bathos wave advance --to W5"}}' "$1"
+json_shell_wave() {
+  # T2: 실측 tool_name "shell"의 tool_input.command가 웨이브 진입 명령.
+  printf '{"session_id":"s1","turn_id":"t1","hook_event_name":"PreToolUse","tool_name":"shell","cwd":"%s","tool_input":{"command":"bathos wave advance --to W5"}}' "$1"
+}
+json_exec_command_wave() {
+  # T2: 실측 tool_name "exec_command"(shell과 별개 값)로도 동일하게 발화해야 한다.
+  printf '{"session_id":"s1","turn_id":"t1","hook_event_name":"PreToolUse","tool_name":"exec_command","cwd":"%s","tool_input":{"command":"bathos wave advance --to W5"}}' "$1"
 }
 json_bash_benign() {
-  printf '{"session_id":"s1","turn_id":"t1","hook_event_name":"PreToolUse","tool_name":"Bash","cwd":"%s","tool_input":{"command":"ls -la"}}' "$1"
+  printf '{"session_id":"s1","turn_id":"t1","hook_event_name":"PreToolUse","tool_name":"shell","cwd":"%s","tool_input":{"command":"ls -la"}}' "$1"
 }
 json_write_docs() {
   printf '{"session_id":"s1","turn_id":"t1","hook_event_name":"PreToolUse","tool_name":"apply_patch","cwd":"%s","tool_input":{"patch":"*** Update File: .agent-team/08-impl-notes/backend.md"}}' "$1"
+}
+json_shell_write_src() {
+  # T1: apply_patch가 아니라 shell 도구가 sed -i로 소스 경로를 직접 쓰는 경우
+  # (§4 T1 케이스가 apply_patch 외 shell/exec_command도 포함하는지 검증).
+  printf '{"session_id":"s1","turn_id":"t1","hook_event_name":"PreToolUse","tool_name":"shell","cwd":"%s","tool_input":{"command":"sed -i \\"\\" \\"s/x/y/\\" core/crates/bathos-cli/src/main.rs"}}' "$1"
+}
+json_legacy_bash_wave() {
+  # P4가 가정했던(그러나 실제로는 존재하지 않는) tool_name "Bash"로 동일한
+  # 웨이브 진입 명령을 보낸다 — Bash는 케이스문에 없으므로 TRIGGER가 비고
+  # bathos 호출 없이 즉시 exit 0이어야 한다(= 옛 가정이 남아 있어도 무해).
+  printf '{"session_id":"s1","turn_id":"t1","hook_event_name":"PreToolUse","tool_name":"Bash","cwd":"%s","tool_input":{"command":"bathos wave advance --to W5"}}' "$1"
+}
+json_unrelated_tool() {
+  # 게이트 트리거와 무관한 tool_name(가상의 read 계열 도구) -> 항상 통과.
+  printf '{"session_id":"s1","turn_id":"t1","hook_event_name":"PreToolUse","tool_name":"read_file","cwd":"%s","tool_input":{"path":"README.md"}}' "$1"
 }
 json_stop() {
   printf '{"session_id":"s1","turn_id":"t9","hook_event_name":"Stop","stop_hook_active":false,"cwd":"%s","last_assistant_message":"done"}' "$1"
@@ -155,12 +185,12 @@ else
   assert_true "B-2 stderr에 BLOCKED·FAIL 포함" 0
 fi
 
-# --- B-3: J_BASH_WAVE, verdict=FAIL -> exit 2, stderr에 wave-entry-command ---
+# --- B-3: J_SHELL_WAVE(tool_name=shell, 실측), verdict=FAIL -> exit 2, stderr에 wave-entry-command ---
 P3="$(make_fixture_project b3)"
 STUB3="$TMPDIR_BASE/stub-b3"; make_stub_bathos "$STUB3" "FAIL"
-RES="$(BATHOS_BIN="$STUB3/bathos" run_hook "$HOOKS_DIR/pretooluse-gate.sh" "$(json_bash_wave "$P3")")"
+RES="$(BATHOS_BIN="$STUB3/bathos" run_hook "$HOOKS_DIR/pretooluse-gate.sh" "$(json_shell_wave "$P3")")"
 EC="$(get_exit "$RES")"; ERR="$(get_stderr "$RES")"
-assert_exit "B-3 웨이브진입명령 + FAIL -> 차단(exit 2)" 2 "$EC"
+assert_exit "B-3 웨이브진입명령(tool_name=shell) + FAIL -> 차단(exit 2)" 2 "$EC"
 if printf '%s' "$ERR" | grep -q 'wave-entry-command'; then
   assert_true "B-3 stderr에 wave-entry-command 포함" 1
 else
@@ -179,12 +209,12 @@ else
   assert_true "B-4 stderr에 CONCERNS 포함" 0
 fi
 
-# --- B-5: J_BASH_BENIGN, verdict=FAIL(스텁) -> exit 0, calls.log 비어있음(비트리거는 bathos 미호출) ---
+# --- B-5: J_BASH_BENIGN(tool_name=shell, 무해 명령), verdict=FAIL(스텁) -> exit 0, calls.log 비어있음(비트리거는 bathos 미호출) ---
 P5="$(make_fixture_project b5)"
 STUB5="$TMPDIR_BASE/stub-b5"; make_stub_bathos "$STUB5" "FAIL"
 RES="$(BATHOS_BIN="$STUB5/bathos" run_hook "$HOOKS_DIR/pretooluse-gate.sh" "$(json_bash_benign "$P5")")"
 EC="$(get_exit "$RES")"
-assert_exit "B-5 무해 Bash -> 통과" 0 "$EC"
+assert_exit "B-5 무해 shell 명령 -> 통과" 0 "$EC"
 if [ ! -s "$STUB5/calls.log" ]; then
   assert_true "B-5 calls.log 비어있음(bathos 미호출)" 1
 else
@@ -234,6 +264,66 @@ STUB10="$TMPDIR_BASE/stub-b10"; make_stub_bathos "$STUB10" "FAIL"
 RES="$(BATHOS_BIN="$STUB10/bathos" run_hook "$HOOKS_DIR/pretooluse-gate.sh" "$(json_write_src "$NO_STATE_DIR")")"
 EC="$(get_exit "$RES")"
 assert_exit "B-10 _state 없는 cwd -> 비-BATHOS 프로젝트 통과" 0 "$EC"
+
+# --------------------------------------------------------------------------
+# B-15 ~ B-18: P5 실측 회귀(Codex v0.144.5) — tool_name 하드닝 계약화
+# --------------------------------------------------------------------------
+
+# --- B-15: J_EXEC_COMMAND_WAVE(tool_name=exec_command), verdict=FAIL -> exit 2 ---
+# (a) 웨이브 진입 명령이 exec_command로 와도 shell과 동일하게 차단되어야 한다.
+P15="$(make_fixture_project b15)"
+STUB15="$TMPDIR_BASE/stub-b15"; make_stub_bathos "$STUB15" "FAIL"
+RES="$(BATHOS_BIN="$STUB15/bathos" run_hook "$HOOKS_DIR/pretooluse-gate.sh" "$(json_exec_command_wave "$P15")")"
+EC="$(get_exit "$RES")"; ERR="$(get_stderr "$RES")"
+assert_exit "B-15 웨이브진입명령(tool_name=exec_command) + FAIL -> 차단(exit 2)" 2 "$EC"
+if printf '%s' "$ERR" | grep -q 'wave-entry-command'; then
+  assert_true "B-15 stderr에 wave-entry-command 포함" 1
+else
+  assert_true "B-15 stderr에 wave-entry-command 포함" 0
+fi
+
+# --- B-16: J_SHELL_WRITE_SRC(tool_name=shell, sed -i 로 src/ 직접 쓰기), verdict=FAIL -> exit 2 ---
+# (b) apply_patch가 아니어도 shell이 소스 경로를 직접 쓰면 T1(source-write)로
+# 차단되어야 한다(§4 T1 케이스가 apply_patch 외 shell/exec_command도 포함).
+P16="$(make_fixture_project b16)"
+STUB16="$TMPDIR_BASE/stub-b16"; make_stub_bathos "$STUB16" "FAIL"
+RES="$(BATHOS_BIN="$STUB16/bathos" run_hook "$HOOKS_DIR/pretooluse-gate.sh" "$(json_shell_write_src "$P16")")"
+EC="$(get_exit "$RES")"; ERR="$(get_stderr "$RES")"
+assert_exit "B-16 shell의 소스직접쓰기(sed -i) + FAIL -> 차단(exit 2)" 2 "$EC"
+if printf '%s' "$ERR" | grep -q 'source-write'; then
+  assert_true "B-16 stderr에 source-write 포함" 1
+else
+  assert_true "B-16 stderr에 source-write 포함" 0
+fi
+
+# --- B-17: J_LEGACY_BASH_WAVE(tool_name="Bash", P4의 옛 가정), verdict=FAIL -> exit 0, bathos 미호출 ---
+# (c) 과거 P4가 가정했던 "Bash"는 실측 결과 존재하지 않는 tool_name이다.
+# 케이스문에서 완전히 제거됐어도(=더 이상 필요 없음) 여전히 무해(비트리거로
+# 즉시 통과, bathos도 호출하지 않음)함을 계약화한다 — 회귀 시 이 값이 다시
+# T2로 오인 매칭되면 fail-open 리스크가 재발하므로 명시적으로 감시한다.
+P17="$(make_fixture_project b17)"
+STUB17="$TMPDIR_BASE/stub-b17"; make_stub_bathos "$STUB17" "FAIL"
+RES="$(BATHOS_BIN="$STUB17/bathos" run_hook "$HOOKS_DIR/pretooluse-gate.sh" "$(json_legacy_bash_wave "$P17")")"
+EC="$(get_exit "$RES")"
+assert_exit "B-17 옛 가정 tool_name=Bash + FAIL(verdict) -> 비트리거 통과(exit 0)" 0 "$EC"
+if [ ! -s "$STUB17/calls.log" ]; then
+  assert_true "B-17 calls.log 비어있음(Bash는 트리거 아님 -> bathos 미호출)" 1
+else
+  assert_true "B-17 calls.log 비어있음(Bash는 트리거 아님 -> bathos 미호출)" 0
+fi
+
+# --- B-18: J_UNRELATED_TOOL(tool_name=read_file), verdict=FAIL -> exit 0 ---
+# (d) 게이트 트리거와 무관한 tool_name은 verdict와 무관하게 항상 통과.
+P18="$(make_fixture_project b18)"
+STUB18="$TMPDIR_BASE/stub-b18"; make_stub_bathos "$STUB18" "FAIL"
+RES="$(BATHOS_BIN="$STUB18/bathos" run_hook "$HOOKS_DIR/pretooluse-gate.sh" "$(json_unrelated_tool "$P18")")"
+EC="$(get_exit "$RES")"
+assert_exit "B-18 무관 tool_name(read_file) -> 통과(exit 0)" 0 "$EC"
+if [ ! -s "$STUB18/calls.log" ]; then
+  assert_true "B-18 calls.log 비어있음(비트리거 -> bathos 미호출)" 1
+else
+  assert_true "B-18 calls.log 비어있음(비트리거 -> bathos 미호출)" 0
+fi
 
 # ==========================================================================
 # B-11 ~ B-14: stop-save.sh

--- a/codex-adapter/hooks/pretooluse-gate.sh
+++ b/codex-adapter/hooks/pretooluse-gate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # =============================================================================
-# BATHOS P4 — codex-adapter/hooks/pretooluse-gate.sh
+# BATHOS P5 — codex-adapter/hooks/pretooluse-gate.sh
 # Codex PreToolUse 훅: W3 Implementation 게이트가 FAIL인 동안 "구현 웨이브(W5)
 # 진입"을 뜻하는 도구 호출만 exit 2로 물리 차단한다. 그 외 모든 상황은 통과.
 #
@@ -8,9 +8,19 @@
 # 의미론은 .claude/hooks/gate-enforce.sh(Claude Code용)와 문자 그대로 동일하게
 # 유지한다(ADR-P4-2) — 런타임이 달라도 게이트 정책은 하나다.
 #
+# P5 하드닝(2026-07-16, 실측 기반 — Codex v0.144.5 macos-x86_64 실제 설치본):
+#   실제 tool_name 값은 `shell` / `exec_command`(셸 실행) / `apply_patch`
+#   (파일 편집) 뿐이다. **`Bash`는 존재하지 않는다** — P4에서 문서 예시만
+#   보고 가정했던 `Bash` 매칭은 실측 결과 항상 미스매치라 T1/T2가 발화하지
+#   않고 게이트가 fail-open(무력화)되는 버그였다. 아래 트리거 판정은 실측
+#   3개 값만 사용한다(추정 이름 write_file/edit/create_file/local_shell도
+#   함께 제거 — 확인되지 않은 이름을 남겨 두는 것 자체가 "실측 기반"이라는
+#   전제를 흐린다).
+#
 # stdin/stdout/exit 계약:
-#   stdin  = Codex PreToolUse JSON 1개(session_id/turn_id/tool_name/tool_input/
-#            cwd/hook_event_name 등). 비-JSON/빈 입력 -> fail-safe exit 0.
+#   stdin  = Codex PreToolUse JSON 1개. 실측 필드(snake_case): hook_event_name,
+#            tool_name, tool_input, session_id, cwd, source, transcript_path,
+#            command. 비-JSON/빈 입력 -> fail-safe exit 0.
 #   stdout = 사용 안 함(비움 유지 — exit 0에서 무출력=성공).
 #   stderr = 차단 사유·경고만.
 #   exit   = 0(통과) | 2(차단). 그 외 코드는 절대 사용하지 않는다 — 내부 오류도
@@ -84,13 +94,28 @@ fi
 # (문서·산출물 쓰기는 게이트 대상이 아니다).
 SRC_ERE="${BATHOS_GATE_SRC_ERE:-(^|[^A-Za-z0-9_./-])(src|core/crates|core/src|codex-adapter/hooks)/}"
 
-# T2 웨이브 진입 명령 ERE (gate-enforce.sh is_w5_entry와 정렬).
+# T2 웨이브 진입 명령 ERE (gate-enforce.sh is_w5_entry와 정렬). 매칭 대상은
+# INPUT_FLAT 전체(= tool_input.command/argv를 포함한 stdin 원문의 개행제거본)
+# 다 — tool_input 내부만 잘라내는 정밀 JSON 파싱은 하지 않는다(§C0, jq 금지
+# 원칙). 명령 문자열이 아닌 다른 필드(session_id/cwd 등)에 이 패턴이 우연히
+# 등장할 가능성은 사실상 없으므로 과탐 리스크는 낮고, 설령 과탐해도 FAIL
+# 상태에서만 영향이 있어 careful 원칙(과차단 > 놓침)에 부합한다.
 W5_ENTRY_ERE='bathos[[:space:]]+wave[[:space:]]+(advance|start|enter)|wave.?5|wave.?4-implement|W5.*(진입|시작)|implement(ation)?[[:space:]]+(start|begin)'
 
 TRIGGER=""
 
+# T1(소스 쓰기) — tool_name 실측값(Codex v0.144.5)만 매칭한다:
+#   - apply_patch     : 파일 편집(유일한 편집 도구). tool_input에 대상 파일이
+#                        실린다(필드명 미문서화 — 패치 텍스트/파일 목록 어느
+#                        쪽이든 아래는 원문 전체를 대상으로 경로 패턴 검색).
+#   - shell/exec_command: 셸 실행 도구도 `sed -i`/`tee`/`cp`/`mv` 등으로 소스
+#                        경로에 직접 쓸 수 있으므로 T1 후보에 함께 넣는다
+#                        (T2 웨이브-진입 판정보다 먼저 검사 — 한 호출이 두
+#                        트리거에 동시 해당하면 source-write를 우선 보고).
+# ⚠️ `Bash`는 Codex tool_name으로 존재하지 않는다(실측 확정) — P4의 `Bash`
+# 매칭은 이 케이스에 절대 도달하지 못해 게이트가 fail-open 되는 버그였다.
 case "$TOOL" in
-  apply_patch|write_file|edit|create_file)
+  apply_patch|shell|exec_command)
     # 예외: ".agent-team/" 만 언급되면 트리거 아님(문서·산출물 쓰기는 게이트
     # 대상이 아니다) — ".agent-team/<...>" 경로 세그먼트를 원문에서 지운 뒤에도
     # SRC_ERE가 매치되면, 그 매치는 .agent-team/ 바깥의 진짜 소스 경로라는 뜻.
@@ -103,9 +128,12 @@ case "$TOOL" in
     ;;
 esac
 
+# T2(웨이브 진입 명령) — shell/exec_command만 대상(apply_patch는 명령 실행이
+# 아니므로 해당 없음). T1에서 이미 source-write로 판정됐으면 재검사하지
+# 않는다(하나의 도구 호출은 한 TRIGGER만 보고).
 if [ -z "$TRIGGER" ]; then
   case "$TOOL" in
-    Bash|bash|shell|local_shell|exec_command)
+    shell|exec_command)
       if printf '%s' "$INPUT_FLAT" | grep -Eiq "$W5_ENTRY_ERE"; then
         TRIGGER="wave-entry-command"
       fi

--- a/docs/codex-adapter-kr.md
+++ b/docs/codex-adapter-kr.md
@@ -2,7 +2,13 @@
 
 > **성격: 런타임 포팅.** Claude Code 접착층(Agent Teams·훅·커맨드)을 OpenAI Codex CLI의 확장점으로 옮긴다. `bathos` 엔진은 그대로 CLI로 호출.
 > 상위 판단·단계 계획: `docs/PORTABILITY-kr.md`. 이 문서는 Codex 매핑 상세 + 재설계 지점 + 변환 스캐폴드(`scripts/to-codex.sh`) 사용법.
-> ⚠️ Codex 훅은 실험적·Windows 미지원 가능성. 커스텀 프롬프트는 deprecated(→skills). 실사용 전 출처 재확인.
+> **P5 갱신(2026-07-16, Phillip)**: Codex CLI **v0.144.5**(macos-x86_64)를 실제
+> 설치해 훅 스키마를 실측했다. **hooks 기능 = stable(실험적 아님)·기본 활성**
+> (`codex features list`에서 `hooks  stable  true` 확인), tool_name 실측값은
+> `shell`/`exec_command`/`apply_patch`(`Bash`는 존재하지 않음), `SessionEnd`
+> 이벤트는 없음(확정)·`Stop`은 유효 이벤트임을 확인했다. 아래 §1~§3은 이
+> 실측을 반영해 갱신됐다(과거 "실험적/문서 예시 기준" 표기는 실측으로 대체).
+> 커스텀 프롬프트는 deprecated(→skills) — 이 항목은 여전히 미실측 추정.
 
 ---
 
@@ -14,7 +20,7 @@
 | `.claude/commands/<c>.md` | `~/.codex/prompts/<c>.md` (`/prompts:<c>`, `$1..$9`·`$ARGUMENTS`·front matter) | `to-codex.sh`가 기계 변환 |
 | `AGENTS.md` | 네이티브(Codex가 읽음) | 그대로 |
 | MCP 서버 | `~/.codex/config.toml` `[mcp_servers.x]` | 수동/후속 |
-| 훅(settings.json) | `~/.codex/config.toml` `[hooks]`(실험적) | §3 재설계 |
+| 훅(settings.json) | `~/.codex/config.toml` `[hooks]`(v0.144.5 실측: stable·기본 활성) | §3 재설계 |
 | 모델 ID `claude-*` | Codex `model` + `[model_providers.x]` | §4 |
 
 **중첩 규칙 부합:** Codex `agents.max_depth` 기본 1 = "루트만 서브에이전트 스폰, 팀원은 중첩 팀 금지" → BATHOS 규칙과 일치(추가 조치 불필요).
@@ -39,13 +45,30 @@ bash scripts/to-codex.sh --write --dest /경로   # 출력 위치 지정
 ### (a) `TaskCompleted` 게이트 → `PreToolUse` exit-2 게이트
 BATHOS는 W3 등 핵심 게이트를 "태스크 완료 차단"(TaskCompleted 훅)으로 하드 강제했다. Codex엔 등가 이벤트가 없다.
 - **대안:** 다음 단계 진입 트리거(예: 구현 파일 쓰기, `wave5` 커맨드 실행)를 `PreToolUse` 훅으로 가로채 `bathos gate show`가 PASS/CONCERNS 아니면 **exit 2 + stderr 사유**로 차단. Codex에서 exit 2 = `"decision":"block"`.
+- **실측 정정(P5)**: 트리거 매칭의 `tool_name`은 실제로 `shell`/`exec_command`
+  (셸 실행)/`apply_patch`(파일 편집)이며, **`Bash`는 존재하지 않는다.** P4는
+  공식 문서 예시만 보고 `Bash`를 가정했고, 이 때문에 T1/T2가 결코 발화하지
+  않아 게이트가 **fail-open**되는 버그가 있었다(2026-07-16 실측으로 확정·
+  `codex-adapter/hooks/pretooluse-gate.sh`에서 수정 완료 — 상세는
+  `codex-adapter/README.md` §정직한 한계).
 
 ### (b) `SessionEnd` 없음 → `Stop` 근사
 CLAUDE.md §9(종료 시 저장→리포트→종료 강제)는 Codex에 SessionEnd가 없어 물리적으로 동일 구현 불가.
 - **대안:** `Stop`(턴 종료) 훅에서 스냅샷/리포트를 **증분 저장**(세션 종료 ≠ 턴 종료이므로 매 턴 갱신 방식). 완전한 "종료 시 1회"는 포기하고 "자주 저장"으로 대체. `/save-session` 수동 저장 병행 권장.
+- **실측 확정(P5)**: Codex v0.144.5의 `HookEventNameWire` 상수를 직접 확인한
+  결과 유효 이벤트는 PreToolUse·PostToolUse·PermissionRequest·PreCompact·
+  PostCompact·SessionStart·SubagentStart·SubagentStop·**Stop**·
+  UserPromptSubmit이다. **`SessionEnd`는 이 목록에 없다(확정)** — 즉 위
+  "Stop 근사"는 추정이 아니라 유일하게 가능한 정답임이 실측으로 검증됐다.
 
-### (c) 훅 실험적·Windows 공백
-Codex 훅은 실험적(첫 도입 2026-03)·Windows 미지원 가능성 ⚠️. BATHOS의 Windows/WSL 지원과 충돌 시, Windows에서는 훅 없는 축소 모드(수동 게이트) 문서화 필요.
+### (c) 훅 stable·Windows 공백
+- **실측 정정(P5)**: Codex 훅은 더 이상 실험적이 아니다 — `codex features
+  list`에서 `hooks  stable  true`로 확인됨(2026-07-16, v0.144.5). 다만
+  BATHOS의 Windows/WSL 지원과의 관계는 여전히 유의할 것: hook config
+  스키마에 **`commandWindows`**(Windows 전용 명령) 필드가 실측으로 존재함을
+  확인했다 — Windows 네이티브 경로가 실제로 있다는 뜻이나, 이번 스코프에서
+  `.ps1` 포트는 하지 않았다(§5). Windows 사용자는 당분간 WSL에서 Codex
+  구동을 권장(`scripts/wsl-setup.sh`).
 
 ---
 
@@ -61,13 +84,25 @@ Codex 훅은 실험적(첫 도입 2026-03)·Windows 미지원 가능성 ⚠️. 
 - **P4: 완료(2026-07-16, Phillip)** — (a)(b) 훅 재설계가 `codex-adapter/`에
   실구현되었다: `hooks/pretooluse-gate.sh`(W3 게이트 exit-2) ·
   `hooks/stop-save.sh`(Stop 증분 저장) · `hooks/_test-codex-hooks.sh`(14케이스
-  시뮬레이션, 실 Codex 불요 — 전부 통과) · `config.toml.example`. 상세는
-  `codex-adapter/README.md`와 `.agent-team/08-impl-notes/backend.md` 참고.
-  **미해소:** 실 Codex 미설치 상태라 `tool_name` 실측값(§3-a 트리거 매칭의
-  전제)은 여전히 문서 예시(`Bash`·`apply_patch`) 기준 ⚠️[추정]이다 — 설치
-  후 최우선 재확인 필요(fail-open 리스크).
-- P5: Codex+GLM 프록시 연동, 커맨드→skills 마이그레이션(공식 방향).
-- P6: `bathos runtime` 추상화(런타임 감지→어댑터 자동 선택).
+  시뮬레이션, 실 Codex 불요 — 전부 통과) · `config.toml.example`. 당시
+  미해소: `tool_name` 실측값 미확인(문서 예시 `Bash`·`apply_patch` 기준
+  ⚠️[추정] — fail-open 리스크).
+- **P5: 완료(2026-07-16, Phillip)** — 리드가 Codex CLI **v0.144.5**
+  (macos-x86_64)를 실제로 설치해 바이너리 임베드 스키마를 실측, P4의
+  `tool_name=Bash` 가정이 실제로는 항상 미스매치라 게이트가 fail-open되는
+  버그를 확정하고 수정했다. 실측 tool_name(`shell`/`exec_command`/
+  `apply_patch`)으로 `pretooluse-gate.sh`를 하드닝, `config.toml.example`을
+  실측 스키마(`matcher`/`command`/`commandWindows`/`timeoutSec`)로 정정,
+  `_test-codex-hooks.sh`에 회귀 케이스(B-15~B-18) 4건을 추가해 18케이스·
+  37 assertion 전부 실행·통과시켰다. hooks=stable·기본 활성, `SessionEnd`
+  부재(확정), `Stop` 유효도 이번에 재확인됨. **남은 미실증**: 라이브 인증
+  세션(auth 부재로 미실행) — 스키마·계약까지만 실측했고, 실제 인증 세션에서
+  config 등록이 배선대로 동작하는지는 다음 실사용 시 확인 필요. 또한 이
+  해소는 **v0.144.5 버전 고정**이므로 업그레이드 시 재확인 필요.
+- P6: Codex+GLM 프록시 연동, 커맨드→skills 마이그레이션(공식 방향), 네이티브
+  마이그레이션(AGENTS_MD/HOOKS/COMMANDS/SUBAGENTS/MCP import)을 `to-codex.sh`
+  스캐폴드 변환의 대안으로 검토.
+- P7: `bathos runtime` 추상화(런타임 감지→어댑터 자동 선택).
 
 ## 출처
 - prompts/slash: developers.openai.com/codex/custom-prompts · /guides/slash-commands


### PR DESCRIPTION
## 요약
Codex 어댑터 **P5 실검증** — 실제 Codex CLI **v0.144.5**(macos-x86_64)를 설치해 임베드 스키마를 실측하고, 게이트 트리거를 측정값으로 고정.

## 실측 (설치 바이너리)
- `hooks` = **stable·기본 활성**(실험적 아님) · `Stop` 유효 · **`SessionEnd` 부재 확정**(stop-save 근사 정당) · `commandWindows` 존재(Windows 경로)
- 실 tool_name = **`shell`/`exec_command`/`apply_patch`** (⚠️ `Bash` 없음) · PreToolUse stdin 필드(snake_case) 확인

## 변경
- `pretooluse-gate.sh`: 트리거 매칭을 측정값만 남기고 미확인 이름(Bash/local_shell/write_file/edit/create_file) 제거
- `_test-codex-hooks.sh`: 실측값 픽스처 + 회귀 B-15~B-18 → **37/37 PASS**
- `config.toml.example`: 측정 TOML 스키마(matcher/command/commandWindows) · `docs/codex-adapter-kr.md`·README "v0.144.5 실측 기반"

## 정직 고지
기존 매처가 이미 실측값을 추측값과 함께 포함하고 있어 **literal fail-open은 재현되지 않음** — 이번 변경은 측정값-only로 좁혀 잠재 리스크를 제거·정합한 것. **미실증: 라이브 인증 세션**(자격증명 부재) — 계약·스키마까지만 실측. v0.144.5 고정(업그레이드 시 재확인).