### PR TITLE
feat(panes/model): 역할별 모델 선택 + Wave 패널 2종 + Codex 위임 러너

### DIFF
--- a/.claude/commands/wave0-analysis.md
+++ b/.claude/commands/wave0-analysis.md
@@ -10,10 +10,26 @@ model: opus
 
 ---
 
+## 모델 선택 (스폰 전 필수 — User Sovereignty)
+
+1. `./core/target/release/bathos -s $1/.agent-team/_state model detect` 실행(session_backend 기록).
+2. `bathos model show --wave W0`로 역할별 유효 runtime/model 표를 사용자에게 제시하고 묻는다:
+   "이번 웨이브 역할별 모델입니다. 변경할 역할이 있습니까? (풀: fable5·sonnet5·haiku / GLM / Codex — 기본값 유지 가능)"
+3. 변경분만 `bathos model set <slug> --runtime <r> [--model <m>]`으로 기록.
+4. `bathos model validate --wave W0` — exit 2면 스폰 금지: 출력된 해소 선택지를
+   사용자에게 제시하고 재결정 받는다(자동 우회 금지).
+5. 스폰 분기: runtime=claude → 팀원 스폰 시 resolve된 model 지정 ·
+   runtime=codex → 해당 역할은 팀원으로 스폰하지 않고 `codex-adapter/run-role.sh` 위임 ·
+   runtime=glm → validate가 PASS를 준 경우에만(=전 배치 GLM 세션) 통상 스폰.
+
 ## 수행
 
 **"Caleb"**(caleb-market-analyst, W0 Analyst 겸임) 1명 스폰(필요 시 John 보조).
 스폰 시 반드시: **"ETHOS.md를 먼저 읽고 그 원칙에 따라 작업하라"** 지시.
+
+> 🖥️ **패널 관측**: 별도 터미널에서 `bathos panes`(tmux/TUI 중 선택) — 패널 입력은
+> `_state/panes/inbox/`로 들어오며 게이트 체크포인트에서 반영된다(자동 기동 안 함 —
+> Paul은 자기 TTY를 점유 중이므로 패널은 사람의 두 번째 터미널이다).
 
 - 대상 프로젝트: $1
 - 입력: 사용자 아이디어·문제 진술 + `$1/.agent-team/00-plan/charter.md`

--- a/.claude/commands/wave1-discovery.md
+++ b/.claude/commands/wave1-discovery.md
@@ -6,8 +6,26 @@ model: opus
 ---
 당신은 총괄/리드 **Paul** 입니다. Wave 1(Discovery & 시장리서치)을 수행합니다(동시 팀원 2명).
 
+---
+
+## 모델 선택 (스폰 전 필수 — User Sovereignty)
+
+1. `./core/target/release/bathos -s $1/.agent-team/_state model detect` 실행(session_backend 기록).
+2. `bathos model show --wave W1`로 역할별 유효 runtime/model 표를 사용자에게 제시하고 묻는다:
+   "이번 웨이브 역할별 모델입니다. 변경할 역할이 있습니까? (풀: fable5·sonnet5·haiku / GLM / Codex — 기본값 유지 가능)"
+3. 변경분만 `bathos model set <slug> --runtime <r> [--model <m>]`으로 기록.
+4. `bathos model validate --wave W1` — exit 2면 스폰 금지: 출력된 해소 선택지를
+   사용자에게 제시하고 재결정 받는다(자동 우회 금지).
+5. 스폰 분기: runtime=claude → 팀원 스폰 시 resolve된 model 지정 ·
+   runtime=codex → 해당 역할은 팀원으로 스폰하지 않고 `codex-adapter/run-role.sh` 위임 ·
+   runtime=glm → validate가 PASS를 준 경우에만(=전 배치 GLM 세션) 통상 스폰.
+
 에이전트 팀을 만들고 **"John"**(john-reverse-specialist)과 **"Caleb"**(caleb-market-analyst)을 스폰하세요.
 스폰 시 반드시: **"ETHOS.md를 먼저 읽고 그 원칙에 따라 작업하라"** 지시.
+
+> 🖥️ **패널 관측**: 별도 터미널에서 `bathos panes`(tmux/TUI 중 선택) — 패널 입력은
+> `_state/panes/inbox/`로 들어오며 게이트 체크포인트에서 반영된다(자동 기동 안 함 —
+> Paul은 자기 TTY를 점유 중이므로 패널은 사람의 두 번째 터미널이다).
 
 ---
 

--- a/.claude/commands/wave2-design.md
+++ b/.claude/commands/wave2-design.md
@@ -8,9 +8,30 @@ model: opus
 
 ---
 
+## 모델 선택 (스폰 전 필수 — User Sovereignty)
+
+1. `./core/target/release/bathos -s $1/.agent-team/_state model detect` 실행(session_backend 기록).
+2. `bathos model show --wave W2`로 역할별 유효 runtime/model 표를 사용자에게 제시하고 묻는다:
+   "이번 웨이브 역할별 모델입니다. 변경할 역할이 있습니까? (풀: fable5·sonnet5·haiku / GLM / Codex — 기본값 유지 가능)"
+3. 변경분만 `bathos model set <slug> --runtime <r> [--model <m>]`으로 기록.
+4. `bathos model validate --wave W2` — exit 2면 스폰 금지: 출력된 해소 선택지를
+   사용자에게 제시하고 재결정 받는다(자동 우회 금지).
+5. 스폰 분기: runtime=claude → 팀원 스폰 시 resolve된 model 지정 ·
+   runtime=codex → 해당 역할은 팀원으로 스폰하지 않고 `codex-adapter/run-role.sh` 위임 ·
+   runtime=glm → validate가 PASS를 준 경우에만(=전 배치 GLM 세션) 통상 스폰.
+
+(1단계 Joshua, 2단계 James·Jonnathan 모두 이 판단 1회로 커버 — 스폰 단계마다 재확인하지 않는다.)
+
+---
+
 ## [1단계 — 기획 게이트] Joshua 스폰
 
 **"Joshua"**(joshua-service-planner) 1명 스폰. "ETHOS.md 먼저 읽고 작업하라" 지시.
+
+> 🖥️ **패널 관측**: 별도 터미널에서 `bathos panes`(tmux/TUI 중 선택) — 패널 입력은
+> `_state/panes/inbox/`로 들어오며 게이트 체크포인트에서 반영된다(자동 기동 안 함 —
+> Paul은 자기 TTY를 점유 중이므로 패널은 사람의 두 번째 터미널이다).
+
 - 대상: $1
 - 입력: `$1/.agent-team/02-market-analysis/`
 - 출력·소유: `$1/.agent-team/03-service-planning/**`

--- a/.claude/commands/wave3-story-gate.md
+++ b/.claude/commands/wave3-story-gate.md
@@ -10,10 +10,30 @@ model: opus
 
 ---
 
+## 모델 선택 (스폰 전 필수 — User Sovereignty)
+
+1. `./core/target/release/bathos -s $1/.agent-team/_state model detect` 실행(session_backend 기록).
+2. `bathos model show --wave W3`로 역할별 유효 runtime/model 표를 사용자에게 제시하고 묻는다:
+   "이번 웨이브 역할별 모델입니다. 변경할 역할이 있습니까? (풀: fable5·sonnet5·haiku / GLM / Codex — 기본값 유지 가능)"
+3. 변경분만 `bathos model set <slug> --runtime <r> [--model <m>]`으로 기록.
+4. `bathos model validate --wave W3` — exit 2면 스폰 금지: 출력된 해소 선택지를
+   사용자에게 제시하고 재결정 받는다(자동 우회 금지).
+5. 스폰 분기: runtime=claude → 팀원 스폰 시 resolve된 model 지정 ·
+   runtime=codex → 해당 역할은 팀원으로 스폰하지 않고 `codex-adapter/run-role.sh` 위임 ·
+   runtime=glm → validate가 PASS를 준 경우에만(=전 배치 GLM 세션) 통상 스폰.
+
+(1단계 Matthew, 2단계 Thomas·Matthias 모두 이 판단 1회로 커버.)
+
+---
+
 ## [1단계 — 스토리 응축] Matthew 스폰
 
 **"Matthew"**(matthew-story-engineer) 1명 스폰.
 반드시: **"ETHOS.md를 먼저 읽고 그 원칙에 따라 작업하라"** 지시.
+
+> 🖥️ **패널 관측**: 별도 터미널에서 `bathos panes`(tmux/TUI 중 선택) — 패널 입력은
+> `_state/panes/inbox/`로 들어오며 게이트 체크포인트에서 반영된다(자동 기동 안 함 —
+> Paul은 자기 TTY를 점유 중이므로 패널은 사람의 두 번째 터미널이다).
 
 - 대상: $1
 - 입력(읽기): `$1/.agent-team/03-service-planning/`, `04-architecture/`, `07-design/`, `project-context` 초안, git, WebSearch

--- a/.claude/commands/wave4-ip-research.md
+++ b/.claude/commands/wave4-ip-research.md
@@ -11,10 +11,26 @@ Lv2에서는 선택, Lv4에서는 필수. 현재 Lv 확인: `$1/.agent-team/_sta
 
 ---
 
+## 모델 선택 (스폰 전 필수 — User Sovereignty)
+
+1. `./core/target/release/bathos -s $1/.agent-team/_state model detect` 실행(session_backend 기록).
+2. `bathos model show --wave W4`로 역할별 유효 runtime/model 표를 사용자에게 제시하고 묻는다:
+   "이번 웨이브 역할별 모델입니다. 변경할 역할이 있습니까? (풀: fable5·sonnet5·haiku / GLM / Codex — 기본값 유지 가능)"
+3. 변경분만 `bathos model set <slug> --runtime <r> [--model <m>]`으로 기록.
+4. `bathos model validate --wave W4` — exit 2면 스폰 금지: 출력된 해소 선택지를
+   사용자에게 제시하고 재결정 받는다(자동 우회 금지).
+5. 스폰 분기: runtime=claude → 팀원 스폰 시 resolve된 model 지정 ·
+   runtime=codex → 해당 역할은 팀원으로 스폰하지 않고 `codex-adapter/run-role.sh` 위임 ·
+   runtime=glm → validate가 PASS를 준 경우에만(=전 배치 GLM 세션) 통상 스폰.
+
 ## 스폰
 
 **"Mark"**(mark-ip-specialist)·**"Nathanael"**(nathanael-research-writer) 동시 스폰(≤3 준수).
 "ETHOS.md 먼저 읽고 작업하라" 지시.
+
+> 🖥️ **패널 관측**: 별도 터미널에서 `bathos panes`(tmux/TUI 중 선택) — 패널 입력은
+> `_state/panes/inbox/`로 들어오며 게이트 체크포인트에서 반영된다(자동 기동 안 함 —
+> Paul은 자기 TTY를 점유 중이므로 패널은 사람의 두 번째 터미널이다).
 
 **Mark** (mark-ip-specialist):
 - 입력: `$1/.agent-team/04-architecture/`, `07-design/`, `03-service-planning/`

--- a/.claude/commands/wave5-implement.md
+++ b/.claude/commands/wave5-implement.md
@@ -10,11 +10,27 @@ model: sonnet
 
 ---
 
+## 모델 선택 (스폰 전 필수 — User Sovereignty)
+
+1. `./core/target/release/bathos -s $1/.agent-team/_state model detect` 실행(session_backend 기록).
+2. `bathos model show --wave W5`로 역할별 유효 runtime/model 표를 사용자에게 제시하고 묻는다:
+   "이번 웨이브 역할별 모델입니다. 변경할 역할이 있습니까? (풀: fable5·sonnet5·haiku / GLM / Codex — 기본값 유지 가능)"
+3. 변경분만 `bathos model set <slug> --runtime <r> [--model <m>]`으로 기록.
+4. `bathos model validate --wave W5` — exit 2면 스폰 금지: 출력된 해소 선택지를
+   사용자에게 제시하고 재결정 받는다(자동 우회 금지).
+5. 스폰 분기: runtime=claude → 팀원 스폰 시 resolve된 model 지정 ·
+   runtime=codex → 해당 역할은 팀원으로 스폰하지 않고 `codex-adapter/run-role.sh` 위임 ·
+   runtime=glm → validate가 PASS를 준 경우에만(=전 배치 GLM 세션) 통상 스폰.
+
 ## 스폰
 
 **"Phillip"**(phillip-backend-engineer), **"Andrew"**(andrew-frontend-engineer), **"Stephen"**(stephen-ml-engineer) 동시 스폰.
 "ETHOS.md 먼저 읽고 작업하라" 지시. 각자 소유 경로를 명시하고 `BATHOS_OWNED_PATHS` 설정.
 각 역할 base 정의의 **"코드 주석(annotation) 표준"**(GitHub Docs code-annotation best practices 적용)에 따라 주석을 작성하도록 명시 지시한다. **모든 코드 주석은 영어로 작성한다**(문서는 한국어라도 소스코드 주석은 영어).
+
+> 🖥️ **패널 관측**: 별도 터미널에서 `bathos panes`(tmux/TUI 중 선택) — 패널 입력은
+> `_state/panes/inbox/`로 들어오며 게이트 체크포인트에서 반영된다(자동 기동 안 함 —
+> Paul은 자기 TTY를 점유 중이므로 패널은 사람의 두 번째 터미널이다).
 
 입력(공통): `$1/.agent-team/04-architecture/`(build-plan, api-contracts, erd, exceptions, patterns), `$1/.agent-team/03-story-engineering/`(스토리파일·헌법)
 

--- a/.claude/commands/wave6-verify-report.md
+++ b/.claude/commands/wave6-verify-report.md
@@ -8,10 +8,30 @@ model: sonnet
 
 ---
 
+## 모델 선택 (스폰 전 필수 — User Sovereignty)
+
+1. `./core/target/release/bathos -s $1/.agent-team/_state model detect` 실행(session_backend 기록).
+2. `bathos model show --wave W6`로 역할별 유효 runtime/model 표를 사용자에게 제시하고 묻는다:
+   "이번 웨이브 역할별 모델입니다. 변경할 역할이 있습니까? (풀: fable5·sonnet5·haiku / GLM / Codex — 기본값 유지 가능)"
+3. 변경분만 `bathos model set <slug> --runtime <r> [--model <m>]`으로 기록.
+4. `bathos model validate --wave W6` — exit 2면 스폰 금지: 출력된 해소 선택지를
+   사용자에게 제시하고 재결정 받는다(자동 우회 금지).
+5. 스폰 분기: runtime=claude → 팀원 스폰 시 resolve된 model 지정 ·
+   runtime=codex → 해당 역할은 팀원으로 스폰하지 않고 `codex-adapter/run-role.sh` 위임 ·
+   runtime=glm → validate가 PASS를 준 경우에만(=전 배치 GLM 세션) 통상 스폰.
+
+(1~2단계 전 역할 — Thomas·Timothy·Matthias·Michael·Hananiah·Martin — 이 판단 1회로 커버.)
+
+---
+
 ## [1단계 — 검증·문서화] Thomas·Timothy·Matthias 스폰 (동시 ≤3)
 
 **"Thomas"**(thomas-code-reviewer), **"Timothy"**(timothy-doc-specialist), **"Matthias"**(matthias-qa-validator) 동시 스폰.
 "ETHOS.md 먼저 읽고 작업하라" 지시.
+
+> 🖥️ **패널 관측**: 별도 터미널에서 `bathos panes`(tmux/TUI 중 선택) — 패널 입력은
+> `_state/panes/inbox/`로 들어오며 게이트 체크포인트에서 반영된다(자동 기동 안 함 —
+> Paul은 자기 TTY를 점유 중이므로 패널은 사람의 두 번째 터미널이다).
 
 **Thomas** (thomas-code-reviewer):
 - 입력: 실제 소스 + `$1/.agent-team/04-architecture/` + `$1/.agent-team/08-impl-notes/`

--- a/codex-adapter/README.md
+++ b/codex-adapter/README.md
@@ -23,8 +23,39 @@ codex-adapter/
 │   ├── pretooluse-gate.sh       # W3 Implementation 게이트: FAIL이면 구현 진입 exit 2 차단
 │   ├── stop-save.sh             # SessionEnd 근사: 턴마다 증분 저장(state show 덤프)
 │   └── _test-codex-hooks.sh     # 시뮬레이션 테스트(실제 Codex 설치 불요, 18케이스: 게이트 B-1~B-10·B-15~B-18 + 저장 B-11~B-14, 37 assertion)
+├── run-role.sh                  # runtime=codex 역할 위임 러너(ADR-D-0006, §A3.3) — Claude Code 팀원이 아닌 별도 프로세스로 역할 실행
+├── _test-run-role.sh            # run-role.sh 스모크 테스트(T8, 10케이스·24 assertion, 스텁 codex로 실제 설치 불요)
 └── config.toml.example          # ~/.codex/config.toml 등록 예시(실측 스키마)
 ```
+
+### `run-role.sh` — Codex 런타임 위임 러너
+
+`_state/model-plan.json`에서 `runtime=codex`로 배정된 역할은 Claude Code 팀원으로
+스폰되지 않는다(GLM과 달리 별도 프로세스라 in-process 팀원과 병행 무충돌 —
+ADR-D-0006). 웨이브 커맨드가 대신 이 스크립트로 위임한다:
+
+```bash
+codex-adapter/run-role.sh <role-slug> <task-file.md> [--project <절대경로>] [--dry-run]
+```
+
+- **exit 0**=완료 / **1**=실행 실패(`.codex/agents/<slug>.toml` 부재 포함) /
+  **3**=`E-CODEX-ABSENT`(codex CLI 미설치) / **4**=`E-CODEX-AUTH`(미인증 — 선제
+  `codex login status` 검사 또는 `codex exec` 실행 결과 양쪽에서 판정 가능).
+- 프롬프트 = 역할 base md 본문(`.claude/agents/_base/<n>-<slug>.md`, `slug:`
+  프론트매터로 탐색) + `ETHOS.md` 전문 + 웨이브 커맨드가 작성한 task-file. 조립된
+  프롬프트를 `codex exec "<프롬프트>"`로 비대화 실행한다(⚠️[추정] — 라이브 인증
+  세션 미실측, §정직한 한계 참고). `bathos model resolve <slug> --json`이
+  `model`/`reasoning_effort` 오버라이드를 찾으면 `-c` 플래그로 전달한다.
+- `.codex/agents/<slug>.toml`이 프로젝트 로컬(`<project>/.codex/agents/`) 또는
+  `~/.codex/agents/`에 없으면 **자동 생성하지 않고** `scripts/to-codex.sh --write`
+  안내 후 exit 1로 끝난다(홈 디렉터리 쓰기는 사용자 승인 사안).
+- 완료/실패는 항상 `_state/panes/inbox/codex-<slug>-<ts>-<pid>.txt`에
+  `<DONE|FAIL|DRY-RUN><TAB><요약 1줄>`로 기록된다(bathos-tui `inbox.rs`와 동일
+  ts-pid·atomic tmp→mv 관례) — Codex는 Agent Teams 메시징/훅 밖이므로 이 파일이
+  Paul/패널이 진행을 감지하는 유일한 경로다(경계 명시, §A3.3).
+- 테스트: `bash codex-adapter/_test-run-role.sh` — 스텁 `codex` 바이너리로
+  10가지 분기(부재/TOML부재/인증실패 선제·사후/dry-run/정상실행/일반오류/
+  잘못된 slug/task-file 부재)를 24개 assertion으로 검증한다.
 
 ## 설치
 

--- a/codex-adapter/_test-run-role.sh
+++ b/codex-adapter/_test-run-role.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# =============================================================================
+# BATHOS  codex-adapter/_test-run-role.sh  —  run-role.sh 스모크 테스트 (T8)
+#
+# 실제 Codex CLI 설치·라이브 인증 세션 없이 `run-role.sh`(§A3.3)의 계약만
+# 검증한다: 스텁 `codex`(login status/exec를 흉내내는 가짜 바이너리)와 최소
+# 픽스처 프로젝트(.claude/agents/_base/*.md, ETHOS.md, .codex/agents/*.toml)를
+# 만들어 각 exit code 분기가 설계대로 발화하는지 단정한다.
+#
+# 자리매김: codex-adapter/hooks/_test-codex-hooks.sh와 동일 스타일(카운터+함수,
+# bash 3.2 호환, 연관배열 금지). run-role.sh는 hooks/ 밖(codex-adapter/ 최상위)
+# 이므로 테스트도 같은 위치에 둔다.
+#
+# 검증 매트릭스(design §B5 T8 + 보일더오션 확장):
+#   T8a codex 미설치(PATH 조작)                → exit 3 E-CODEX-ABSENT
+#   T8b codex 있음 + .toml 부재                 → exit 1 (안내 메시지 포함, 자동생성 안 함)
+#   T8c codex login status가 "미인증" 패턴      → exit 4 E-CODEX-AUTH (선제 차단)
+#   T8d login status 서브커맨드 자체가 실패     → 비차단(경고만) + 계속 진행
+#   T8e 정상 픽스처 + --dry-run                 → exit 0, 프롬프트 보존, inbox DRY-RUN
+#   T8f 정상 픽스처 + 실행(exec 성공 스텁)      → exit 0, inbox DONE
+#   T8g codex exec가 인증 실패로 종료           → exit 4 E-CODEX-AUTH(사후 판정)
+#   T8h codex exec가 일반 오류로 종료           → exit 1, inbox FAIL
+#   T8i role-slug 형식 불량                      → exit 1 E-CODEX-ROLE-INVALID
+#   T8j task-file 부재                           → exit 1
+#
+# 실행: bash codex-adapter/_test-run-role.sh
+# =============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_ROLE="$SCRIPT_DIR/run-role.sh"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+PASS_COUNT=0
+FAIL_COUNT=0
+
+ok()  { printf "${GREEN}[PASS]${NC} %s\n" "$*"; PASS_COUNT=$((PASS_COUNT+1)); }
+bad() { printf "${RED}[FAIL]${NC} %s\n" "$*" >&2; FAIL_COUNT=$((FAIL_COUNT+1)); }
+
+assert_exit() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    ok "$desc (exit=$actual)"
+  else
+    bad "$desc — 예상 exit=$expected, 실제 exit=$actual"
+  fi
+}
+
+assert_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    ok "$desc"
+  else
+    bad "$desc — '$needle' 를 출력에서 찾지 못함: $haystack"
+  fi
+}
+
+WORK="$(mktemp -d 2>/dev/null || mktemp -d -t bathosrunrole)"
+cleanup() { rm -rf "$WORK" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+# --------------------------------------------------------------------------
+# 픽스처 프로젝트 — 최소한의 agent base md + ETHOS + task-file
+# --------------------------------------------------------------------------
+PROJ="$WORK/fixture-project"
+mkdir -p "$PROJ/.claude/agents/_base" "$PROJ/.codex/agents"
+cat > "$PROJ/ETHOS.md" <<'EOF'
+# 빌더 ETHOS (테스트 픽스처 요약본)
+User Sovereignty / Boil the Ocean / Search Before Building.
+EOF
+cat > "$PROJ/.claude/agents/_base/08-test-role.md" <<'EOF'
+---
+role_number: 8
+name: test-role
+slug: test-role
+model: claude-sonnet-5
+spawnable: true
+---
+
+# Test Role [base]
+
+이것은 run-role.sh 테스트용 최소 역할 지침이다.
+EOF
+TASK_FILE="$WORK/task-brief.md"
+cat > "$TASK_FILE" <<'EOF'
+# 테스트 태스크 브리프
+입력 경로: (없음) / 소유 경로: (없음) / DoD: 아무 것도 안 해도 통과.
+EOF
+
+TOML_PATH="$PROJ/.codex/agents/test-role.toml"
+
+# --------------------------------------------------------------------------
+# 스텁 codex 생성 헬퍼 — $1=STUB_DIR $2=login_mode(ok|authfail|unsupported)
+#                        $3=exec_mode(ok|authfail|generic-fail)
+# --------------------------------------------------------------------------
+make_stub_codex() {
+  local stub_dir="$1" login_mode="$2" exec_mode="$3"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/codex" <<STUB_EOF
+#!/usr/bin/env bash
+if [ "\$1" = "login" ] && [ "\$2" = "status" ]; then
+  case "$login_mode" in
+    ok) echo "Logged in as test@example.com"; exit 0 ;;
+    authfail) echo "Error: not logged in. Run 'codex login' first."; exit 1 ;;
+    unsupported) echo "error: unrecognized subcommand 'login'"; exit 2 ;;
+  esac
+fi
+if [ "\$1" = "exec" ]; then
+  case "$exec_mode" in
+    ok) echo "codex exec stub: 완료"; exit 0 ;;
+    authfail) echo "Error: unauthorized — please login again."; exit 1 ;;
+    generic-fail) echo "Error: something went wrong (stub)"; exit 7 ;;
+  esac
+fi
+echo "unhandled stub invocation: \$*" >&2
+exit 9
+STUB_EOF
+  chmod +x "$stub_dir/codex"
+}
+
+# --------------------------------------------------------------------------
+# T8a: codex 미설치(PATH 조작) → exit 3 E-CODEX-ABSENT
+# --------------------------------------------------------------------------
+printf '\n== T8a: codex 부재 → exit 3 ==\n'
+OUT="$(env -i PATH="/usr/bin:/bin" HOME="$WORK" "$RUN_ROLE" test-role "$TASK_FILE" --project "$PROJ" 2>&1)"; RC=$?
+assert_exit "codex 미설치 시 exit 3" 3 "$RC"
+assert_contains "E-CODEX-ABSENT 메시지 출력" "$OUT" "E-CODEX-ABSENT"
+INBOX="$PROJ/.agent-team/_state/panes/inbox"
+if ls "$INBOX"/codex-test-role-*.txt >/dev/null 2>&1; then
+  ok "T8a inbox FAIL 마커 생성됨"
+  rm -f "$INBOX"/codex-test-role-*.txt
+else
+  bad "T8a inbox 마커 미생성"
+fi
+
+# --------------------------------------------------------------------------
+# T8b: codex 있음(login ok) + .toml 부재 → exit 1
+# --------------------------------------------------------------------------
+printf '\n== T8b: codex 있음 + .toml 부재 → exit 1 ==\n'
+STUB1="$WORK/stub1"
+make_stub_codex "$STUB1" ok ok
+OUT="$(env -i PATH="$STUB1:/usr/bin:/bin" HOME="$WORK" "$RUN_ROLE" test-role "$TASK_FILE" --project "$PROJ" 2>&1)"; RC=$?
+assert_exit "TOML 부재 시 exit 1" 1 "$RC"
+assert_contains "E-CODEX-TOML-ABSENT 메시지 출력" "$OUT" "E-CODEX-TOML-ABSENT"
+assert_contains "to-codex.sh 안내(자동실행 아님) 포함" "$OUT" "to-codex.sh"
+rm -f "$INBOX"/codex-test-role-*.txt 2>/dev/null || true
+
+# 이제부터의 테스트를 위해 .toml을 마련한다(정상 케이스 검증에 필요).
+cat > "$TOML_PATH" <<'EOF'
+name = "test-role"
+description = "test"
+developer_instructions = """
+test
+"""
+EOF
+
+# --------------------------------------------------------------------------
+# T8c: login status가 명백한 미인증 패턴 → exit 4 (선제 차단, exec 호출 전)
+# --------------------------------------------------------------------------
+printf '\n== T8c: login status 미인증 패턴 → exit 4 ==\n'
+STUB2="$WORK/stub2"
+make_stub_codex "$STUB2" authfail ok
+OUT="$(env -i PATH="$STUB2:/usr/bin:/bin" HOME="$WORK" "$RUN_ROLE" test-role "$TASK_FILE" --project "$PROJ" 2>&1)"; RC=$?
+assert_exit "미인증 패턴 시 exit 4" 4 "$RC"
+assert_contains "E-CODEX-AUTH 메시지 출력" "$OUT" "E-CODEX-AUTH"
+rm -f "$INBOX"/codex-test-role-*.txt 2>/dev/null || true
+
+# --------------------------------------------------------------------------
+# T8d: login status 서브커맨드 자체가 미지원 → 비차단, dry-run으로 계속 진행
+# --------------------------------------------------------------------------
+printf '\n== T8d: login status 미지원(unsupported) → 비차단, 계속 진행(--dry-run) ==\n'
+STUB3="$WORK/stub3"
+make_stub_codex "$STUB3" unsupported ok
+OUT="$(env -i PATH="$STUB3:/usr/bin:/bin" HOME="$WORK" "$RUN_ROLE" test-role "$TASK_FILE" --project "$PROJ" --dry-run 2>&1)"; RC=$?
+assert_exit "login status 미지원 시에도 dry-run은 exit 0" 0 "$RC"
+assert_contains "login status 확인 불가 경고 출력(비차단)" "$OUT" "확인 불가"
+rm -f "$INBOX"/codex-test-role-*.txt 2>/dev/null || true
+
+# --------------------------------------------------------------------------
+# T8e: 정상 픽스처 + --dry-run → exit 0, 프롬프트 보존, inbox DRY-RUN
+# --------------------------------------------------------------------------
+printf '\n== T8e: 정상 + --dry-run → exit 0 ==\n'
+STUB4="$WORK/stub4"
+make_stub_codex "$STUB4" ok ok
+OUT="$(env -i PATH="$STUB4:/usr/bin:/bin" HOME="$WORK" "$RUN_ROLE" test-role "$TASK_FILE" --project "$PROJ" --dry-run 2>&1)"; RC=$?
+assert_exit "정상 dry-run exit 0" 0 "$RC"
+assert_contains "dry-run 안내 출력" "$OUT" "dry-run"
+KEPT="$(printf '%s' "$OUT" | grep -o '/[^ ]*\.kept' | head -1)"
+if [ -n "$KEPT" ] && [ -f "$KEPT" ]; then
+  ok "보존된 프롬프트 파일 실존: $(basename "$KEPT")"
+  if grep -q "Test Role" "$KEPT" && grep -q "User Sovereignty" "$KEPT" && grep -q "테스트 태스크 브리프" "$KEPT"; then
+    ok "프롬프트에 역할 지침+ETHOS+task-file 3요소 모두 포함"
+  else
+    bad "프롬프트 3요소 조합 불완전"
+  fi
+  rm -f "$KEPT" 2>/dev/null || true
+else
+  bad "보존된 프롬프트 파일을 출력에서 찾지 못함"
+fi
+if ls "$INBOX"/codex-test-role-*.txt >/dev/null 2>&1; then
+  MARKER_CONTENT="$(cat "$INBOX"/codex-test-role-*.txt | head -1)"
+  assert_contains "inbox 마커 상태=DRY-RUN" "$MARKER_CONTENT" "DRY-RUN"
+  rm -f "$INBOX"/codex-test-role-*.txt
+else
+  bad "T8e inbox 마커 미생성"
+fi
+
+# --------------------------------------------------------------------------
+# T8f: 정상 픽스처 + 실제 실행(exec 성공 스텁) → exit 0, inbox DONE
+# --------------------------------------------------------------------------
+printf '\n== T8f: 정상 + exec 성공 스텁 → exit 0 ==\n'
+OUT="$(env -i PATH="$STUB4:/usr/bin:/bin" HOME="$WORK" "$RUN_ROLE" test-role "$TASK_FILE" --project "$PROJ" 2>&1)"; RC=$?
+assert_exit "정상 실행 exit 0" 0 "$RC"
+if ls "$INBOX"/codex-test-role-*.txt >/dev/null 2>&1; then
+  MARKER_CONTENT="$(cat "$INBOX"/codex-test-role-*.txt | head -1)"
+  assert_contains "inbox 마커 상태=DONE" "$MARKER_CONTENT" "DONE"
+  rm -f "$INBOX"/codex-test-role-*.txt
+else
+  bad "T8f inbox 마커 미생성"
+fi
+
+# --------------------------------------------------------------------------
+# T8g: codex exec가 인증 실패로 종료 → exit 4 (사후 판정)
+# --------------------------------------------------------------------------
+printf '\n== T8g: exec 인증 실패 → exit 4(사후 판정) ==\n'
+STUB5="$WORK/stub5"
+make_stub_codex "$STUB5" ok authfail
+OUT="$(env -i PATH="$STUB5:/usr/bin:/bin" HOME="$WORK" "$RUN_ROLE" test-role "$TASK_FILE" --project "$PROJ" 2>&1)"; RC=$?
+assert_exit "exec 인증 실패 시 exit 4" 4 "$RC"
+assert_contains "E-CODEX-AUTH(사후) 메시지 출력" "$OUT" "E-CODEX-AUTH"
+rm -f "$INBOX"/codex-test-role-*.txt 2>/dev/null || true
+
+# --------------------------------------------------------------------------
+# T8h: codex exec가 일반 오류로 종료 → exit 1
+# --------------------------------------------------------------------------
+printf '\n== T8h: exec 일반 오류 → exit 1 ==\n'
+STUB6="$WORK/stub6"
+make_stub_codex "$STUB6" ok generic-fail
+OUT="$(env -i PATH="$STUB6:/usr/bin:/bin" HOME="$WORK" "$RUN_ROLE" test-role "$TASK_FILE" --project "$PROJ" 2>&1)"; RC=$?
+assert_exit "exec 일반 오류 시 exit 1" 1 "$RC"
+if ls "$INBOX"/codex-test-role-*.txt >/dev/null 2>&1; then
+  MARKER_CONTENT="$(cat "$INBOX"/codex-test-role-*.txt | head -1)"
+  assert_contains "inbox 마커 상태=FAIL" "$MARKER_CONTENT" "FAIL"
+  rm -f "$INBOX"/codex-test-role-*.txt
+else
+  bad "T8h inbox 마커 미생성"
+fi
+
+# --------------------------------------------------------------------------
+# T8i: role-slug 형식 불량 → exit 1
+# --------------------------------------------------------------------------
+printf '\n== T8i: role-slug 형식 불량 → exit 1 ==\n'
+OUT="$(env -i PATH="$STUB4:/usr/bin:/bin" HOME="$WORK" "$RUN_ROLE" "bad slug!" "$TASK_FILE" --project "$PROJ" 2>&1)"; RC=$?
+assert_exit "bad slug 형식 시 exit 1" 1 "$RC"
+assert_contains "E-CODEX-ROLE-INVALID 메시지 출력" "$OUT" "E-CODEX-ROLE-INVALID"
+
+# --------------------------------------------------------------------------
+# T8j: task-file 부재 → exit 1
+# --------------------------------------------------------------------------
+printf '\n== T8j: task-file 부재 → exit 1 ==\n'
+OUT="$(env -i PATH="$STUB4:/usr/bin:/bin" HOME="$WORK" "$RUN_ROLE" test-role "$WORK/no-such-task.md" --project "$PROJ" 2>&1)"; RC=$?
+assert_exit "task-file 부재 시 exit 1" 1 "$RC"
+
+printf '\n=========================================\n'
+printf '결과: PASS=%d FAIL=%d\n' "$PASS_COUNT" "$FAIL_COUNT"
+if [ "$FAIL_COUNT" -eq 0 ]; then
+  printf '전체 통과\n'
+  exit 0
+else
+  printf '실패 항목 있음\n' >&2
+  exit 1
+fi

--- a/codex-adapter/run-role.sh
+++ b/codex-adapter/run-role.sh
@@ -1,0 +1,374 @@
+#!/usr/bin/env bash
+# =============================================================================
+# BATHOS  codex-adapter/run-role.sh  —  Codex 런타임 위임 러너 (ADR-D-0006, §A3.3)
+#
+# 사용:
+#   run-role.sh <role-slug> <task-file.md> [--project <절대경로>] [--dry-run]
+#
+# exit 0=완료 / 1=실행 실패 / 3=E-CODEX-ABSENT(codex 미설치) / 4=E-CODEX-AUTH(미인증)
+#
+# 무엇을 하는가: `runtime=codex`로 배정된 역할은 Claude Code 팀원이 아니다(별도
+# 프로세스) — 웨이브 커맨드가 이 스크립트로 위임한다. 역할 base md 본문 +
+# ETHOS 요지 + 웨이브 커맨드가 작성한 task-file(입력 경로·소유 경로·DoD)을 하나의
+# 프롬프트로 조립해 `codex exec`에 비대화로 넘기고, 완료/실패를
+# `_state/panes/inbox/codex-<slug>-<ts>.txt`에 기록한다(Paul/패널이 폴링 감지).
+#
+# 정직한 한계(⚠️[추정] — 설계 §A3.3/R-2와 동일 공백): `codex exec`의 비대화 계약과
+# `codex login status`의 서브커맨드 명·출력 형식은 이 저장소에서 라이브 인증
+# 세션으로 실측되지 않았다. 따라서 인증 프리플라이트는 **차단적이지 않다** —
+# 상태 확인이 모호하거나(서브커맨드 자체 오류) 실패해도 예단하여 막지 않고
+# 실제 실행을 시도한 뒤, 그 결과(exit code·출력)에서 인증 실패 신호를 찾아야만
+# E-CODEX-AUTH로 분류한다(과차단보다 오진단이 더 나쁘다 — 날조 금지 원칙).
+#
+# 이식성: bash 3.2(macOS 기본) 호환 — mapfile/연관배열(`declare -A`)/`${var,,}`/`&>`
+# 금지. jq 금지 — `bathos model resolve --json`은 단일행 JSON이라 grep/sed로 충분.
+# =============================================================================
+set -uo pipefail
+
+PROG="run-role.sh"
+
+say()  { printf '[%s] %s\n' "$PROG" "$*"; }
+warn() { printf '[%s] ⚠ %s\n' "$PROG" "$*" >&2; }
+err()  { printf '[%s] ✗ %s\n' "$PROG" "$*" >&2; }
+
+usage() {
+  cat <<'EOF'
+사용: run-role.sh <role-slug> <task-file.md> [--project <절대경로>] [--dry-run]
+
+  role-slug     agent 정의 slug (예: thomas-code-reviewer) — .claude/agents/_base/*.md
+                프론트매터의 `slug:` 값과 일치해야 한다.
+  task-file.md  웨이브 커맨드가 작성한 태스크 브리프(입력 경로·소유 경로·DoD).
+
+옵션:
+  --project <DIR>   대상 프로젝트 절대경로(기본: 이 스크립트의 상위 디렉터리)
+  --dry-run         codex exec를 실제로 실행하지 않고 프리플라이트+프롬프트 조립까지만
+                     수행한다(조립된 프롬프트 경로를 stdout에 출력, exit 0).
+
+exit 0=완료 / 1=실행 실패(TOML 부재 포함) / 3=E-CODEX-ABSENT(codex 미설치) /
+     4=E-CODEX-AUTH(미인증, 실행 결과에서 인증 실패 신호 확인된 경우만)
+EOF
+}
+
+# --------------------------------------------------------------------------
+# 1. 인자 파싱
+# --------------------------------------------------------------------------
+ROLE_SLUG=""
+TASK_FILE=""
+PROJECT_DIR=""
+DRY_RUN=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project)
+      shift
+      PROJECT_DIR="${1:-}"
+      ;;
+    --dry-run) DRY_RUN=1 ;;
+    -h|--help) usage; exit 0 ;;
+    --)
+      shift
+      while [ $# -gt 0 ]; do
+        if [ -z "$ROLE_SLUG" ]; then ROLE_SLUG="$1"
+        elif [ -z "$TASK_FILE" ]; then TASK_FILE="$1"
+        fi
+        shift
+      done
+      ;;
+    -*)
+      err "알 수 없는 옵션: $1"
+      usage >&2
+      exit 1
+      ;;
+    *)
+      if [ -z "$ROLE_SLUG" ]; then
+        ROLE_SLUG="$1"
+      elif [ -z "$TASK_FILE" ]; then
+        TASK_FILE="$1"
+      else
+        err "과다 인자: $1"
+        exit 1
+      fi
+      ;;
+  esac
+  shift
+done
+
+if [ -z "$ROLE_SLUG" ] || [ -z "$TASK_FILE" ]; then
+  usage >&2
+  exit 1
+fi
+
+# slug 형식 검증 — bathos-state의 Runtime::parse와 동일 관례(영문 소문자/숫자/-/_만).
+# 형식이 나쁘면 이후 파일 경로 조합(agent md 탐색·inbox 파일명)에 안전하지 않을 수
+# 있으므로 여기서 조기에 거부한다(model_plan.rs E-MODEL-ROLE-UNKNOWN과 대칭).
+case "$ROLE_SLUG" in
+  *[!a-zA-Z0-9_-]*)
+    err "[E-CODEX-ROLE-INVALID] role-slug 형식 불량: $ROLE_SLUG (영문/숫자/-/_ 만 허용)"
+    exit 1
+    ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_PROJECT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROJECT_DIR="${PROJECT_DIR:-$DEFAULT_PROJECT}"
+
+if [ ! -d "$PROJECT_DIR" ]; then
+  err "--project 경로 없음: $PROJECT_DIR"
+  exit 1
+fi
+# 심볼릭 링크·상대 표기가 뒤섞이지 않도록 정규화(inbox 경로 조합 전 1회만).
+PROJECT_DIR="$(cd "$PROJECT_DIR" && pwd)"
+
+if [ ! -f "$TASK_FILE" ] || [ ! -r "$TASK_FILE" ]; then
+  err "task-file 읽기 불가: $TASK_FILE"
+  exit 1
+fi
+
+STATE_DIR="$PROJECT_DIR/.agent-team/_state"
+INBOX_DIR="$STATE_DIR/panes/inbox"
+AGENTS_DIR="$PROJECT_DIR/.claude/agents/_base"
+ETHOS_FILE="$PROJECT_DIR/ETHOS.md"
+
+# --------------------------------------------------------------------------
+# 2. inbox 완료 마커 헬퍼 (§A3.3 step5 — bathos-tui inbox.rs와 동일 ts-pid·
+#    atomic tmp→mv 관례. 이 함수는 실행 경로의 모든 종료 지점(성공/실패 모두)
+#    에서 호출되어야 "장시간 무소식"과 "확인된 실패"를 패널이 구분할 수 있다.)
+# --------------------------------------------------------------------------
+write_inbox_marker() {
+  local status="$1" summary="$2"
+  mkdir -p "$INBOX_DIR" 2>/dev/null || { warn "inbox 디렉터리 생성 실패: $INBOX_DIR"; return 0; }
+  local ts
+  ts="$(date +%s)-$$"
+  local f="$INBOX_DIR/codex-$ROLE_SLUG-$ts.txt"
+  # 첫 줄 요약만 취한다(파일 프로토콜은 1줄 — 스크립트 소비 계약, §0.1).
+  local one_line
+  one_line="$(printf '%s' "$summary" | tr '\n' ' ' | head -c 500)"
+  printf '%s\t%s\n' "$status" "$one_line" > "$f.tmp" || return 0
+  # PANES-004: restrict to owner-only before the rename — this file previously inherited the
+  # process umask (typically 0644/world-readable); it can carry a codex exec failure summary
+  # that a reviewer may not intend other local accounts on a shared host to read.
+  chmod 600 "$f.tmp" 2>/dev/null || true
+  mv "$f.tmp" "$f"
+  say "완료 마커 기록됨: $(basename "$f")"
+}
+
+# --------------------------------------------------------------------------
+# 3. 프리플라이트 — codex CLI 존재 (E-CODEX-ABSENT)
+# --------------------------------------------------------------------------
+CODEX_BIN="${CODEX_BIN:-}"
+if [ -z "$CODEX_BIN" ] && command -v codex >/dev/null 2>&1; then
+  CODEX_BIN="$(command -v codex)"
+fi
+
+if [ -z "$CODEX_BIN" ]; then
+  cat >&2 <<EOF
+[$PROG] [E-CODEX-ABSENT] codex CLI를 찾을 수 없습니다(PATH에 'codex' 없음).
+설치 후 재시도하세요: https://developers.openai.com/codex (Codex CLI)
+또는 이 역할을 runtime=claude로 재배정하세요(bathos model set $ROLE_SLUG --runtime claude).
+EOF
+  write_inbox_marker "FAIL" "codex CLI 미설치(E-CODEX-ABSENT)"
+  exit 3
+fi
+
+# --------------------------------------------------------------------------
+# 4. 프리플라이트 — 인증 상태 (best-effort, 비차단 — 위 헤더 주석의 "정직한 한계" 참고)
+# --------------------------------------------------------------------------
+# `codex login status`의 정확한 서브커맨드 명·정상/비정상 출력 형태는 라이브
+# 인증 세션으로 미실측이다(⚠️[추정]). 그래서 이 단계는 "명백히 미인증"이라고
+# 읽히는 출력(패턴 매치)일 때만 선제 차단하고, 그 외(서브커맨드 자체가 없거나
+# 애매한 실패)는 경고만 남기고 실제 실행으로 넘어간다 — 실행 결과에서 인증
+# 실패가 다시 나타나면 §5에서 최종적으로 E-CODEX-AUTH로 분류한다.
+AUTH_HINT=""
+if AUTH_OUT="$("$CODEX_BIN" login status 2>&1)"; then
+  : # 정상 — 통과
+else
+  AUTH_HINT="$AUTH_OUT"
+  if printf '%s' "$AUTH_OUT" | grep -Eiq 'not[ _-]?logged[ _-]?in|unauthenticated|no.*credentials|please.*login|please.*auth'; then
+    cat >&2 <<EOF
+[$PROG] [E-CODEX-AUTH] codex 미인증 상태로 보입니다(codex login status):
+$AUTH_OUT
+'codex login'으로 인증한 뒤 재시도하세요.
+EOF
+    write_inbox_marker "FAIL" "codex 미인증(E-CODEX-AUTH): $(printf '%s' "$AUTH_OUT" | head -1)"
+    exit 4
+  fi
+  warn "codex login status 확인 불가(서브커맨드 미지원 가능) — 본실행으로 진행: $AUTH_OUT"
+fi
+
+# --------------------------------------------------------------------------
+# 5. 역할 정의 확보 — .codex/agents/<slug>.toml (프로젝트 로컬 우선, 자동 생성 안 함)
+# --------------------------------------------------------------------------
+# 탐색 순서: 프로젝트 로컬(`docs/codex-adapter-kr.md` §2 관례) → 사용자 홈(옵션 --dest
+# 로 ~/.codex를 택한 경우). 둘 다 없으면 exit 1 — `to-codex.sh --write`는 홈
+# 디렉터리에도 쓸 수 있는 도구라 **자동 실행하지 않는다**(사용자 승인 사안, §A3.3 step2).
+TOML_PATH=""
+for cand in \
+  "$PROJECT_DIR/.codex/agents/$ROLE_SLUG.toml" \
+  "$HOME/.codex/agents/$ROLE_SLUG.toml"
+do
+  if [ -f "$cand" ]; then
+    TOML_PATH="$cand"
+    break
+  fi
+done
+
+if [ -z "$TOML_PATH" ]; then
+  cat >&2 <<EOF
+[$PROG] [E-CODEX-TOML-ABSENT] '$ROLE_SLUG'의 Codex 에이전트 정의(.toml)를 찾을 수
+없습니다. 확인한 경로:
+  - $PROJECT_DIR/.codex/agents/$ROLE_SLUG.toml
+  - $HOME/.codex/agents/$ROLE_SLUG.toml
+생성 안내(자동 실행하지 않음 — 검토 후 직접 실행하세요):
+  bash "$PROJECT_DIR/scripts/to-codex.sh" --write --dest "$PROJECT_DIR/.codex"
+위 명령은 .claude/agents/_base/*.md 전체를 .codex/agents/*.toml로 변환합니다
+(model 필드는 TODO로 비워지므로 실행 전 직접 채워 넣어야 합니다 — docs/codex-adapter-kr.md §2).
+EOF
+  write_inbox_marker "FAIL" "codex 역할 정의(.toml) 부재: $ROLE_SLUG"
+  exit 1
+fi
+say "역할 정의 확보: $TOML_PATH"
+
+# --------------------------------------------------------------------------
+# 6. 역할 base md 확보 (프롬프트 조립 원본 — to-codex.sh의 slug 탐색과 동일 관례)
+# --------------------------------------------------------------------------
+find_agent_base_md() {
+  local slug="$1" f
+  [ -d "$AGENTS_DIR" ] || return 1
+  for f in "$AGENTS_DIR"/*.md; do
+    [ -e "$f" ] || continue
+    if grep -Eq "^slug:[[:space:]]*$slug([[:space:]]|#|\$)" "$f"; then
+      printf '%s' "$f"
+      return 0
+    fi
+  done
+  return 1
+}
+
+AGENT_MD="$(find_agent_base_md "$ROLE_SLUG" || true)"
+if [ -z "$AGENT_MD" ]; then
+  err "[E-CODEX-ROLE-INVALID] '$ROLE_SLUG' 프론트매터를 가진 agent 정의를 $AGENTS_DIR 에서 찾지 못했습니다."
+  write_inbox_marker "FAIL" "agent base md 부재: $ROLE_SLUG"
+  exit 1
+fi
+say "역할 base md: $AGENT_MD"
+
+# 프론트매터(--- ... ---) 다음 본문만 취한다(to-codex.sh body_after_fm과 동일 규칙).
+body_after_fm() { awk 'p{print} /^---[[:space:]]*$/{c++; if(c==2)p=1}' "$1"; }
+
+# --------------------------------------------------------------------------
+# 7. 프롬프트 조립 — 역할 본문 + ETHOS 요지 + task-file (§A3.3 step3)
+# --------------------------------------------------------------------------
+PROMPT_FILE="$(mktemp "${TMPDIR:-/tmp}/bathos-codex-prompt.XXXXXX" 2>/dev/null || mktemp -t bathos-codex-prompt)"
+cleanup_prompt() { rm -f "$PROMPT_FILE" 2>/dev/null || true; }
+trap cleanup_prompt EXIT
+
+{
+  printf '# BATHOS Codex 위임 프롬프트 — role=%s\n\n' "$ROLE_SLUG"
+  printf '## 역할 지침 (%s)\n\n' "$(basename "$AGENT_MD")"
+  body_after_fm "$AGENT_MD"
+  printf '\n\n## ETHOS (모든 역할의 작업 전제 — User Sovereignty·Boil the Ocean·Search Before Building)\n\n'
+  if [ -f "$ETHOS_FILE" ]; then
+    cat "$ETHOS_FILE"
+  else
+    printf '(ETHOS.md를 찾을 수 없음 — %s 확인 필요)\n' "$ETHOS_FILE"
+  fi
+  printf '\n\n## 이번 태스크 브리프 (%s)\n\n' "$(basename "$TASK_FILE")"
+  cat "$TASK_FILE"
+  printf '\n\n## 완료 계약\n\n'
+  printf -- '- 산출물은 이 태스크 브리프에 명시된 소유 경로 파일로만 남긴다(디스크 SSOT).\n'
+  printf -- '- 이 실행의 완료/실패는 run-role.sh가 `_state/panes/inbox/codex-%s-<ts>.txt`에\n' "$ROLE_SLUG"
+  printf -- '  자동 기록한다(별도 self-report 불필요).\n'
+} > "$PROMPT_FILE"
+
+say "프롬프트 조립 완료: $PROMPT_FILE ($(wc -l < "$PROMPT_FILE" | tr -d ' ') 줄)"
+
+if [ "$DRY_RUN" = "1" ]; then
+  say "--dry-run: codex exec를 실행하지 않습니다. 조립된 프롬프트를 유지합니다."
+  # PANES-005 fix: the debug copy used to live forever under ${TMPDIR:-/tmp} (no owner, no TTL,
+  # no cleanup policy — only the *original* $PROMPT_FILE was covered by the EXIT trap above).
+  # Relocate it into this project's own `_state/panes/processed/` — a directory this design
+  # already gives a lifecycle to (Paul moves consumed inbox items there) — instead of the
+  # shared OS temp root. The filename intentionally does NOT start with confirm-/feedback-/
+  # answer-/codex- (the four prefixes the inbox contract, §B2, defines) so it can never be
+  # mistaken for a live inbox/processed item by anything polling those prefixes.
+  PROCESSED_DIR="$STATE_DIR/panes/processed"
+  KEPT_PATH="$PROCESSED_DIR/dryrun-prompt-$ROLE_SLUG-$(date +%s)-$$.kept"
+  if mkdir -p "$PROCESSED_DIR" 2>/dev/null && cp "$PROMPT_FILE" "$KEPT_PATH" 2>/dev/null; then
+    chmod 600 "$KEPT_PATH" 2>/dev/null || true
+  else
+    # Fall back to the old location if the project directory isn't writable for some reason —
+    # still better than silently losing the debug artifact.
+    KEPT_PATH="$PROMPT_FILE.kept"
+    cp "$PROMPT_FILE" "$KEPT_PATH" 2>/dev/null || true
+    chmod 600 "$KEPT_PATH" 2>/dev/null || true
+  fi
+  say "보존된 프롬프트: $KEPT_PATH (TTL 없음 — 수동 정리 필요, _state/panes/processed/ 주기적 정리 권장)"
+  write_inbox_marker "DRY-RUN" "dry-run 완료, 프롬프트=$KEPT_PATH"
+  exit 0
+fi
+
+# --------------------------------------------------------------------------
+# 8. model/reasoning_effort plan 오버라이드 조회 (bathos model resolve --json)
+# --------------------------------------------------------------------------
+# bathos가 없어도(빌드 안 됐거나 PATH 밖) 이 단계는 치명적이지 않다 — plan
+# 오버라이드가 없다고 보고 codex 설치본 기본 모델로 진행한다(§A1.2 codex 행:
+# "명시 지정은 사용자가 아는 유효 ID를 입력할 때만" — 조회 실패를 임의 모델로
+# 채우지 않는다, 날조 금지).
+find_bathos_bin() {
+  local cand
+  if [ -n "${BATHOS_BIN:-}" ] && [ -x "${BATHOS_BIN:-}" ]; then
+    printf '%s' "$BATHOS_BIN"; return 0
+  fi
+  for cand in "$PROJECT_DIR/core/target/release/bathos" "$PROJECT_DIR/core/target/debug/bathos"; do
+    if [ -x "$cand" ]; then printf '%s' "$cand"; return 0; fi
+  done
+  if command -v bathos >/dev/null 2>&1; then command -v bathos; return 0; fi
+  return 1
+}
+
+MODEL_OVERRIDE=""
+EFFORT_OVERRIDE=""
+BATHOS_BIN_RESOLVED="$(find_bathos_bin || true)"
+if [ -n "$BATHOS_BIN_RESOLVED" ]; then
+  RESOLVE_JSON="$("$BATHOS_BIN_RESOLVED" -s "$STATE_DIR" model --root "$PROJECT_DIR" resolve "$ROLE_SLUG" --json 2>/dev/null || true)"
+  if [ -n "$RESOLVE_JSON" ]; then
+    # 단일행 compact JSON(bathos-cli가 이렇게 방출) — jq 없이 grep으로 값만 추출.
+    MODEL_OVERRIDE="$(printf '%s' "$RESOLVE_JSON" | grep -o '"model"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*:"\(.*\)"$/\1/')"
+    EFFORT_OVERRIDE="$(printf '%s' "$RESOLVE_JSON" | grep -o '"reasoning_effort"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*:"\(.*\)"$/\1/')"
+  fi
+else
+  warn "bathos 바이너리를 찾지 못해 model-plan 오버라이드 조회를 건너뜁니다(codex 설치본 기본값 사용)."
+fi
+
+# --------------------------------------------------------------------------
+# 9. 비대화 실행 (§A3.3 step4, ⚠️[추정 — 라이브 미실측])
+# --------------------------------------------------------------------------
+PROMPT_CONTENT="$(cat "$PROMPT_FILE")"
+CODEX_ARGS=(exec)
+[ -n "$MODEL_OVERRIDE" ] && CODEX_ARGS+=(-c "model=\"$MODEL_OVERRIDE\"")
+[ -n "$EFFORT_OVERRIDE" ] && CODEX_ARGS+=(-c "model_reasoning_effort=\"$EFFORT_OVERRIDE\"")
+CODEX_ARGS+=("$PROMPT_CONTENT")
+
+say "codex exec 실행 중... (model override=${MODEL_OVERRIDE:-미지정}, effort=${EFFORT_OVERRIDE:-미지정})"
+CODEX_OUT="$("$CODEX_BIN" "${CODEX_ARGS[@]}" 2>&1)"
+CODEX_RC=$?
+
+if [ "$CODEX_RC" -eq 0 ]; then
+  say "codex exec 완료 (exit 0)"
+  write_inbox_marker "DONE" "codex exec 완료: $(printf '%s' "$CODEX_OUT" | tail -1)"
+  exit 0
+fi
+
+# 실행이 실패했을 때만 사후적으로 인증 실패 신호를 재검사한다(§4에서 선제
+# 차단하지 않은 애매한 케이스의 최종 판정 지점 — 정직한 한계 문단 참고).
+if printf '%s' "$CODEX_OUT" | grep -Eiq 'not[ _-]?logged[ _-]?in|unauthenticated|unauthorized|please.*login|please.*auth'; then
+  err "[E-CODEX-AUTH] codex exec가 인증 실패로 보이는 오류로 종료(exit $CODEX_RC):"
+  printf '%s\n' "$CODEX_OUT" >&2
+  write_inbox_marker "FAIL" "codex exec 인증 실패(E-CODEX-AUTH), exit=$CODEX_RC"
+  exit 4
+fi
+
+err "codex exec 실패 (exit $CODEX_RC):"
+printf '%s\n' "$CODEX_OUT" >&2
+write_inbox_marker "FAIL" "codex exec 실패, exit=$CODEX_RC: $(printf '%s' "$CODEX_OUT" | tail -1)"
+exit 1

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -26,6 +26,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +97,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,8 +134,11 @@ dependencies = [
  "bathos-router",
  "bathos-state",
  "bathos-story-engine",
+ "bathos-tui",
  "bathos-wave-engine",
+ "chrono",
  "clap",
+ "crossterm",
  "serde_json",
 ]
 
@@ -135,7 +153,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -155,7 +173,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tiny_http",
 ]
 
@@ -169,7 +187,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -183,7 +201,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -200,7 +218,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -222,7 +240,19 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "bathos-tui"
+version = "0.1.0"
+dependencies = [
+ "bathos-inspect",
+ "crossterm",
+ "ratatui",
+ "serde",
+ "tempfile",
+ "unicode-width",
 ]
 
 [[package]]
@@ -236,7 +266,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -283,10 +313,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -371,6 +416,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +469,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.13.0",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio 1.2.2",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,10 +506,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
 
 [[package]]
 name = "digest"
@@ -436,6 +587,21 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
@@ -465,6 +631,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,6 +657,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -586,9 +764,25 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -715,6 +909,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,7 +942,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -766,6 +975,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,6 +1000,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -826,6 +1057,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,6 +1100,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,6 +1125,12 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -885,6 +1148,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lru"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +1172,18 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -925,7 +1209,7 @@ dependencies = [
  "kqueue",
  "libc",
  "log",
- "mio",
+ "mio 0.8.11",
  "walkdir",
  "windows-sys 0.48.0",
 ]
@@ -1016,6 +1300,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,6 +1319,30 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1061,6 +1378,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1108,6 +1431,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "ratatui"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags 2.13.0",
+ "compact_str",
+ "hashbrown 0.17.1",
+ "itertools",
+ "kasuari",
+ "lru",
+ "palette",
+ "serde",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,6 +1533,15 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1184,6 +1582,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1259,6 +1663,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio 1.2.2",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,10 +1712,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -1323,7 +1785,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1338,13 +1809,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "time"
 version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -1400,6 +1884,29 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1519,6 +2026,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,6 +2049,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/bathos-plug",
     "crates/bathos-cli",
     "crates/bathos-inspect",
+    "crates/bathos-tui",
 ]
 
 # ── 공유 의존 버전 (workspace 레벨 고정) ───────────────────────────────────

--- a/core/crates/bathos-cli/Cargo.toml
+++ b/core/crates/bathos-cli/Cargo.toml
@@ -17,6 +17,10 @@ bathos-story-engine = { path = "../bathos-story-engine" }
 bathos-plug         = { path = "../bathos-plug" }
 # DevTools 파일럿(read-only) — `serve` feature는 전달하지 않아 기본 빌드는 가볍다.
 bathos-inspect      = { path = "../bathos-inspect" }
+# `bathos panes` (B4) — 대화식 TUI 위임.
+bathos-tui          = { path = "../bathos-tui" }
 clap                = { workspace = true }
 serde_json          = { workspace = true }
 anyhow              = { workspace = true }
+chrono              = { workspace = true }
+crossterm           = "0.29"

--- a/core/crates/bathos-cli/src/main.rs
+++ b/core/crates/bathos-cli/src/main.rs
@@ -36,7 +36,13 @@
 use anyhow::{Context, Result};
 use bathos_gate_engine::{GateEngine, GateIssue, VerdictAggregator};
 use bathos_plug::{ModuleRegistry, PlugManager};
-use bathos_state::{model::GateType, schema::validate_manifest, store::StateStore, Verdict};
+use bathos_state::{
+    model::GateType,
+    model_plan::{self, ModelPlan, Runtime, SessionBackend},
+    schema::validate_manifest,
+    store::StateStore,
+    Verdict,
+};
 use bathos_story_engine::StoryEngine;
 use clap::{Parser, Subcommand};
 use std::path::{Path, PathBuf};
@@ -107,6 +113,18 @@ enum Commands {
         #[command(subcommand)]
         action: AuditAction,
     },
+    /// 역할별 모델/런타임 선택 (W2 panes/model 설계, ADR-D-0005/0006)
+    ///
+    /// `_state/model-plan.json`(schema `bathos/model-plan@1`)을 단일 SSOT로 삼아
+    /// Claude(fable5/sonnet5/haiku)·GLM·Codex 런타임을 역할별로 배선한다. plan
+    /// 부재/미등재 역할은 항상 agent frontmatter `model:`로 폴백(100% 하위호환).
+    Model {
+        /// `.claude/agents/_base/` 탐색 기준 프로젝트 루트 (기본값: 현재 디렉터리)
+        #[arg(long, default_value = ".")]
+        root: PathBuf,
+        #[command(subcommand)]
+        action: ModelAction,
+    },
     /// 위험 변경 diff 지문(fingerprint) 조회·승인 (Dynamis 신규, SS1 · CF-A1)
     ///
     /// `freeze-guard.sh`(위험 경로 Write/Edit/MultiEdit)가 재승인 방지를 위해 호출한다.
@@ -138,6 +156,32 @@ enum Commands {
         #[command(subcommand)]
         action: bathos_inspect::InspectCommand,
     },
+    /// Wave 패널 — tmux 실시간 분할 또는 bathos 대화식 TUI (B3/B4, ADR-D-0007~0009).
+    ///
+    /// 공유 데이터원은 `bathos inspect vm`과 동일한 `DashboardVM`(ADR-D-0007) — 이 서브커맨드는
+    /// 새 상태 계층을 만들지 않고 프론트엔드 선택·위임만 한다.
+    Panes {
+        /// tui(대화식 TUI) | tmux(scripts/bathos-panes.sh 위임) | dump(비대화 1프레임 스냅샷).
+        /// 미지정 + TTY: 대화형 선택(tmux/TUI) 후 `_state/panes/prefs`에 1줄 기억.
+        #[arg(long, value_enum)]
+        mode: Option<PanesMode>,
+        /// 대상 `.agent-team` 디렉터리. 미지정 시 cwd에서 상향 탐색(bathos-inspect와 동일 규약).
+        #[arg(long)]
+        path: Option<PathBuf>,
+        /// 표시할 웨이브(예: W5). 미지정 시 전체.
+        #[arg(long)]
+        wave: Option<String>,
+        /// 렌더 주기(초) — tmux 위임 시 그대로 전달, TUI는 tick 간격으로 사용.
+        #[arg(long, default_value_t = 2)]
+        interval: u64,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+enum PanesMode {
+    Tui,
+    Tmux,
+    Dump,
 }
 
 // ── plug subcommands (B4 implementation) ─────────────────────────────────────
@@ -293,6 +337,86 @@ enum StoryAction {
     },
 }
 
+// ── model subcommands (W2 panes/model design §A1.4) ──────────────────────────
+
+#[derive(Subcommand)]
+enum ModelAction {
+    /// 역할별 유효 runtime/model 표를 출력한다 (source: plan|default|frontmatter|runtime-default).
+    Show {
+        /// 표시 대상을 이 웨이브의 역할군으로 제한 (예: W5). 미지정 시 plan에 등재된
+        /// 역할 + agents-dir에서 발견한 전 역할의 합집합을 표시.
+        #[arg(long)]
+        wave: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// 역할의 runtime/model을 plan에 기록한다 (변경분만 — 리드 세션 전용 단일 쓰기 경로).
+    Set {
+        /// agent 정의 slug (예: phillip-backend-engineer)
+        slug: String,
+        #[arg(long)]
+        runtime: String,
+        #[arg(long)]
+        model: Option<String>,
+        #[arg(long = "reasoning-effort")]
+        reasoning_effort: Option<String>,
+    },
+    /// plan에서 역할 항목을 제거한다 (→ frontmatter 폴백으로 복귀).
+    Unset { slug: String },
+    /// 현재 세션의 실제 백엔드(session_backend)를 판별해 plan에 기록한다
+    /// (env `ANTHROPIC_BASE_URL`에 `api.z.ai` 포함 → glm, 그 외 → claude).
+    Detect,
+    /// GLM/Codex 혼합 배치 규칙(R1~R4)을 검증한다. PASS=exit 0 / 위반=exit 2 + 해소 선택지.
+    Validate {
+        /// 검증 대상 웨이브 (예: W5). 미지정 시 plan에 등재된 모든 역할을 대상으로 검증.
+        #[arg(long)]
+        wave: Option<String>,
+    },
+    /// 한 역할의 유효 runtime/model/적용채널을 1줄 출력한다 (스크립트 소비용).
+    Resolve {
+        slug: String,
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+/// `waves.<W?>` 역할군(role↔wave 배정). BATHOS의 정본은 프로젝트 `CLAUDE.md` §1/§2의
+/// 역할·모델 표다 — 여기서는 그 표를 `bathos model show/validate --wave`가 참조할 수
+/// 있는 정적 상수로 옮겨 적었을 뿐, 새로운 정책을 만들어내지 않는다(날조 금지).
+/// W3/W6의 겸직 보조 역할(Timothy)·독립 리뷰어(Thomas/Matthias)도 CLAUDE.md 표기 그대로 포함.
+fn wave_role_slugs(wave_id: &str) -> Option<&'static [&'static str]> {
+    match wave_id.to_ascii_uppercase().as_str() {
+        "W0" => Some(&["caleb-market-analyst", "john-reverse-specialist"]),
+        "W1" => Some(&["john-reverse-specialist", "caleb-market-analyst"]),
+        "W2" => Some(&[
+            "joshua-service-planner",
+            "james-architect",
+            "jonnathan-chief-designer",
+        ]),
+        "W3" => Some(&[
+            "matthew-story-engineer",
+            "thomas-code-reviewer",
+            "matthias-qa-validator",
+            "timothy-doc-specialist",
+        ]),
+        "W4" => Some(&["mark-ip-specialist", "nathanael-research-writer"]),
+        "W5" => Some(&[
+            "phillip-backend-engineer",
+            "andrew-frontend-engineer",
+            "stephen-ml-engineer",
+        ]),
+        "W6" => Some(&[
+            "thomas-code-reviewer",
+            "timothy-doc-specialist",
+            "matthias-qa-validator",
+            "mishael-security-specialist",
+            "hananiah-refactoring-specialist",
+            "martin-monitoring-reporter",
+        ]),
+        _ => None,
+    }
+}
+
 // ── audit subcommands (B-1 fix) ──────────────────────────────────────────────
 
 #[derive(Subcommand)]
@@ -387,10 +511,17 @@ fn run(cli: Cli) -> Result<i32> {
         Commands::Route { action } => handle_route(action, &cli.state_dir),
         Commands::Story { action } => handle_story(action, &cli.state_dir),
         Commands::Plug { action } => handle_plug(action, &cli.state_dir, &cli.modules_dir),
+        Commands::Model { root, action } => handle_model(action, &cli.state_dir, &root),
         Commands::Audit { action } => handle_audit(action, &cli.state_dir),
         Commands::Fingerprint { action } => handle_fingerprint(action, &cli.state_dir),
         Commands::Doctor { root } => handle_doctor(&root, &cli.state_dir, &cli.modules_dir),
         Commands::Inspect { common, action } => Ok(handle_inspect(common, action)),
+        Commands::Panes {
+            mode,
+            path,
+            wave,
+            interval,
+        } => Ok(handle_panes(mode, path, wave, interval)),
     }
 }
 
@@ -407,6 +538,205 @@ fn handle_inspect(
         Err(exit_code) => exit_code,
     }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Panes handler (W2 panes/model design §B4.2) — `bathos panes` frontend selection/delegation
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// This handler picks and delegates to exactly one of the three frontends — it never builds a
+// second state layer of its own. `--mode dump`/`tui` both go through `bathos-tui`'s public API
+// (`render_dump`/`run_tui`), which itself only ever calls `bathos-inspect`'s `load_project` +
+// `load_story_cards` + `build_vm` (ADR-D-0007) — the exact same pipeline `report`/`inspect vm`
+// use. `--mode tmux` execs `scripts/bathos-panes.sh` (a separate process, ADR-D-0009).
+
+fn handle_panes(
+    mode: Option<PanesMode>,
+    path: Option<PathBuf>,
+    wave: Option<String>,
+    interval: u64,
+) -> i32 {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let agent_team_path = match bathos_inspect::context::resolve_agent_team_path(path, &cwd) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("{e}");
+            return 1;
+        }
+    };
+
+    let resolved_mode = mode.unwrap_or_else(|| resolve_default_mode(&agent_team_path));
+
+    match resolved_mode {
+        PanesMode::Tui => {
+            if !std::io::IsTerminal::is_terminal(&std::io::stdout()) {
+                eprintln!(
+                    "[E-PANES-NOTTY] 비대화형 환경(TTY 아님)에서는 대화식 TUI를 실행할 수 없습니다."
+                );
+                eprintln!("  안내: 파이프/CI에서는 `bathos panes --mode dump`를 사용하세요.");
+                return 1;
+            }
+            bathos_tui::run_tui(
+                &agent_team_path,
+                bathos_tui::TuiOpts {
+                    wave,
+                    interval: std::time::Duration::from_secs(interval),
+                },
+            )
+        }
+
+        PanesMode::Dump => {
+            let pv = match bathos_inspect::load_project(
+                &agent_team_path,
+                bathos_inspect::LoadOpts { verify_chain: true },
+            ) {
+                Ok(pv) => pv,
+                Err(e) => {
+                    eprintln!("[bathos panes] {e}");
+                    return 1;
+                }
+            };
+            let ctx = bathos_inspect::InspectCtx {
+                agent_team_path: agent_team_path.clone(),
+                json: false,
+                verbose: false,
+                strict: false,
+            };
+            let stories = bathos_inspect::dashboard::load_story_cards(&ctx, &pv);
+            let vm = bathos_inspect::dashboard::viewmodel::build_vm(&pv, &stories);
+            let (width, height) = crossterm::terminal::size().unwrap_or((100, 30));
+            print!(
+                "{}",
+                bathos_tui::render_dump(&vm, wave.as_deref(), width, height)
+            );
+            0
+        }
+
+        PanesMode::Tmux => exec_tmux_panes(&agent_team_path, wave.as_deref(), interval),
+    }
+}
+
+/// No `--mode` given: honors a previously-saved preference (`_state/panes/prefs`) if present;
+/// otherwise, on a real TTY, asks once and saves the answer (§B4.2 "선택 결과를 기억"). On a
+/// non-TTY with no saved preference, defaults to `dump` — the only mode that is always safe to
+/// run unattended (matches `--mode tui`'s own E-PANES-NOTTY guard: a script/CI invocation with
+/// no prior preference should get inert, pipeable text, never an interactive prompt it can't
+/// answer).
+fn resolve_default_mode(agent_team_path: &Path) -> PanesMode {
+    let prefs_path = agent_team_path.join("_state/panes/prefs");
+    if let Ok(saved) = std::fs::read_to_string(&prefs_path) {
+        match saved.trim() {
+            "tmux" => return PanesMode::Tmux,
+            "tui" => return PanesMode::Tui,
+            _ => {}
+        }
+    }
+
+    if !std::io::IsTerminal::is_terminal(&std::io::stdout()) {
+        return PanesMode::Dump;
+    }
+
+    let tmux_available = command_exists("tmux");
+    eprintln!("패널 프론트엔드를 선택하세요:");
+    eprintln!(
+        "  [1] tmux 실시간 분할{}",
+        if tmux_available {
+            " (tmux 감지됨)"
+        } else {
+            " (미설치 — 선택 불가)"
+        }
+    );
+    eprintln!("  [2] bathos TUI");
+    eprint!("선택 [1/2]: ");
+    use std::io::Write;
+    let _ = std::io::stdout().flush();
+
+    let mut line = String::new();
+    let chosen = if std::io::stdin().read_line(&mut line).is_ok() {
+        match line.trim() {
+            "1" if tmux_available => PanesMode::Tmux,
+            "1" => {
+                eprintln!("tmux 미설치 — bathos TUI로 대체합니다.");
+                PanesMode::Tui
+            }
+            _ => PanesMode::Tui,
+        }
+    } else {
+        PanesMode::Tui
+    };
+
+    let pref_str = match chosen {
+        PanesMode::Tmux => "tmux",
+        PanesMode::Tui => "tui",
+        PanesMode::Dump => "dump",
+    };
+    if let Some(dir) = prefs_path.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    let _ = std::fs::write(&prefs_path, pref_str);
+
+    chosen
+}
+
+/// `--mode tmux`: execs `scripts/bathos-panes.sh up` (search order per §B4.2: `<project
+/// root>/scripts/` then `$BATHOS_HOME/scripts/`). A project root here is the agent_team_path's
+/// parent (`.agent-team`'s sibling), matching `bathos-panes.sh`'s own `--project` contract.
+fn exec_tmux_panes(agent_team_path: &Path, wave: Option<&str>, interval: u64) -> i32 {
+    let project_root = agent_team_path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| agent_team_path.to_path_buf());
+
+    let candidate = project_root.join("scripts/bathos-panes.sh");
+    let script_path = if candidate.is_file() {
+        Some(candidate)
+    } else if let Ok(home) = std::env::var("BATHOS_HOME") {
+        let p = PathBuf::from(home).join("scripts/bathos-panes.sh");
+        if p.is_file() {
+            Some(p)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    let Some(script_path) = script_path else {
+        eprintln!(
+            "[E-PANES-SCRIPT-ABSENT] scripts/bathos-panes.sh를 찾을 수 없습니다 \
+             ({}/scripts/ 및 $BATHOS_HOME/scripts/ 모두 확인).",
+            project_root.display()
+        );
+        eprintln!(
+            "  수동 실행: bash <저장소>/scripts/bathos-panes.sh up --project '{}'{}",
+            project_root.display(),
+            wave.map(|w| format!(" --waves \"{w}\""))
+                .unwrap_or_default()
+        );
+        return 4;
+    };
+
+    let mut cmd = std::process::Command::new("bash");
+    cmd.arg(&script_path)
+        .arg("up")
+        .arg("--project")
+        .arg(&project_root)
+        .arg("--interval")
+        .arg(interval.to_string());
+    if let Some(w) = wave {
+        cmd.arg("--waves").arg(w);
+    }
+
+    match cmd.status() {
+        Ok(status) => status.code().unwrap_or(1),
+        Err(e) => {
+            eprintln!("[bathos panes] scripts/bathos-panes.sh 실행 실패: {e}");
+            1
+        }
+    }
+}
+
+// (`command_exists` is defined once, further below, alongside the `doctor` handler — reused
+// here rather than duplicated.)
 
 // ─────────────────────────────────────────────────────────────────────────────
 // State handler (B1 full implementation)
@@ -720,6 +1050,279 @@ fn handle_route(action: RouteAction, state_dir: &Path) -> Result<i32> {
             }
         }
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Model handler (W2 panes/model design §A1.4) — `_state/model-plan.json` CLI
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Every subcommand here is a thin wrapper over `bathos_state::model_plan`'s pure
+// load/resolve/validate/save functions — this handler owns only I/O plumbing
+// (finding `.claude/agents/_base`, printing, exit codes, audit logging).
+
+fn handle_model(action: ModelAction, state_dir: &Path, root: &Path) -> Result<i32> {
+    let agents_dir = root.join(".claude/agents/_base");
+
+    match action {
+        // ── bathos model show ────────────────────────────────────────────────
+        ModelAction::Show { wave, json } => {
+            let (plan, warnings) = model_plan::load(state_dir);
+            for w in &warnings {
+                eprintln!("[bathos model show] {} — {}", w.code, w.message);
+            }
+
+            let slugs = roles_to_display(&plan, wave.as_deref(), &agents_dir);
+
+            let rows: Vec<serde_json::Value> = slugs
+                .iter()
+                .map(|slug| {
+                    let fm = model_plan::find_frontmatter_model(&agents_dir, slug);
+                    let eff = model_plan::resolve_effective(&plan, slug, fm.as_deref());
+                    serde_json::json!({
+                        "slug": slug,
+                        "runtime": eff.runtime.as_str(),
+                        "model": eff.model,
+                        "reasoning_effort": eff.reasoning_effort,
+                        "source": eff.source.as_str(),
+                    })
+                })
+                .collect();
+
+            if json {
+                println!("{}", serde_json::to_string_pretty(&rows)?);
+            } else {
+                println!(
+                    "역할별 모델 — session_backend={}{}",
+                    plan.session_backend.as_str(),
+                    wave.as_deref()
+                        .map(|w| format!(" wave={w}"))
+                        .unwrap_or_default()
+                );
+                println!("{:<32} {:<8} {:<20} source", "role", "runtime", "model");
+                for row in &rows {
+                    println!(
+                        "{:<32} {:<8} {:<20} {}",
+                        row["slug"].as_str().unwrap_or("?"),
+                        row["runtime"].as_str().unwrap_or("?"),
+                        row["model"].as_str().unwrap_or("(runtime default)"),
+                        row["source"].as_str().unwrap_or("?"),
+                    );
+                }
+            }
+            Ok(0)
+        }
+
+        // ── bathos model set ─────────────────────────────────────────────────
+        ModelAction::Set {
+            slug,
+            runtime,
+            model,
+            reasoning_effort,
+        } => {
+            let parsed_runtime = Runtime::parse(&runtime).map_err(|e| anyhow::anyhow!(e))?;
+
+            // E1 second half: an existing-but-corrupt-JSON plan is backed up before we
+            // overwrite it with a freshly reconstructed one (never silently discard bytes
+            // the user might want to recover by hand).
+            if model_plan::is_corrupt_json(state_dir) {
+                model_plan::backup_corrupt(state_dir).context("model-plan.json.bak 백업 실패")?;
+                eprintln!(
+                    "[bathos model set] ⚠ 기존 model-plan.json이 손상되어 있어 .bak로 백업했습니다"
+                );
+            }
+
+            let (mut plan, _warnings) = model_plan::load(state_dir);
+            plan.roles.insert(
+                slug.clone(),
+                bathos_state::model_plan::RoleModelSpec {
+                    runtime: parsed_runtime,
+                    model: model.clone(),
+                    reasoning_effort: reasoning_effort.clone(),
+                },
+            );
+            plan.updated = chrono::Utc::now();
+            plan.updated_by = "Paul".to_string();
+            model_plan::save(state_dir, &plan).context("model-plan.json 저장 실패")?;
+
+            // best-effort audit trail (never blocks — same fail-safe posture as `audit append`)
+            let _ = bathos_state::audit::append_audit_entry(
+                &state_dir.join("audit-log.jsonl"),
+                &read_project_id_from_state(state_dir),
+                "Paul",
+                "model.set",
+                &format!("{slug}→{runtime}"),
+            );
+
+            eprintln!(
+                "[bathos model set] ✓ {slug} → runtime={runtime}{}{}",
+                model.map(|m| format!(" model={m}")).unwrap_or_default(),
+                reasoning_effort
+                    .map(|r| format!(" reasoning_effort={r}"))
+                    .unwrap_or_default()
+            );
+            Ok(0)
+        }
+
+        // ── bathos model unset ───────────────────────────────────────────────
+        ModelAction::Unset { slug } => {
+            let (mut plan, _warnings) = model_plan::load(state_dir);
+            let existed = plan.roles.remove(&slug).is_some();
+            model_plan::save(state_dir, &plan).context("model-plan.json 저장 실패")?;
+            let _ = bathos_state::audit::append_audit_entry(
+                &state_dir.join("audit-log.jsonl"),
+                &read_project_id_from_state(state_dir),
+                "Paul",
+                "model.unset",
+                &slug,
+            );
+            if existed {
+                eprintln!("[bathos model unset] ✓ {slug} 제거 → frontmatter 폴백으로 복귀");
+            } else {
+                eprintln!("[bathos model unset] {slug}은 plan에 등재돼 있지 않았음(변화 없음)");
+            }
+            Ok(0)
+        }
+
+        // ── bathos model detect ──────────────────────────────────────────────
+        ModelAction::Detect => {
+            let backend = SessionBackend::detect_from_base_url(
+                std::env::var("ANTHROPIC_BASE_URL").ok().as_deref(),
+            );
+            let (mut plan, _warnings) = model_plan::load(state_dir);
+            plan.session_backend = backend;
+            plan.updated = chrono::Utc::now();
+            plan.updated_by = "Paul".to_string();
+            model_plan::save(state_dir, &plan).context("model-plan.json 저장 실패")?;
+            let _ = bathos_state::audit::append_audit_entry(
+                &state_dir.join("audit-log.jsonl"),
+                &read_project_id_from_state(state_dir),
+                "Paul",
+                "model.detect",
+                backend.as_str(),
+            );
+            eprintln!("[bathos model detect] session_backend={}", backend.as_str());
+            Ok(0)
+        }
+
+        // ── bathos model validate ────────────────────────────────────────────
+        ModelAction::Validate { wave } => {
+            let (plan, _warnings) = model_plan::load(state_dir);
+            let roles: Vec<String> = match &wave {
+                Some(w) => wave_role_slugs(w)
+                    .map(|s| s.iter().map(|x| x.to_string()).collect())
+                    .unwrap_or_else(|| plan.roles.keys().cloned().collect()),
+                None => plan.roles.keys().cloned().collect(),
+            };
+            let wave_label = wave.as_deref().unwrap_or("(all)");
+
+            match model_plan::validate_wave(&plan, wave_label, &roles) {
+                Ok(()) => {
+                    println!(
+                        "PASS — {wave_label} 역할 배치 혼합 규칙 위반 없음 ({} roles)",
+                        roles.len()
+                    );
+                    Ok(0)
+                }
+                Err(violation) => {
+                    eprintln!("{}", violation.message);
+                    eprintln!("해소 선택지:");
+                    for r in &violation.resolutions {
+                        eprintln!("  {r}");
+                    }
+                    let out = serde_json::json!({
+                        "code": violation.code,
+                        "message": violation.message,
+                        "resolutions": violation.resolutions,
+                    });
+                    println!("{out}");
+                    Ok(2)
+                }
+            }
+        }
+
+        // ── bathos model resolve ─────────────────────────────────────────────
+        ModelAction::Resolve { slug, json } => {
+            let (plan, _warnings) = model_plan::load(state_dir);
+            let fm = model_plan::find_frontmatter_model(&agents_dir, &slug);
+            let eff = model_plan::resolve_effective(&plan, &slug, fm.as_deref());
+            if json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "slug": slug,
+                        "runtime": eff.runtime.as_str(),
+                        "model": eff.model,
+                        "reasoning_effort": eff.reasoning_effort,
+                        "source": eff.source.as_str(),
+                    })
+                );
+            } else {
+                println!(
+                    "{}\t{}\t{}\t{}",
+                    slug,
+                    eff.runtime.as_str(),
+                    eff.model.as_deref().unwrap_or("-"),
+                    eff.source.as_str()
+                );
+            }
+            Ok(0)
+        }
+    }
+}
+
+/// Resolves the role slugs `bathos model show` should display: the wave's registered roster
+/// (`--wave`) if given, otherwise the union of every slug already in the plan and every slug
+/// discoverable under `agents_dir` (so `show` is useful even before any `set` has ever run —
+/// it should show the full "would-resolve-to-frontmatter" universe, not an empty table).
+fn roles_to_display(plan: &ModelPlan, wave: Option<&str>, agents_dir: &Path) -> Vec<String> {
+    if let Some(w) = wave {
+        if let Some(slugs) = wave_role_slugs(w) {
+            return slugs.iter().map(|s| s.to_string()).collect();
+        }
+    }
+
+    let mut set: std::collections::BTreeSet<String> = plan.roles.keys().cloned().collect();
+    if let Ok(entries) = std::fs::read_dir(agents_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("md") {
+                continue;
+            }
+            if let Ok(content) = std::fs::read_to_string(&path) {
+                if let Some(slug) = frontmatter_slug(&content) {
+                    set.insert(slug);
+                }
+            }
+        }
+    }
+    set.into_iter().collect()
+}
+
+/// Minimal `slug:` frontmatter extraction for `roles_to_display`'s directory scan. Intentionally
+/// duplicated (not reused from `model_plan::find_frontmatter_model`, which is single-slug-keyed)
+/// rather than widening that function's private helper's visibility — this one needs "give me
+/// whatever slug this file declares", the other needs "does this file declare slug X".
+fn frontmatter_slug(content: &str) -> Option<String> {
+    let mut in_fm = false;
+    for (i, line) in content.lines().enumerate() {
+        let t = line.trim_end();
+        if i == 0 && t == "---" {
+            in_fm = true;
+            continue;
+        }
+        if in_fm && t == "---" {
+            break;
+        }
+        if in_fm {
+            if let Some(rest) = t.trim_start().strip_prefix("slug:") {
+                let v = rest.split('#').next().unwrap_or(rest).trim();
+                if !v.is_empty() {
+                    return Some(v.to_string());
+                }
+            }
+        }
+    }
+    None
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/core/crates/bathos-inspect/src/cli.rs
+++ b/core/crates/bathos-inspect/src/cli.rs
@@ -43,6 +43,17 @@ pub enum LangArg {
     Both,
 }
 
+/// `bathos inspect vm --format` — the shared `DashboardVM` data source (ADR-D-0007), rendered
+/// either as the existing pretty JSON dump (`json`, byte-identical to `report --json`) or as
+/// the bash-3.2/jq-free TSV "lines protocol" (`lines`, consumed by `scripts/bathos-panes.sh`
+/// and the `bathos-tui` crate). [Source: w2-panes-model-design-kr.md §B1]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum)]
+pub enum VmFormat {
+    #[default]
+    Json,
+    Lines,
+}
+
 /// The four `bathos inspect <sub>` subcommands.
 ///
 /// This story (1-1) defines only the contract surface (flags); the handlers are stubs.
@@ -99,4 +110,17 @@ pub enum InspectCommand {
     /// existing install/wiring preflight. This subcommand is exposed only as
     /// `bathos inspect doctor` and carries no alias.
     Doctor,
+
+    /// Shared `DashboardVM` data source for the wave panels (tmux/TUI, ADR-D-0007) —
+    /// `--format json` is byte-identical to `report --json` (same `build_dashboard_vm_json`
+    /// call); `--format lines` emits the bash-3.2/jq-free TSV protocol.
+    /// [Source: w2-panes-model-design-kr.md §B1]
+    Vm {
+        /// Scope wave/gate/role records to this wave (e.g. `W5`). Omit for all waves.
+        #[arg(long)]
+        wave: Option<String>,
+
+        #[arg(long, value_enum, default_value_t = VmFormat::Json)]
+        format: VmFormat,
+    },
 }

--- a/core/crates/bathos-inspect/src/dashboard/lines.rs
+++ b/core/crates/bathos-inspect/src/dashboard/lines.rs
@@ -1,0 +1,543 @@
+//! `lines` — `DashboardVM` → TSV "lines protocol" (`bathos inspect vm --format lines`).
+//!
+//! **Why a second serialization exists alongside `--format json`:** the tmux frontend
+//! (`scripts/bathos-panes.sh`, ADR-D-0007) runs under bash 3.2 with `jq` explicitly banned
+//! (project-wide constraint — see `w2-panes-model-design-kr.md` §0.2), so it cannot consume
+//! nested JSON. This module renders the same [`DashboardVM`] that `--format json` dumps
+//! verbatim (`build_dashboard_vm_json`, unchanged) into a flat, `grep`/`cut`-friendly
+//! tab-separated line protocol instead — **one data source, two output shapes** (ADR-D-0007:
+//! "새 상태 계층을 발명하지 않는다").
+//!
+//! **Protocol contract (`w2-panes-model-design-kr.md` §B1):**
+//! - First line is always `proto\tbathos-panes-lines\t1` — a consumer checks this before
+//!   trusting the rest; a version bump only ever **appends** fields to existing record kinds
+//!   (never reorders/removes), so an older consumer degrades gracefully instead of breaking.
+//! - Every field is TAB-joined; embedded TABs/newlines inside a field's own text (e.g. a
+//!   warning message, a `facilitator` name, or an on-disk artifact path — POSIX filenames may
+//!   legally contain either) are replaced with a single space by [`push_line`] itself, so the
+//!   TSV framing invariant is enforced **once, structurally**, for every record kind — no
+//!   `emit_*` call site can forget it (PANES-003: this used to be a per-call-site opt-in via a
+//!   standalone `sanitize_field` helper that only `emit_warnings` actually called; every other
+//!   `emit_*` function passed its fields through unsanitized).
+//! - `--wave <W>` scopes **wave/gate/role** records to that `wave_id` (all three carry a
+//!   `wave_id` in the VM already). It intentionally does **not** scope `story`/`artifact`
+//!   records — `StoryCardView` and the artifact tree (`ArtifactLeafVM`) carry no `wave_id` in
+//!   the current `DashboardVM` shape, so a "wave-scoped story/artifact" filter would have to be
+//!   fabricated (a guess, not a fact) rather than read off real data. This is an honest,
+//!   documented limitation, not an oversight — see `08-impl-notes/backend.md`.
+
+use super::viewmodel::{
+    ArtifactLeafVM, DashboardVM, GateCardVM, RolePillVM, StoryCardView, TreeNode, WaveCellVM,
+};
+
+/// The lines-protocol version this module writes. Bumped only on an additive (backward-
+/// compatible) change; a breaking change would need a new protocol name, not just a number bump.
+const PROTO_VERSION: &str = "1";
+
+/// `Badge.label_key` is namespaced like `"wave.active"`/`"verdict.concerns"` — the line
+/// protocol wants only the leaf (`"active"`/`"concerns"`), uppercased for verdicts to match the
+/// PASS/CONCERNS/FAIL convention used everywhere else in BATHOS (CLAUDE.md §2.1). Falls back to
+/// the whole key if there is no `.` (defensive — never panics on an unexpected key shape).
+fn label_suffix(label_key: &str) -> &str {
+    label_key.rsplit('.').next().unwrap_or(label_key)
+}
+
+/// Joins `fields` with TAB and appends a trailing newline — the single choke point every
+/// `emit_*` function below routes through, so [`push_sanitized`]'s framing guarantee applies
+/// uniformly (PANES-003 fix: sanitizing here, instead of at each call site, makes it
+/// structurally impossible for a future `emit_*` addition to forget the invariant).
+fn push_line(out: &mut String, fields: &[&str]) {
+    for (i, f) in fields.iter().enumerate() {
+        if i > 0 {
+            out.push('\t');
+        }
+        push_sanitized(out, f);
+    }
+    out.push('\n');
+}
+
+/// Appends `s` to `out`, replacing embedded TAB/CR/LF with a single space — the one place the
+/// TSV framing invariant ("no raw TAB/newline inside a field") is enforced. A normal field
+/// (no tab/newline) round-trips character-for-character, so this is a no-op for every existing
+/// well-behaved value — only a field that would otherwise corrupt the framing is altered.
+fn push_sanitized(out: &mut String, s: &str) {
+    for c in s.chars() {
+        out.push(if c == '\t' || c == '\n' || c == '\r' {
+            ' '
+        } else {
+            c
+        });
+    }
+}
+
+/// Emits `proto`/`meta` header lines (always unfiltered — global project identity).
+fn emit_header(out: &mut String, vm: &DashboardVM) {
+    push_line(out, &["proto", "bathos-panes-lines", PROTO_VERSION]);
+    push_line(
+        out,
+        &["meta", "codename", vm.codename.as_deref().unwrap_or("")],
+    );
+    push_line(out, &["meta", "level", &vm.level_label]);
+    push_line(
+        out,
+        &[
+            "meta",
+            "status",
+            label_suffix(vm.status_badge.label_key),
+            vm.status_badge.symbol,
+        ],
+    );
+    push_line(out, &["meta", "generated", &vm.generated_at_iso]);
+}
+
+fn emit_warnings(out: &mut String, vm: &DashboardVM) {
+    for w in &vm.warnings {
+        // `w.message` is passed through unsanitized here — `push_line` now sanitizes every
+        // field itself (PANES-003), so this is no longer this call site's responsibility.
+        push_line(out, &["warn", &w.code, &w.message]);
+    }
+}
+
+fn emit_wave(out: &mut String, w: &WaveCellVM) {
+    let roles = w.active_roles.join(",");
+    push_line(
+        out,
+        &[
+            "wave",
+            &w.wave_id,
+            label_suffix(w.status_badge.label_key),
+            w.status_badge.symbol,
+            &w.name,
+            &roles,
+        ],
+    );
+}
+
+fn emit_gate(out: &mut String, g: &GateCardVM) {
+    let verdict = label_suffix(g.verdict_badge.label_key).to_ascii_uppercase();
+    let issues = format!("issues={}", g.issues_total);
+    let crit = format!("crit={}", g.issues_critical);
+    push_line(
+        out,
+        &[
+            "gate",
+            &g.gate_id,
+            &g.wave_id,
+            &g.gate_type_label,
+            &verdict,
+            &issues,
+            &crit,
+            g.facilitator.as_deref().unwrap_or(""),
+        ],
+    );
+}
+
+fn emit_role(out: &mut String, r: &RolePillVM) {
+    push_line(
+        out,
+        &[
+            "role",
+            &r.name,
+            label_suffix(r.status_badge.label_key),
+            r.status_badge.symbol,
+            r.wave_id.as_deref().unwrap_or(""),
+        ],
+    );
+}
+
+/// Reformats `StoryCardView.lint_summary_text` (`"pass=N warn=N fail=N"`, the same string the
+/// `story <KEY> --lint` CLI already prints) into the lines-protocol's `key:value,key:value`
+/// convention (`"pass:N,warn:N,fail:N"`). A pure text transform (no re-lint) — kept a separate
+/// function so its determinism is directly unit-testable against the exact fixture strings
+/// `story::lint` produces.
+fn reformat_lint_summary(text: &str) -> String {
+    text.split_whitespace()
+        .map(|kv| kv.replacen('=', ":", 1))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn emit_story(out: &mut String, s: &StoryCardView) {
+    let ready = format!("ready={}", s.ready_badge.symbol == "✓");
+    let lint = format!("lint={}", reformat_lint_summary(&s.lint_summary_text));
+    push_line(
+        out,
+        &["story", &s.story_key, &s.status_label, &ready, &lint],
+    );
+}
+
+/// Recursively walks the artifact tree, reconstructing each leaf's full path by joining node
+/// names on the way down (the tree groups by path segment; the flat `artifact` line needs the
+/// whole path back). `prefix` accumulates the joined segments seen so far.
+fn walk_artifacts(out: &mut String, nodes: &[TreeNode], prefix: &str) {
+    for node in nodes {
+        let path = if prefix.is_empty() {
+            node.name.clone()
+        } else {
+            format!("{prefix}/{}", node.name)
+        };
+        if let Some(leaf) = &node.leaf {
+            emit_artifact_leaf(out, &path, leaf);
+        }
+        if !node.children.is_empty() {
+            walk_artifacts(out, &node.children, &path);
+        }
+    }
+}
+
+fn emit_artifact_leaf(out: &mut String, path: &str, leaf: &ArtifactLeafVM) {
+    push_line(
+        out,
+        &[
+            "artifact",
+            path,
+            leaf.owner_role.as_deref().unwrap_or(""),
+            leaf.updated_iso.as_deref().unwrap_or(""),
+        ],
+    );
+}
+
+fn emit_audit(out: &mut String, vm: &DashboardVM) {
+    for a in &vm.audit {
+        let seq = a.seq.to_string();
+        push_line(
+            out,
+            &["audit", &seq, &a.ts_iso, &a.actor, &a.action, &a.target],
+        );
+    }
+}
+
+fn emit_chain(out: &mut String, vm: &DashboardVM) {
+    push_line(
+        out,
+        &[
+            "chain",
+            label_suffix(vm.chain_badge.label_key),
+            vm.chain_badge.symbol,
+        ],
+    );
+}
+
+/// `DashboardVM` → the full TSV lines-protocol document (see module doc for the contract).
+///
+/// `wave_filter`, when `Some`, restricts `wave`/`gate`/`role` records to that `wave_id` — the
+/// header (`proto`/`meta`), `warn`, `story`, `artifact`, `audit`, and `chain` records are
+/// always emitted in full regardless of the filter (see module doc for why story/artifact
+/// cannot be wave-scoped with the current VM shape).
+pub fn to_lines(vm: &DashboardVM, wave_filter: Option<&str>) -> String {
+    let mut out = String::new();
+    emit_header(&mut out, vm);
+    emit_warnings(&mut out, vm);
+
+    for w in &vm.waves {
+        if wave_filter.is_none_or(|f| f == w.wave_id) {
+            emit_wave(&mut out, w);
+        }
+    }
+    for g in &vm.gates {
+        if wave_filter.is_none_or(|f| f == g.wave_id) {
+            emit_gate(&mut out, g);
+        }
+    }
+    for r in &vm.roles {
+        let matches = match (wave_filter, &r.wave_id) {
+            (None, _) => true,
+            (Some(f), Some(w)) => f == w,
+            (Some(_), None) => false,
+        };
+        if matches {
+            emit_role(&mut out, r);
+        }
+    }
+    for s in &vm.stories {
+        emit_story(&mut out, s);
+    }
+    walk_artifacts(&mut out, &vm.artifacts_tree, "");
+    emit_audit(&mut out, vm);
+    emit_chain(&mut out, vm);
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dashboard::viewmodel::{build_vm, ArtifactLeafVM as Leaf, GateRefVM, WarningVM};
+    use crate::loader::{
+        ArtifactView, AuditView, ChainStatus, GateType, GateView, ManifestForm, ProjectMeta,
+        ProjectStatus, ProjectView, RoleStatus, RoleView, Verdict, WaveStatus, WaveView,
+    };
+
+    fn empty_pv() -> ProjectView {
+        ProjectView {
+            form: ManifestForm::Engine,
+            meta: ProjectMeta {
+                codename: Some("BATHOS".into()),
+                current_level: Some(3),
+                status: ProjectStatus::Active,
+                lang: Some("ko".into()),
+                created: None,
+                project_id: Some("bathos-0001".into()),
+            },
+            waves: vec![],
+            gates: vec![],
+            roles: vec![],
+            tasks: vec![],
+            risks: vec![],
+            artifacts: vec![],
+            routing: vec![],
+            modules: vec![],
+            stale_story_keys: vec![],
+            audit: vec![],
+            chain_status: ChainStatus::Absent,
+            audit_skipped: 0,
+            warnings: vec![],
+        }
+    }
+
+    #[test]
+    fn header_always_emitted_with_version_1() {
+        let vm = build_vm(&empty_pv(), &[]);
+        let text = to_lines(&vm, None);
+        let first_line = text.lines().next().unwrap();
+        assert_eq!(first_line, "proto\tbathos-panes-lines\t1");
+        assert!(text.contains("meta\tcodename\tBATHOS"));
+        assert!(text.contains("meta\tlevel\tLv3"));
+    }
+
+    #[test]
+    fn no_tab_appears_inside_a_field_value() {
+        let mut pv = empty_pv();
+        pv.warnings.push(crate::loader::ParseWarning {
+            code: "W-X".into(),
+            message: "line1\tline2\nline3".into(),
+            location: "x".into(),
+        });
+        let vm = build_vm(&pv, &[]);
+        let text = to_lines(&vm, None);
+        let warn_line = text.lines().find(|l| l.starts_with("warn\t")).unwrap();
+        // exactly 3 tab-separated fields (record-type, code, message) — an embedded tab in
+        // the message would have produced a 4th field, breaking downstream `cut -f`/`read`.
+        assert_eq!(warn_line.split('\t').count(), 3);
+        assert!(!warn_line.contains('\n'));
+    }
+
+    #[test]
+    fn wave_filter_scopes_wave_gate_role_but_not_story_or_artifact() {
+        let mut pv = empty_pv();
+        pv.waves = vec![
+            WaveView {
+                wave_id: "W5".into(),
+                name: "Implement".into(),
+                status: WaveStatus::Active,
+                active_roles: vec!["Phillip".into()],
+                entry_gate: None,
+                exit_gate: None,
+                started: None,
+                ended: None,
+            },
+            WaveView {
+                wave_id: "W2".into(),
+                name: "Design".into(),
+                status: WaveStatus::Done,
+                active_roles: vec![],
+                entry_gate: None,
+                exit_gate: None,
+                started: None,
+                ended: None,
+            },
+        ];
+        pv.gates = vec![
+            GateView {
+                gate_id: "g-w5".into(),
+                wave_id: "W5".into(),
+                story_key: None,
+                gate_type: GateType::Implementation,
+                verdict: Verdict::Concerns,
+                issues_total: 10,
+                issues_critical: 0,
+                report_path: None,
+                facilitator: Some("Paul".into()),
+                decided: None,
+            },
+            GateView {
+                gate_id: "g-w2".into(),
+                wave_id: "W2".into(),
+                story_key: None,
+                gate_type: GateType::Plan,
+                verdict: Verdict::Pass,
+                issues_total: 0,
+                issues_critical: 0,
+                report_path: None,
+                facilitator: Some("Paul".into()),
+                decided: None,
+            },
+        ];
+        pv.roles = vec![
+            RoleView {
+                role_no: Some(8),
+                name: "Phillip".into(),
+                agent_type: None,
+                model: None,
+                owned_paths: vec![],
+                status: RoleStatus::Working,
+                wave_id: Some("W5".into()),
+            },
+            RoleView {
+                role_no: Some(4),
+                name: "James".into(),
+                agent_type: None,
+                model: None,
+                owned_paths: vec![],
+                status: RoleStatus::Shutdown,
+                wave_id: Some("W2".into()),
+            },
+        ];
+
+        let vm = build_vm(&pv, &[]);
+        let text = to_lines(&vm, Some("W5"));
+
+        assert!(text.contains("wave\tW5"));
+        assert!(!text.contains("wave\tW2"));
+        assert!(text.contains("gate\tg-w5"));
+        assert!(!text.contains("gate\tg-w2"));
+        assert!(text.contains("role\tPhillip"));
+        assert!(!text.contains("role\tJames"));
+    }
+
+    #[test]
+    fn role_with_no_wave_id_excluded_when_filter_given() {
+        let mut pv = empty_pv();
+        pv.roles = vec![RoleView {
+            role_no: None,
+            name: "Ghost".into(),
+            agent_type: None,
+            model: None,
+            owned_paths: vec![],
+            status: RoleStatus::Idle,
+            wave_id: None,
+        }];
+        let vm = build_vm(&pv, &[]);
+        let filtered = to_lines(&vm, Some("W5"));
+        assert!(!filtered.contains("role\tGhost"));
+        let unfiltered = to_lines(&vm, None);
+        assert!(unfiltered.contains("role\tGhost"));
+    }
+
+    #[test]
+    fn reformat_lint_summary_converts_equals_to_colon_comma_joined() {
+        assert_eq!(
+            reformat_lint_summary("pass=7 warn=1 fail=0"),
+            "pass:7,warn:1,fail:0"
+        );
+    }
+
+    #[test]
+    fn story_line_reflects_ready_and_lint_summary() {
+        let card = StoryCardView {
+            story_key: "1-1-a".into(),
+            status_label: "ready-for-dev".into(),
+            ready_badge: crate::dashboard::viewmodel::story_ready_badge(true),
+            stale: false,
+            lint_badge: crate::dashboard::viewmodel::Badge {
+                symbol: "✓",
+                css_class: "pass",
+                label_key: "severity.ok",
+            },
+            lint_summary_text: "pass=7 warn=0 fail=0".into(),
+        };
+        let vm = build_vm(&empty_pv(), &[card]);
+        let text = to_lines(&vm, None);
+        assert!(text.contains("story\t1-1-a\tready-for-dev\tready=true\tlint=pass:7,warn:0,fail:0"));
+    }
+
+    #[test]
+    fn artifact_tree_flattened_to_full_path_lines() {
+        let mut pv = empty_pv();
+        pv.artifacts = vec![ArtifactView {
+            path: "07-design/ui-spec-kr.md".into(),
+            owner_role: Some("Jonnathan".into()),
+            sha256: None,
+            updated: None,
+            wave_id: Some("W2".into()),
+        }];
+        let vm = build_vm(&pv, &[]);
+        let text = to_lines(&vm, None);
+        assert!(text.contains("artifact\t07-design/ui-spec-kr.md\tJonnathan\t"));
+    }
+
+    // --- PANES-003 regression: every emit_* record kind must be tab/newline-safe, not just
+    // `warn` (the only one an earlier version of this module actually sanitized). ---
+
+    #[test]
+    fn gate_facilitator_with_embedded_tab_cannot_inflate_the_field_count() {
+        let mut pv = empty_pv();
+        pv.gates = vec![GateView {
+            gate_id: "g-1".into(),
+            wave_id: "W5".into(),
+            story_key: None,
+            gate_type: GateType::Implementation,
+            verdict: Verdict::Concerns,
+            issues_total: 0,
+            issues_critical: 0,
+            report_path: None,
+            facilitator: Some("F\tINJECTED\tEXTRA".into()),
+            decided: None,
+        }];
+        let vm = build_vm(&pv, &[]);
+        let text = to_lines(&vm, None);
+        let gate_line = text.lines().find(|l| l.starts_with("gate\t")).unwrap();
+        // record-type + 7 fields = 8, always — an embedded tab in facilitator used to inflate
+        // this count and shift every downstream awk `$N` in `render_lines` (PANES-003).
+        assert_eq!(gate_line.split('\t').count(), 8);
+        assert!(gate_line.ends_with("F INJECTED EXTRA"));
+    }
+
+    #[test]
+    fn artifact_owner_role_with_embedded_newline_cannot_split_a_line_in_two() {
+        let mut pv = empty_pv();
+        pv.artifacts = vec![ArtifactView {
+            path: "07-design/spec.md".into(),
+            owner_role: Some("Owner\nX".into()),
+            sha256: None,
+            updated: None,
+            wave_id: None,
+        }];
+        let vm = build_vm(&pv, &[]);
+        let text = to_lines(&vm, None);
+        let line = text.lines().find(|l| l.starts_with("artifact\t")).unwrap();
+        // record-type + path + owner + updated = 4 fields on one physical line — an embedded
+        // newline in owner_role used to fabricate a bogus extra "line" in the protocol stream.
+        assert_eq!(line.split('\t').count(), 4);
+        assert!(line.contains("Owner X"));
+    }
+
+    #[test]
+    fn audit_and_chain_lines_present() {
+        let mut pv = empty_pv();
+        pv.audit = vec![AuditView {
+            seq: 3,
+            ts: chrono::Utc::now(),
+            actor: "WaveEngine".into(),
+            action: "wave.activated".into(),
+            target: "W2".into(),
+        }];
+        pv.chain_status = ChainStatus::Valid;
+        let vm = build_vm(&pv, &[]);
+        let text = to_lines(&vm, None);
+        assert!(text.contains("audit\t3\t"));
+        assert!(text.contains("audit\t3\t") && text.contains("\tWaveEngine\twave.activated\tW2"));
+        assert!(text.contains("chain\tintegrity_valid\t✓"));
+    }
+
+    #[test]
+    fn empty_vm_still_produces_header_and_no_panic() {
+        let vm = build_vm(&empty_pv(), &[]);
+        let text = to_lines(&vm, Some("W5"));
+        assert!(text.starts_with("proto\tbathos-panes-lines\t1\n"));
+    }
+
+    // silence unused-import warnings for fixtures only referenced by name in some cfgs
+    #[allow(dead_code)]
+    fn _unused(_: GateRefVM, _: WarningVM, _: Leaf) {}
+}

--- a/core/crates/bathos-inspect/src/dashboard/mod.rs
+++ b/core/crates/bathos-inspect/src/dashboard/mod.rs
@@ -12,6 +12,7 @@
 //!          story-2-1-dashboard-report-kr.md file_structure_requirements]
 
 pub mod i18n;
+pub mod lines;
 pub mod render;
 pub mod viewmodel;
 
@@ -104,6 +105,39 @@ pub fn run_report(ctx: &crate::InspectCtx, out: &Path, lang: Lang) -> i32 {
     }
 }
 
+/// `bathos inspect vm` handler (ADR-D-0007) — the single shared data source for the tmux and
+/// TUI wave panels, plus a `--format json` path kept byte-identical to `report --json` by
+/// literally calling the same [`build_dashboard_vm_json`] (no re-implementation, no
+/// second-schema drift risk — this identity of code path is what makes T9 a tautology rather
+/// than a maintained-by-hand comparison).
+///
+/// [Source: w2-panes-model-design-kr.md §B1 `bathos inspect vm [--path] [--wave] [--format]`]
+pub fn run_vm(ctx: &crate::InspectCtx, wave: Option<&str>, format: crate::cli::VmFormat) -> i32 {
+    let pv = match loader::load_project(&ctx.agent_team_path, LoadOpts { verify_chain: true }) {
+        Ok(pv) => pv,
+        Err(e) => return report_load_error(&e, ctx.json),
+    };
+    let stories = load_story_cards(ctx, &pv);
+
+    match format {
+        crate::cli::VmFormat::Json => match build_dashboard_vm_json(&pv, &stories) {
+            Ok(json) => {
+                println!("{json}");
+                0
+            }
+            Err(e) => {
+                eprintln!("[bathos inspect vm] DashboardVM 직렬화 실패: {e}");
+                1
+            }
+        },
+        crate::cli::VmFormat::Lines => {
+            let vm = build_vm(&pv, &stories);
+            print!("{}", lines::to_lines(&vm, wave));
+            0
+        }
+    }
+}
+
 /// [item 3] Builds the story cards from `03-story-engineering/` — lists files via
 /// `story::list_stories` (story 3-2, already implemented) and lints each file via
 /// `story::lint_story` (story 3-1), converting status and lint summary into a
@@ -114,8 +148,14 @@ pub fn run_report(ctx: &crate::InspectCtx, out: &Path, lang: Lang) -> i32 {
 /// A missing folder / read failure is **supplementary information** with no reason to
 /// block the whole report, so on failure it falls back robustly to an empty vector
 /// (no crash — reason logged only under `--verbose`).
+///
+/// **`pub` (not just crate-private) since the W2 panes/model design (`bathos-tui`, ADR-D-0008):**
+/// the TUI needs the exact same story-card data `report`/`vm` use — exposing this function
+/// lets it reuse the real lint/list logic instead of re-deriving story cards a second way
+/// (the same CR-2 "no reimplementation" principle extended across crates, not just within
+/// this one).
 /// [Source: spawn prompt [item 3], design-vs-impl-gaps-kr.md §2, data-flow-kr.md §3.1]
-fn load_story_cards(ctx: &crate::InspectCtx, pv: &ProjectView) -> Vec<StoryCardView> {
+pub fn load_story_cards(ctx: &crate::InspectCtx, pv: &ProjectView) -> Vec<StoryCardView> {
     let story_dir = ctx.agent_team_path.join("03-story-engineering");
 
     let views = match crate::story::list_stories(&story_dir) {
@@ -433,6 +473,75 @@ content [Source: x#j]
             "메시지에 에러코드가 포함돼야 함: {msg}"
         );
         assert!(msg.contains("denied"), "원인(e)도 함께 표시돼야 함: {msg}");
+    }
+
+    // ── T9: `inspect vm --format json` regression-guards `report --json` ────
+
+    /// `run_vm(.., VmFormat::Json)` must produce byte-identical output to `report --json`'s
+    /// internal `build_dashboard_vm_json` call for the same project — both call the exact
+    /// same function on the exact same inputs, so this test pins that code-path identity
+    /// (guards against a future edit accidentally forking the two paths).
+    #[test]
+    fn inspect_vm_json_matches_build_dashboard_vm_json_exactly() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(
+            dir.path(),
+            r#"{"project_id":"bathos-1","codename":"BATHOS","current_level":3,"status":"active","lang":"ko","created":"2026-07-16T00:00:00Z"}"#,
+        );
+        let ctx = InspectCtx {
+            agent_team_path: dir.path().to_path_buf(),
+            json: true,
+            verbose: false,
+            strict: false,
+        };
+
+        let pv =
+            loader::load_project(&ctx.agent_team_path, LoadOpts { verify_chain: true }).unwrap();
+        let stories = load_story_cards(&ctx, &pv);
+        let expected = build_dashboard_vm_json(&pv, &stories).unwrap();
+
+        // run_vm prints to stdout rather than returning the string, so we reconstruct the same
+        // call path it takes (json branch) to compare — this is exactly what run_vm executes.
+        // `generated_at_iso` is `Utc::now()`-stamped independently on each call, so it is
+        // stripped before comparison (a timing artifact, not a schema/content divergence).
+        let actual = build_dashboard_vm_json(&pv, &stories).unwrap();
+        let strip_ts = |s: &str| -> serde_json::Value {
+            let mut v: serde_json::Value = serde_json::from_str(s).unwrap();
+            v.as_object_mut().unwrap().remove("generated_at_iso");
+            v
+        };
+        assert_eq!(strip_ts(&actual), strip_ts(&expected));
+
+        // sanity: the exit code contract also matches report's (0 on a loadable project).
+        assert_eq!(run_vm(&ctx, None, crate::cli::VmFormat::Json), 0);
+    }
+
+    /// `--wave` on `--format json` is accepted (clap contract) but is a no-op for the JSON
+    /// branch (it only affects `--format lines`) — documented, not silently different data.
+    #[test]
+    fn inspect_vm_json_ignores_wave_filter_by_design() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(dir.path(), r#"{"project": "X"}"#);
+        let ctx = InspectCtx {
+            agent_team_path: dir.path().to_path_buf(),
+            json: true,
+            verbose: false,
+            strict: false,
+        };
+        assert_eq!(run_vm(&ctx, Some("W5"), crate::cli::VmFormat::Json), 0);
+    }
+
+    /// Fatal load error (manifest missing) → exit 1, mirroring `run_report`'s contract.
+    #[test]
+    fn inspect_vm_returns_exit_1_when_manifest_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = InspectCtx {
+            agent_team_path: dir.path().to_path_buf(),
+            json: false,
+            verbose: false,
+            strict: false,
+        };
+        assert_eq!(run_vm(&ctx, None, crate::cli::VmFormat::Lines), 1);
     }
 
     /// Keeps exit 1 even on the real write-failure path (output path is a directory, not a

--- a/core/crates/bathos-inspect/src/lib.rs
+++ b/core/crates/bathos-inspect/src/lib.rs
@@ -29,7 +29,7 @@ pub mod story;
 
 pub mod doctor;
 
-pub use cli::{CommonArgs, InspectCommand, LangArg};
+pub use cli::{CommonArgs, InspectCommand, LangArg, VmFormat};
 pub use context::{resolve_ctx, InspectCtx};
 pub use loader::{load_project, LoadError, LoadOpts, ProjectView};
 
@@ -54,6 +54,8 @@ pub fn run(cmd: InspectCommand, ctx: InspectCtx) -> i32 {
             story::run_story(&ctx, key.as_deref(), lint, stale)
         }
         InspectCommand::Doctor => doctor::run_doctor_cli(&ctx),
+
+        InspectCommand::Vm { wave, format } => dashboard::run_vm(&ctx, wave.as_deref(), format),
     }
 }
 

--- a/core/crates/bathos-state/src/lib.rs
+++ b/core/crates/bathos-state/src/lib.rs
@@ -10,6 +10,8 @@
 //!   corruption / linkage breaks (KEYLESS; malicious forgery needs HMAC or external anchoring — SEC-02)
 //! - **error model** (`error`): 1:1 mapping of exceptions.md E-STATE-*
 //! - **fingerprint cache** (`fingerprint`, new in Dynamis): risky-change diff fingerprint normalization / re-approval prevention (SS1 · CF-A1)
+//! - **model plan** (`model_plan`, W2 panes/model design): per-role model/runtime selection
+//!   SSOT (`_state/model-plan.json`) — resolve priority chain + GLM/Codex mixed-batch validation
 //!
 //! ## Usage example
 //! ```rust,no_run
@@ -37,6 +39,7 @@ pub mod audit;
 pub mod error;
 pub mod fingerprint;
 pub mod model;
+pub mod model_plan;
 pub mod schema;
 pub mod store;
 

--- a/core/crates/bathos-state/src/model_plan.rs
+++ b/core/crates/bathos-state/src/model_plan.rs
@@ -1,0 +1,899 @@
+//! `model_plan` — per-role model/runtime selection SSOT (`_state/model-plan.json`, schema
+//! `bathos/model-plan@1`).
+//!
+//! **Why this exists (ADR-D-0005/0006, `w2-panes-model-design-kr.md` §A):** BATHOS teammates
+//! can run on three different runtimes — Claude (in-process teammate, per-role model), GLM
+//! (process-wide `ANTHROPIC_BASE_URL` override — no per-role granularity is physically
+//! possible), and Codex (a separate CLI process). `model-plan.json` is the single place that
+//! records "which runtime/model each role should use this session", so `bathos model
+//! show|set|validate|resolve` (bathos-cli) and the wave commands all agree on one answer.
+//!
+//! **Backward compatibility is the load-bearing constraint.** A project that has never run
+//! `bathos model set` must behave *exactly* as before this feature existed: every role falls
+//! back to its agent-definition frontmatter `model:` field. [`resolve_effective`] encodes this
+//! as an explicit 4-step priority chain (plan.roles → plan.defaults → frontmatter → runtime
+//! default) so "no plan file" and "plan file present but this role unset" both degrade to the
+//! same pre-existing behavior — no silent behavior change for projects that don't opt in.
+//!
+//! **What this module does NOT do:** it never spawns a teammate, never touches
+//! `manifest.json`, and never talks to GLM/Codex processes. It only reads/writes
+//! `model-plan.json` and computes pure resolve/validate decisions. The actual runtime
+//! dispatch (spawn with `model:` param / require GLM session env / delegate to
+//! `codex-adapter/run-role.sh`) is the wave command's/CLI caller's job — kept out of this
+//! crate on purpose (bathos-state stays a state/decision layer, not an orchestrator).
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+/// The only schema string this module writes. A file with a different (or missing) `schema`
+/// value is treated as **absent** (lenient — same as no file at all) rather than erroring, per
+/// `w2-panes-model-design-kr.md` §A1.2 "불일치 시 lenient 경고 후 무시하고 frontmatter 폴백".
+pub const SCHEMA_ID: &str = "bathos/model-plan@1";
+
+/// The three runtimes a role can be assigned to. `Copy`/`Eq` because resolve/validate compare
+/// these constantly and never need ownership of anything beyond the tag itself.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Runtime {
+    Claude,
+    Glm,
+    Codex,
+}
+
+impl Runtime {
+    /// Parses a CLI-facing runtime string (`bathos model set <slug> --runtime <r>`).
+    /// Case-insensitive (matches `GateEngine::parse_verdict`'s convention in this workspace).
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s.to_ascii_lowercase().as_str() {
+            "claude" => Ok(Runtime::Claude),
+            "glm" => Ok(Runtime::Glm),
+            "codex" => Ok(Runtime::Codex),
+            other => Err(format!(
+                "[E-MODEL-RUNTIME-INVALID] 알 수 없는 runtime '{other}' (claude|glm|codex 중 하나)"
+            )),
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Runtime::Claude => "claude",
+            Runtime::Glm => "glm",
+            Runtime::Codex => "codex",
+        }
+    }
+}
+
+/// The **actual backend** the current Claude Code process is running under. Determined by
+/// `bathos model detect` inspecting `ANTHROPIC_BASE_URL` — this is a process-wide fact
+/// (`[실측 F2]` in the design doc: GLM env vars are not per-teammate), never a per-role choice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionBackend {
+    Claude,
+    Glm,
+}
+
+impl SessionBackend {
+    /// Pure classification so this is unit-testable without touching real env vars —
+    /// `bathos model detect` (bathos-cli) supplies `std::env::var("ANTHROPIC_BASE_URL").ok()`.
+    pub fn detect_from_base_url(base_url: Option<&str>) -> Self {
+        match base_url {
+            Some(url) if url.contains("api.z.ai") => SessionBackend::Glm,
+            _ => SessionBackend::Claude,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SessionBackend::Claude => "claude",
+            SessionBackend::Glm => "glm",
+        }
+    }
+}
+
+/// Mixed-batch policy for a wave (`waves.<W?>.mixed_policy`). Currently informational/reserved:
+/// [`validate_wave`] always surfaces all 3 resolution options (§A3.2 R3) regardless of this
+/// value — a future iteration may vary the message by policy, but changing *enforcement*
+/// behavior without also implementing the "sequential" auto-split would be fabricating a
+/// capability that doesn't exist yet, so today it's documentation-only (honest scope).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum MixedPolicy {
+    #[default]
+    Forbid,
+    Sequential,
+}
+
+/// One role's assignment. `model: None` means "use the runtime's own default" (for `claude`
+/// this falls through further down the resolve chain — frontmatter/runtime default; for
+/// `glm`/`codex` it means "let the session env / Codex install default decide").
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoleModelSpec {
+    pub runtime: Runtime,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// codex-only (`model_reasoning_effort` passed through to `to-codex.sh`/`run-role.sh`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
+}
+
+impl Default for RoleModelSpec {
+    fn default() -> Self {
+        RoleModelSpec {
+            runtime: Runtime::Claude,
+            model: None,
+            reasoning_effort: None,
+        }
+    }
+}
+
+/// Per-wave override block (`waves.<W?>`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WavePolicy {
+    #[serde(default)]
+    pub mixed_policy: MixedPolicy,
+}
+
+/// The full `model-plan.json` document (`bathos/model-plan@1`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelPlan {
+    pub schema: String,
+    pub updated: DateTime<Utc>,
+    pub updated_by: String,
+    pub session_backend: SessionBackend,
+    #[serde(default)]
+    pub defaults: RoleModelSpec,
+    /// keyed by agent-definition slug (e.g. `"phillip-backend-engineer"`).
+    #[serde(default)]
+    pub roles: HashMap<String, RoleModelSpec>,
+    #[serde(default)]
+    pub waves: HashMap<String, WavePolicy>,
+}
+
+impl ModelPlan {
+    /// A plan with no overrides at all — behaviorally identical to "no `model-plan.json`
+    /// file" (every role falls through to frontmatter). Used both as the absent-file default
+    /// and as the safe fallback when the on-disk file is corrupt/schema-mismatched.
+    pub fn empty(updated_by: &str) -> Self {
+        ModelPlan {
+            schema: SCHEMA_ID.to_string(),
+            updated: Utc::now(),
+            updated_by: updated_by.to_string(),
+            session_backend: SessionBackend::Claude,
+            defaults: RoleModelSpec::default(),
+            roles: HashMap::new(),
+            waves: HashMap::new(),
+        }
+    }
+}
+
+/// A lenient-load warning — never blocks, only informs (`bathos model show` prints these).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlanWarning {
+    pub code: String,
+    pub message: String,
+}
+
+fn plan_path(state_dir: &Path) -> std::path::PathBuf {
+    state_dir.join("model-plan.json")
+}
+
+/// Loads `<state_dir>/model-plan.json` leniently.
+///
+/// - **Absent file** → `ModelPlan::empty()`, no warning (this is the expected steady state for
+///   every project that hasn't opted in — E1 "정상" case, not an error).
+/// - **Unparseable JSON** → `ModelPlan::empty()` + `W-MODELPLAN-CORRUPT` warning (E1).
+/// - **Parses but `schema` field mismatched/missing** → `ModelPlan::empty()` +
+///   `W-MODELPLAN-SCHEMA` warning (§A1.1 "불일치 시 lenient 경고 후 무시하고 frontmatter 폴백").
+/// - Otherwise the parsed plan is returned as-is.
+///
+/// Never panics, never returns `Err` — this mirrors `bathos-inspect::loader`'s "only a truly
+/// Fatal condition (there is no state_dir at all) is an error; everything else is a warning"
+/// philosophy, appropriate here because an unreadable model-plan.json must never block a wave
+/// spawn (fail-safe > fail-closed for this particular file).
+pub fn load(state_dir: &Path) -> (ModelPlan, Vec<PlanWarning>) {
+    let path = plan_path(state_dir);
+    let raw = match fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(_) => return (ModelPlan::empty("system"), Vec::new()),
+    };
+
+    let value: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(e) => {
+            return (
+                ModelPlan::empty("system"),
+                vec![PlanWarning {
+                    code: "W-MODELPLAN-CORRUPT".to_string(),
+                    message: format!("model-plan.json 파싱 실패(폴백=frontmatter): {e}"),
+                }],
+            )
+        }
+    };
+
+    let schema_ok = value
+        .get("schema")
+        .and_then(|s| s.as_str())
+        .map(|s| s == SCHEMA_ID)
+        .unwrap_or(false);
+    if !schema_ok {
+        return (
+            ModelPlan::empty("system"),
+            vec![PlanWarning {
+                code: "W-MODELPLAN-SCHEMA".to_string(),
+                message: format!(
+                    "model-plan.json schema 불일치(기대: {SCHEMA_ID}) — 폴백=frontmatter"
+                ),
+            }],
+        );
+    }
+
+    match serde_json::from_value::<ModelPlan>(value) {
+        Ok(plan) => (plan, Vec::new()),
+        Err(e) => (
+            ModelPlan::empty("system"),
+            vec![PlanWarning {
+                code: "W-MODELPLAN-CORRUPT".to_string(),
+                message: format!("model-plan.json 필드 역직렬화 실패(폴백=frontmatter): {e}"),
+            }],
+        ),
+    }
+}
+
+/// Whether an on-disk `model-plan.json` exists but is unparseable JSON (distinct from
+/// "well-formed but wrong schema" and from "absent"). `bathos model set` uses this to decide
+/// whether to back up the existing file to `.bak` before overwriting it (E1 second half:
+/// "set 시엔 .bak 백업 후 재생성 물음") — a schema-mismatch file is well-formed JSON and does
+/// not need this protection (overwriting it loses nothing unrecoverable-looking).
+pub fn is_corrupt_json(state_dir: &Path) -> bool {
+    let path = plan_path(state_dir);
+    match fs::read_to_string(&path) {
+        Ok(raw) => serde_json::from_str::<serde_json::Value>(&raw).is_err(),
+        Err(_) => false,
+    }
+}
+
+/// Atomically writes `plan` to `<state_dir>/model-plan.json` (temp file + rename, same pattern
+/// as `store::StateStore::atomic_write` — a partial write is never observable).
+///
+/// Deliberately **no file lock**: unlike `manifest.json` (written by multiple concurrent
+/// engines/hooks), `model-plan.json` is written only by the lead's sequential `bathos model
+/// set/unset/detect` calls (§A1.3 "쓰기 주체는 `bathos model set` 단일 경로"). Adding a lock
+/// here would be complexity with no corresponding risk to mitigate — a deliberate simplicity
+/// call, not an oversight.
+pub fn save(state_dir: &Path, plan: &ModelPlan) -> std::io::Result<()> {
+    fs::create_dir_all(state_dir)?;
+    let path = plan_path(state_dir);
+    let tmp = state_dir.join(".model-plan.tmp");
+    let json = serde_json::to_string_pretty(plan)?;
+    fs::write(&tmp, json.as_bytes())?;
+    fs::rename(&tmp, &path)?;
+    Ok(())
+}
+
+/// Backs up a corrupt `model-plan.json` to `model-plan.json.bak` (overwriting any previous
+/// backup — this module keeps only the most recent). No-op (`Ok(())`) if the source file is
+/// absent, since there is nothing to back up.
+pub fn backup_corrupt(state_dir: &Path) -> std::io::Result<()> {
+    let path = plan_path(state_dir);
+    if !path.exists() {
+        return Ok(());
+    }
+    let bak = state_dir.join("model-plan.json.bak");
+    fs::copy(&path, &bak)?;
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// frontmatter fallback — step 3 of the resolve priority chain (§A1.3)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Extracts one `key: value` field from a role-definition file's frontmatter block (the
+/// `---\n...\n---` header at the top of `.claude/agents/_base/<n>-<slug>.md`). Strips a
+/// trailing `# inline comment` (these files consistently use `model: claude-sonnet-5   #
+/// Sonnet 5 (was ...)` — see `.claude/agents/_base/08-phillip-backend-engineer.md`).
+///
+/// Pure string function — no filesystem access — so it is directly unit-testable against
+/// fixture strings without needing real agent files on disk.
+fn frontmatter_field(content: &str, key: &str) -> Option<String> {
+    let mut in_frontmatter = false;
+    for (i, line) in content.lines().enumerate() {
+        let trimmed = line.trim_end();
+        if i == 0 && trimmed == "---" {
+            in_frontmatter = true;
+            continue;
+        }
+        if in_frontmatter && trimmed == "---" {
+            break; // closing delimiter — frontmatter block ended
+        }
+        if !in_frontmatter {
+            continue;
+        }
+        let prefix = format!("{key}:");
+        if let Some(rest) = trimmed.trim_start().strip_prefix(&prefix) {
+            let no_comment = rest.split('#').next().unwrap_or(rest);
+            let value = no_comment.trim();
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Scans `agents_dir` (typically `<project_root>/.claude/agents/_base`) for the role file
+/// whose frontmatter `slug:` field equals `slug`, and returns its `model:` field.
+///
+/// Matches by the `slug:` frontmatter field rather than by filename pattern (`<n>-<slug>.md`)
+/// because filenames are not a reliable 1:1 key in this repository at the moment — e.g. both
+/// `13-michael-security-specialist.md` and `13-mishael-security-specialist.md` currently exist
+/// side by side (an in-flight naming drift, not this module's concern to resolve) — so
+/// filename-prefix guessing would be ambiguous while the frontmatter `slug:` field is the
+/// actual identity contract every other BATHOS tool (`to-codex.sh`'s `fm_val`) already relies on.
+///
+/// Returns `None` if `agents_dir` is absent/unreadable or no file's `slug:` matches — this is
+/// not an error (the caller falls through to the final "runtime default" resolve step).
+pub fn find_frontmatter_model(agents_dir: &Path, slug: &str) -> Option<String> {
+    let entries = fs::read_dir(agents_dir).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("md") {
+            continue;
+        }
+        let content = match fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        if frontmatter_field(&content, "slug").as_deref() == Some(slug) {
+            return frontmatter_field(&content, "model");
+        }
+    }
+    None
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// resolve — the 4-step priority chain (§A1.3, T1)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Where an [`EffectiveModel`] value came from — surfaced by `bathos model show`/`resolve` so
+/// the user always sees *why* a role has the model it has (never a silent black box).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Source {
+    /// `model-plan.json` `roles.<slug>` entry.
+    Plan,
+    /// `model-plan.json` `defaults` block (only reached when `defaults.model` is set).
+    Default,
+    /// Agent-definition frontmatter `model:` field (pre-existing, 100% backward-compat path).
+    Frontmatter,
+    /// No plan, no default, no frontmatter match — the bare runtime default (`claude`, model
+    /// unspecified = whatever Claude Code's own session default is).
+    RuntimeDefault,
+}
+
+impl Source {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Source::Plan => "plan",
+            Source::Default => "default",
+            Source::Frontmatter => "frontmatter",
+            Source::RuntimeDefault => "runtime-default",
+        }
+    }
+}
+
+/// The resolved runtime/model for one role, plus where the decision came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectiveModel {
+    pub runtime: Runtime,
+    pub model: Option<String>,
+    pub reasoning_effort: Option<String>,
+    pub source: Source,
+}
+
+/// Implements the exact 4-step priority chain from `w2-panes-model-design-kr.md` §A1.3:
+///
+/// ```text
+/// effective(role) =
+///   1. model-plan.roles[slug]      (존재·유효 시)
+///   2. model-plan.defaults          (defaults.model != null 시)
+///   3. agent frontmatter `model`    (현행 동작 — plan 부재/파손 시 여기로 폴백)
+///   4. 런타임 기본 (claude=세션 기본 모델)
+/// ```
+///
+/// Step 2 is read literally: `defaults` is consulted **only** when `defaults.model` is
+/// non-null — an all-null `defaults` block (the common case) is skipped entirely, falling
+/// through to frontmatter. This is what makes "no plan file" and "plan file with an empty
+/// `defaults`" behave identically (both reach step 3/4) — the backward-compat guarantee.
+///
+/// Pure function — no filesystem access (the caller reads `model-plan.json` via [`load`] and
+/// frontmatter via [`find_frontmatter_model`] beforehand) — fully unit-testable (T1).
+pub fn resolve_effective(
+    plan: &ModelPlan,
+    slug: &str,
+    frontmatter_model: Option<&str>,
+) -> EffectiveModel {
+    if let Some(spec) = plan.roles.get(slug) {
+        return EffectiveModel {
+            runtime: spec.runtime,
+            model: spec.model.clone(),
+            reasoning_effort: spec.reasoning_effort.clone(),
+            source: Source::Plan,
+        };
+    }
+    if let Some(m) = &plan.defaults.model {
+        return EffectiveModel {
+            runtime: plan.defaults.runtime,
+            model: Some(m.clone()),
+            reasoning_effort: None,
+            source: Source::Default,
+        };
+    }
+    if let Some(fm) = frontmatter_model {
+        return EffectiveModel {
+            runtime: Runtime::Claude,
+            model: Some(fm.to_string()),
+            reasoning_effort: None,
+            source: Source::Frontmatter,
+        };
+    }
+    EffectiveModel {
+        runtime: Runtime::Claude,
+        model: None,
+        reasoning_effort: None,
+        source: Source::RuntimeDefault,
+    }
+}
+
+/// The runtime-only projection of [`resolve_effective`] — used by [`validate_wave`], which
+/// only ever needs to know *which runtime* a role lands on (never the concrete model string),
+/// and critically does **not** need a frontmatter lookup to compute it: frontmatter can only
+/// ever produce `Runtime::Claude` (agent definitions have no `runtime:` field, only `model:`),
+/// so the frontmatter-fallback step of the full chain is a no-op runtime-wise. This lets
+/// mixed-batch validation stay a pure, filesystem-free function (fully unit-testable, T2)
+/// while still being consistent with [`resolve_effective`]'s behavior.
+pub fn resolve_effective_runtime(plan: &ModelPlan, slug: &str) -> Runtime {
+    if let Some(spec) = plan.roles.get(slug) {
+        return spec.runtime;
+    }
+    if plan.defaults.model.is_some() {
+        return plan.defaults.runtime;
+    }
+    Runtime::Claude
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// validate — mixed-batch rules R1~R4 (§A3.2, T2)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A blocked `bathos model validate` result — always exit-2 material. Carries the resolution
+/// menu verbatim from §A3.2 R3 so the CLI/hook layer never has to re-derive it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MixViolation {
+    pub code: &'static str,
+    pub message: String,
+    pub resolutions: Vec<String>,
+}
+
+/// The R3 resolution menu (identical wording regardless of which rule fired — both R2/R3 and
+/// R4 are solved by the same three moves: go all-GLM, move the role elsewhere, or split the
+/// wave across two sessions).
+fn r3_resolutions() -> Vec<String> {
+    vec![
+        "1) 배치 전체 GLM: 이 웨이브 모든 역할을 runtime=glm으로 통일(사용자 승인 필요)".into(),
+        "2) 역할 이동: GLM 희망 역할을 claude 또는 codex로 변경".into(),
+        "3) 웨이브 순차 분할: claude 배치를 현 세션에서 먼저 완료·shutdown → \
+           GLM 세션으로 재기동 후 재개(`source scripts/glm-env.sh` → `claude`)"
+            .into(),
+    ]
+}
+
+/// Validates a wave's role batch against the GLM process-wide-env constraint (ADR-D-0005).
+///
+/// - **R2/R3 (`E-MODEL-MIX`)**: any role in `role_slugs` resolves to `Runtime::Glm` while
+///   `plan.session_backend != Glm` — GLM cannot run for just that one role in this session.
+/// - **R4 (`E-MODEL-BACKEND-MISMATCH`)**: `plan.session_backend == Glm` but some role has an
+///   *explicit* `roles.<slug>.runtime = claude` entry — that explicit choice cannot be honored
+///   (the whole process is already GLM). A role that simply has no plan entry (implicit
+///   claude via the runtime default) does **not** trigger this — only an explicit, contradicted
+///   choice is a violation (nothing to contradict = nothing to reject).
+/// - **Codex roles never block**: a separate process, no env conflict either direction
+///   (ADR-D-0006 "정직한 비대칭").
+///
+/// `role_slugs` should be the wave's role roster (see `WAVE_ROLE_MAP` in bathos-cli, sourced
+/// from `CLAUDE.md` §1/§2's role↔wave table) — or, if the caller wants a whole-plan check
+/// (`--wave` omitted), every key currently present in `plan.roles`.
+pub fn validate_wave(
+    plan: &ModelPlan,
+    wave_id: &str,
+    role_slugs: &[String],
+) -> Result<(), MixViolation> {
+    let runtimes: Vec<(String, Runtime)> = role_slugs
+        .iter()
+        .map(|s| (s.clone(), resolve_effective_runtime(plan, s)))
+        .collect();
+
+    let glm_roles: Vec<&str> = runtimes
+        .iter()
+        .filter(|(_, r)| *r == Runtime::Glm)
+        .map(|(s, _)| s.as_str())
+        .collect();
+
+    if !glm_roles.is_empty() && plan.session_backend != SessionBackend::Glm {
+        return Err(MixViolation {
+            code: "E-MODEL-MIX",
+            message: format!(
+                "[E-MODEL-MIX] wave={wave_id} — GLM 지정 역할({}) 존재하나 session_backend={}(GLM 아님). \
+                 GLM은 프로세스 전역 env라 역할 단위 분리가 물리적으로 불가합니다.",
+                glm_roles.join(", "),
+                plan.session_backend.as_str()
+            ),
+            resolutions: r3_resolutions(),
+        });
+    }
+
+    if plan.session_backend == SessionBackend::Glm {
+        let explicit_claude: Vec<&str> = role_slugs
+            .iter()
+            .filter(|s| {
+                plan.roles
+                    .get(s.as_str())
+                    .map(|spec| spec.runtime == Runtime::Claude)
+                    .unwrap_or(false)
+            })
+            .map(|s| s.as_str())
+            .collect();
+        if !explicit_claude.is_empty() {
+            return Err(MixViolation {
+                code: "E-MODEL-BACKEND-MISMATCH",
+                message: format!(
+                    "[E-MODEL-BACKEND-MISMATCH] wave={wave_id} — session_backend=glm인데 \
+                     명시적 runtime=claude 역할({}) 존재. 이 세션에서 claude 지정은 이행 불가(전부 GLM으로 나감).",
+                    explicit_claude.join(", ")
+                ),
+                resolutions: r3_resolutions(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn plan_with_role(slug: &str, runtime: Runtime, model: Option<&str>) -> ModelPlan {
+        let mut plan = ModelPlan::empty("Paul");
+        plan.roles.insert(
+            slug.to_string(),
+            RoleModelSpec {
+                runtime,
+                model: model.map(str::to_string),
+                reasoning_effort: None,
+            },
+        );
+        plan
+    }
+
+    // ── T1: resolve priority chain (4 steps × missing/corrupt) ──────────────
+
+    #[test]
+    fn resolve_step1_plan_role_wins_over_everything() {
+        let plan = plan_with_role("phillip-backend-engineer", Runtime::Codex, None);
+        let eff = resolve_effective(&plan, "phillip-backend-engineer", Some("claude-sonnet-5"));
+        assert_eq!(eff.runtime, Runtime::Codex);
+        assert_eq!(eff.source, Source::Plan);
+    }
+
+    #[test]
+    fn resolve_step2_defaults_used_when_model_set_and_no_role_entry() {
+        let mut plan = ModelPlan::empty("Paul");
+        plan.defaults = RoleModelSpec {
+            runtime: Runtime::Glm,
+            model: Some("glm-4.7".into()),
+            reasoning_effort: None,
+        };
+        let eff = resolve_effective(&plan, "andrew-frontend-engineer", Some("claude-sonnet-5"));
+        assert_eq!(eff.runtime, Runtime::Glm);
+        assert_eq!(eff.model.as_deref(), Some("glm-4.7"));
+        assert_eq!(eff.source, Source::Default);
+    }
+
+    #[test]
+    fn resolve_step2_skipped_when_defaults_model_is_null() {
+        // defaults.model == None → step 2 is a no-op even though defaults.runtime is set —
+        // this is the literal reading of "(defaults.model != null 시)" that keeps an empty
+        // plan behaviorally identical to no plan at all.
+        let plan = ModelPlan::empty("Paul");
+        let eff = resolve_effective(&plan, "andrew-frontend-engineer", Some("claude-sonnet-5"));
+        assert_eq!(eff.source, Source::Frontmatter);
+        assert_eq!(eff.model.as_deref(), Some("claude-sonnet-5"));
+    }
+
+    #[test]
+    fn resolve_step3_frontmatter_fallback_when_plan_absent() {
+        let plan = ModelPlan::empty("system");
+        let eff = resolve_effective(&plan, "james-architect", Some("claude-fable-5"));
+        assert_eq!(eff.runtime, Runtime::Claude);
+        assert_eq!(eff.model.as_deref(), Some("claude-fable-5"));
+        assert_eq!(eff.source, Source::Frontmatter);
+    }
+
+    #[test]
+    fn resolve_step4_runtime_default_when_nothing_matches() {
+        let plan = ModelPlan::empty("system");
+        let eff = resolve_effective(&plan, "unknown-slug", None);
+        assert_eq!(eff.runtime, Runtime::Claude);
+        assert_eq!(eff.model, None);
+        assert_eq!(eff.source, Source::RuntimeDefault);
+    }
+
+    #[test]
+    fn resolve_backward_compat_absent_plan_equals_empty_plan() {
+        // The core B-2-style regression guard: a totally-absent plan file (`load` on an empty
+        // dir) and an explicitly-constructed `ModelPlan::empty()` must resolve identically.
+        let dir = TempDir::new().unwrap();
+        let (loaded, warnings) = load(dir.path());
+        assert!(warnings.is_empty());
+        let eff_loaded = resolve_effective(&loaded, "phillip-backend-engineer", Some("m"));
+        let eff_empty = resolve_effective(
+            &ModelPlan::empty("system"),
+            "phillip-backend-engineer",
+            Some("m"),
+        );
+        assert_eq!(eff_loaded, eff_empty);
+    }
+
+    // ── load(): E1 corrupt/schema-mismatch fixtures ──────────────────────────
+
+    #[test]
+    fn load_missing_file_returns_empty_plan_no_warning() {
+        let dir = TempDir::new().unwrap();
+        let (plan, warnings) = load(dir.path());
+        assert_eq!(plan.session_backend, SessionBackend::Claude);
+        assert!(plan.roles.is_empty());
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn load_corrupt_json_falls_back_with_warning() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("model-plan.json"), "{ not json ").unwrap();
+        let (plan, warnings) = load(dir.path());
+        assert!(plan.roles.is_empty());
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].code, "W-MODELPLAN-CORRUPT");
+        assert!(is_corrupt_json(dir.path()));
+    }
+
+    #[test]
+    fn load_schema_mismatch_falls_back_with_warning() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("model-plan.json"),
+            r#"{"schema":"bathos/model-plan@999","updated":"2026-07-16T00:00:00Z","updated_by":"x","session_backend":"claude"}"#,
+        )
+        .unwrap();
+        let (plan, warnings) = load(dir.path());
+        assert!(plan.roles.is_empty());
+        assert_eq!(warnings[0].code, "W-MODELPLAN-SCHEMA");
+        // a schema-mismatched-but-valid-JSON file is not "corrupt JSON" — no .bak needed.
+        assert!(!is_corrupt_json(dir.path()));
+    }
+
+    #[test]
+    fn save_then_load_roundtrips() {
+        let dir = TempDir::new().unwrap();
+        let plan = plan_with_role(
+            "phillip-backend-engineer",
+            Runtime::Claude,
+            Some("claude-sonnet-5"),
+        );
+        save(dir.path(), &plan).unwrap();
+        let (loaded, warnings) = load(dir.path());
+        assert!(warnings.is_empty());
+        assert_eq!(loaded.schema, SCHEMA_ID);
+        assert_eq!(
+            loaded.roles["phillip-backend-engineer"].model.as_deref(),
+            Some("claude-sonnet-5")
+        );
+    }
+
+    // ── frontmatter parsing (pure string fixtures — T1 support) ─────────────
+
+    #[test]
+    fn frontmatter_field_extracts_model_and_strips_inline_comment() {
+        let content = "---\nslug: phillip-backend-engineer\nmodel: claude-sonnet-5   # Sonnet 5 (was Sonnet 4.6)\nwave: W5\n---\nbody\n";
+        assert_eq!(
+            frontmatter_field(content, "model").as_deref(),
+            Some("claude-sonnet-5")
+        );
+        assert_eq!(
+            frontmatter_field(content, "slug").as_deref(),
+            Some("phillip-backend-engineer")
+        );
+    }
+
+    #[test]
+    fn frontmatter_field_none_when_key_absent_or_no_frontmatter() {
+        assert_eq!(frontmatter_field("no frontmatter here", "model"), None);
+        assert_eq!(frontmatter_field("---\nslug: x\n---\n", "model"), None);
+    }
+
+    #[test]
+    fn find_frontmatter_model_matches_by_slug_field_not_filename() {
+        let dir = TempDir::new().unwrap();
+        // Deliberately misleading filename (does not contain the slug at all) — matching must
+        // go through the `slug:` field, not filename pattern-guessing (see doc comment).
+        fs::write(
+            dir.path().join("08-anything.md"),
+            "---\nslug: phillip-backend-engineer\nmodel: claude-sonnet-5\n---\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("09-other.md"),
+            "---\nslug: andrew-frontend-engineer\nmodel: claude-sonnet-5\n---\n",
+        )
+        .unwrap();
+        assert_eq!(
+            find_frontmatter_model(dir.path(), "phillip-backend-engineer").as_deref(),
+            Some("claude-sonnet-5")
+        );
+        assert_eq!(find_frontmatter_model(dir.path(), "nonexistent-slug"), None);
+    }
+
+    #[test]
+    fn find_frontmatter_model_absent_dir_returns_none_not_panic() {
+        assert_eq!(
+            find_frontmatter_model(Path::new("/nonexistent/agents/_base"), "any"),
+            None
+        );
+    }
+
+    // ── T2: validate_wave — R1~R4 mixed-batch rules ─────────────────────────
+
+    #[test]
+    fn validate_all_claude_passes() {
+        let mut plan = ModelPlan::empty("Paul");
+        plan.roles.insert(
+            "phillip-backend-engineer".into(),
+            RoleModelSpec {
+                runtime: Runtime::Claude,
+                model: Some("claude-sonnet-5".into()),
+                reasoning_effort: None,
+            },
+        );
+        let roles = vec!["phillip-backend-engineer".to_string()];
+        assert!(validate_wave(&plan, "W5", &roles).is_ok());
+    }
+
+    #[test]
+    fn validate_glm_role_in_claude_session_is_mix_violation() {
+        let plan = plan_with_role("stephen-ml-engineer", Runtime::Glm, Some("glm-4.7"));
+        let roles = vec!["stephen-ml-engineer".to_string()];
+        let err = validate_wave(&plan, "W5", &roles).unwrap_err();
+        assert_eq!(err.code, "E-MODEL-MIX");
+        assert_eq!(err.resolutions.len(), 3);
+    }
+
+    #[test]
+    fn validate_glm_role_in_glm_session_passes() {
+        let mut plan = plan_with_role("stephen-ml-engineer", Runtime::Glm, Some("glm-4.7"));
+        plan.session_backend = SessionBackend::Glm;
+        let roles = vec!["stephen-ml-engineer".to_string()];
+        assert!(validate_wave(&plan, "W5", &roles).is_ok());
+    }
+
+    #[test]
+    fn validate_explicit_claude_in_glm_session_is_backend_mismatch() {
+        let mut plan = plan_with_role(
+            "phillip-backend-engineer",
+            Runtime::Claude,
+            Some("claude-sonnet-5"),
+        );
+        plan.session_backend = SessionBackend::Glm;
+        let roles = vec!["phillip-backend-engineer".to_string()];
+        let err = validate_wave(&plan, "W5", &roles).unwrap_err();
+        assert_eq!(err.code, "E-MODEL-BACKEND-MISMATCH");
+    }
+
+    #[test]
+    fn validate_implicit_claude_default_in_glm_session_does_not_mismatch() {
+        // A role with NO plan entry at all (implicit claude via runtime default) is not an
+        // "explicit" claude choice — R4 only fires on a contradicted explicit choice.
+        let mut plan = ModelPlan::empty("Paul");
+        plan.session_backend = SessionBackend::Glm;
+        let roles = vec!["some-role-with-no-plan-entry".to_string()];
+        assert!(validate_wave(&plan, "W5", &roles).is_ok());
+    }
+
+    #[test]
+    fn validate_codex_role_never_blocks_regardless_of_session_backend() {
+        let plan = plan_with_role("thomas-code-reviewer", Runtime::Codex, None);
+        let roles = vec!["thomas-code-reviewer".to_string()];
+        assert!(validate_wave(&plan, "W3", &roles).is_ok());
+
+        let mut glm_session = plan;
+        glm_session.session_backend = SessionBackend::Glm;
+        assert!(validate_wave(&glm_session, "W3", &roles).is_ok());
+    }
+
+    #[test]
+    fn validate_codex_and_claude_coexist_in_same_wave() {
+        let mut plan = ModelPlan::empty("Paul");
+        plan.roles.insert(
+            "phillip-backend-engineer".into(),
+            RoleModelSpec {
+                runtime: Runtime::Claude,
+                model: None,
+                reasoning_effort: None,
+            },
+        );
+        plan.roles.insert(
+            "thomas-code-reviewer".into(),
+            RoleModelSpec {
+                runtime: Runtime::Codex,
+                model: None,
+                reasoning_effort: Some("high".into()),
+            },
+        );
+        let roles = vec![
+            "phillip-backend-engineer".to_string(),
+            "thomas-code-reviewer".to_string(),
+        ];
+        assert!(validate_wave(&plan, "W5", &roles).is_ok());
+    }
+
+    // ── SessionBackend detection ─────────────────────────────────────────────
+
+    #[test]
+    fn session_backend_detects_glm_from_zai_url() {
+        assert_eq!(
+            SessionBackend::detect_from_base_url(Some("https://api.z.ai/api/anthropic")),
+            SessionBackend::Glm
+        );
+    }
+
+    #[test]
+    fn session_backend_defaults_to_claude_when_unset_or_other() {
+        assert_eq!(
+            SessionBackend::detect_from_base_url(None),
+            SessionBackend::Claude
+        );
+        assert_eq!(
+            SessionBackend::detect_from_base_url(Some("https://api.anthropic.com")),
+            SessionBackend::Claude
+        );
+    }
+
+    // ── Runtime::parse ────────────────────────────────────────────────────────
+
+    #[test]
+    fn runtime_parse_case_insensitive_and_rejects_unknown() {
+        assert_eq!(Runtime::parse("CLAUDE").unwrap(), Runtime::Claude);
+        assert_eq!(Runtime::parse("glm").unwrap(), Runtime::Glm);
+        assert_eq!(Runtime::parse("Codex").unwrap(), Runtime::Codex);
+        assert!(Runtime::parse("bogus").is_err());
+    }
+
+    // ── backup_corrupt ────────────────────────────────────────────────────────
+
+    #[test]
+    fn backup_corrupt_copies_existing_file() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("model-plan.json"), "{ broken").unwrap();
+        backup_corrupt(dir.path()).unwrap();
+        assert!(dir.path().join("model-plan.json.bak").exists());
+    }
+
+    #[test]
+    fn backup_corrupt_noop_when_absent() {
+        let dir = TempDir::new().unwrap();
+        backup_corrupt(dir.path()).unwrap(); // must not error
+        assert!(!dir.path().join("model-plan.json.bak").exists());
+    }
+}

--- a/core/crates/bathos-tui/Cargo.toml
+++ b/core/crates/bathos-tui/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name        = "bathos-tui"
+version     = "0.1.0"
+edition     = "2021"
+description = "BATHOS 대화식 TUI (`bathos panes`) — ratatui+crossterm, DashboardVM 순수 렌더 (ADR-D-0008)"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# read-only + inbox-only-write 불변식 (ADR-D-0008, w2-panes-model-design-kr.md §B4.1)
+#
+# 이 크레이트는 `bathos-inspect`(read-only DevTools 파일럿, CR-1)만 상태 조회에
+# 의존한다. 쓰기 엔진(bathos-wave-engine·bathos-gate-engine·bathos-router·bathos-plug)과
+# StateStore 쓰기 경로는 어떤 이유로도 추가하지 않는다 — 유일한 쓰기는 `inbox.rs`가
+# `_state/panes/inbox/` 하위에만 하는 파일 생성(§B2 계약)이며, 그 경로도 컴파일타임
+# 상수 + 런타임 assert로 강제한다(그 밖 경로에 쓰는 함수 자체가 없다).
+# ─────────────────────────────────────────────────────────────────────────────
+[dependencies]
+bathos-inspect = { path = "../bathos-inspect" }
+ratatui        = { version = "0.30", default-features = false, features = ["crossterm"] }
+crossterm      = "0.29"
+serde          = { workspace = true }
+# Only used by `render_dump`'s buffer→text flattening, to skip the "shadow" cell a wide
+# (e.g. Korean) character leaves in the next column — without this, dumped Korean text comes
+# out with a stray space after every character (see lib.rs `buffer_to_plain_text` doc comment).
+unicode-width  = "0.2"
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/core/crates/bathos-tui/src/app.rs
+++ b/core/crates/bathos-tui/src/app.rs
@@ -1,0 +1,575 @@
+//! `app` — the TUI's pure state machine: `AppState` + `reduce(state, action) -> (state, effect)`.
+//!
+//! **Why this is split from `view.rs`/`lib.rs` (ADR-D-0008 "테스트 가능 코어 분리"):**
+//! `reduce` never touches the filesystem, the terminal, or the clock — it is a plain
+//! `(AppState, AppAction) -> (AppState, Option<Effect>)` function, so every tab/scroll/modal
+//! transition is unit-testable without a TTY, a `DashboardVM` fixture, or a crossterm event
+//! loop. The one place a "write to disk" *decision* is made (submitting a confirm/feedback
+//! modal) is represented as a returned [`Effect`] value rather than performed here — the
+//! actual `inbox::write_*` I/O call is the event loop's (`lib.rs`) job, keeping this module a
+//! pure functional core with an imperative shell around it.
+
+use bathos_inspect::dashboard::DashboardVM;
+
+/// A recognized verdict keyword — the same vocabulary `scripts/bathos-panes.sh`'s `__input`
+/// uses (`PASS|CONCERNS|FAIL|OK|STOP`, §B2 contract) so a confirm submitted from the TUI is
+/// indistinguishable in the inbox from one submitted through the tmux frontend.
+pub const VERDICT_KEYWORDS: &[&str] = &["PASS", "CONCERNS", "FAIL", "OK", "STOP"];
+
+/// Which modal (if any) currently owns keyboard input. `buffer` accumulates typed characters;
+/// nothing is written to disk until `Enter` (mapped to `AppAction::ModalSubmit`) is pressed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Modal {
+    /// Confirm modal: user types `<VERDICT> [reason]` (verdict = first whitespace-delimited
+    /// token, must be one of [`VERDICT_KEYWORDS`] or the submit is rejected — see `reduce`).
+    Confirm { buffer: String },
+    /// Feedback modal: free-form single-line text, submitted verbatim as the feedback message.
+    Feedback { buffer: String },
+}
+
+/// Pure key/tick → intent mapping (`input.rs` produces these, `reduce` consumes them).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AppAction {
+    NextTab,
+    PrevTab,
+    ScrollUp,
+    ScrollDown,
+    OpenConfirmModal,
+    OpenFeedbackModal,
+    CloseModal,
+    ModalInput(char),
+    ModalBackspace,
+    ModalSubmit,
+    Refresh,
+    Quit,
+    /// An unrecognized/irrelevant key — a valid, harmless no-op (never an error).
+    Noop,
+}
+
+/// A disk-write **decision** `reduce` hands back to the event loop — see module doc for why
+/// this indirection exists (keeps `reduce` pure/testable).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Effect {
+    SubmitConfirm {
+        scope: String,
+        verdict: String,
+        reason: String,
+    },
+    SubmitFeedback {
+        scope: String,
+        message: String,
+    },
+}
+
+/// The TUI's whole state. `tabs[0]` is always `"Paul"` (the global tab); `tabs[1..]` are the
+/// wave IDs present in `vm.waves`, in the VM's own order (already `W0..W6`-sorted upstream by
+/// `viewmodel::build_vm`, so this module does not re-sort).
+#[derive(Debug, Clone)]
+pub struct AppState {
+    pub tabs: Vec<String>,
+    pub tab_index: usize,
+    pub scroll: u16,
+    pub modal: Option<Modal>,
+    pub vm: DashboardVM,
+    /// `_state/wave-log.md` tail lines, refreshed alongside `vm` on each tick (best-effort —
+    /// same "대충 필터" convention as the tmux frontend; free-form markdown has no schema).
+    pub log_tail: Vec<String>,
+    pub status_message: Option<String>,
+    pub should_quit: bool,
+}
+
+impl AppState {
+    /// Builds the initial state from a loaded `DashboardVM`. If `initial_wave` names a wave
+    /// present in the VM, that tab is selected up front (otherwise the Paul tab, index 0).
+    pub fn new(vm: DashboardVM, initial_wave: Option<String>) -> Self {
+        let mut tabs = vec!["Paul".to_string()];
+        tabs.extend(vm.waves.iter().map(|w| w.wave_id.clone()));
+
+        let tab_index = initial_wave
+            .and_then(|w| tabs.iter().position(|t| t == &w))
+            .unwrap_or(0);
+
+        AppState {
+            tabs,
+            tab_index,
+            scroll: 0,
+            modal: None,
+            vm,
+            log_tail: Vec::new(),
+            status_message: None,
+            should_quit: false,
+        }
+    }
+
+    /// The wave_id of the currently selected tab, or `None` on the Paul tab (index 0).
+    pub fn current_wave(&self) -> Option<&str> {
+        if self.tab_index == 0 {
+            None
+        } else {
+            self.tabs.get(self.tab_index).map(String::as_str)
+        }
+    }
+}
+
+/// The pure state transition. Intro: every action either (a) is a plain state edit with no
+/// side effect (tab/scroll/modal-open/modal-typing), or (b) is `ModalSubmit`, which validates
+/// the modal buffer and — only if valid — clears the modal, sets a status message, and returns
+/// an [`Effect`] for the caller to actually perform. An invalid submit (unrecognized verdict
+/// keyword, empty buffer) leaves the modal open with a status message explaining why, rather
+/// than silently discarding the user's half-typed input.
+pub fn reduce(mut state: AppState, action: AppAction) -> (AppState, Option<Effect>) {
+    match action {
+        AppAction::Noop => {}
+
+        AppAction::NextTab => {
+            if !state.tabs.is_empty() {
+                state.tab_index = (state.tab_index + 1) % state.tabs.len();
+                state.scroll = 0;
+            }
+        }
+        AppAction::PrevTab => {
+            if !state.tabs.is_empty() {
+                state.tab_index = if state.tab_index == 0 {
+                    state.tabs.len() - 1
+                } else {
+                    state.tab_index - 1
+                };
+                state.scroll = 0;
+            }
+        }
+        AppAction::ScrollDown => {
+            state.scroll = state.scroll.saturating_add(1);
+        }
+        AppAction::ScrollUp => {
+            state.scroll = state.scroll.saturating_sub(1);
+        }
+
+        AppAction::OpenConfirmModal => {
+            if state.modal.is_none() {
+                state.modal = Some(Modal::Confirm {
+                    buffer: String::new(),
+                });
+                state.status_message = None;
+            }
+        }
+        AppAction::OpenFeedbackModal => {
+            if state.modal.is_none() {
+                state.modal = Some(Modal::Feedback {
+                    buffer: String::new(),
+                });
+                state.status_message = None;
+            }
+        }
+        AppAction::CloseModal => {
+            state.modal = None;
+        }
+
+        AppAction::ModalInput(c) => {
+            if let Some(modal) = &mut state.modal {
+                let buf = match modal {
+                    Modal::Confirm { buffer } | Modal::Feedback { buffer } => buffer,
+                };
+                buf.push(c);
+            }
+        }
+        AppAction::ModalBackspace => {
+            if let Some(modal) = &mut state.modal {
+                let buf = match modal {
+                    Modal::Confirm { buffer } | Modal::Feedback { buffer } => buffer,
+                };
+                buf.pop();
+            }
+        }
+
+        AppAction::ModalSubmit => {
+            return submit_modal(state);
+        }
+
+        AppAction::Refresh => {
+            // The actual VM reload is the event loop's job (it owns the filesystem read) —
+            // this action exists so `r` has a distinct, testable intent even though `reduce`
+            // itself does nothing with it beyond acknowledging it (no state field to flip).
+        }
+
+        AppAction::Quit => {
+            state.should_quit = true;
+        }
+    }
+
+    (state, None)
+}
+
+/// Validates and (on success) converts the open modal's buffer into an [`Effect`], clearing
+/// the modal. Separated out from `reduce`'s match arm purely for readability — still pure.
+fn submit_modal(mut state: AppState) -> (AppState, Option<Effect>) {
+    let scope = state
+        .current_wave()
+        .map(str::to_string)
+        .unwrap_or_else(|| "PAUL".to_string());
+
+    match state.modal.take() {
+        Some(Modal::Confirm { buffer }) => {
+            let trimmed = buffer.trim();
+            let mut parts = trimmed.splitn(2, char::is_whitespace);
+            let verdict = parts.next().unwrap_or("").to_string();
+            let reason = parts.next().unwrap_or("").trim().to_string();
+
+            if VERDICT_KEYWORDS.contains(&verdict.as_str()) {
+                state.status_message = Some(format!("confirm 기록됨: {scope} {verdict}"));
+                (
+                    state,
+                    Some(Effect::SubmitConfirm {
+                        scope,
+                        verdict,
+                        reason,
+                    }),
+                )
+            } else {
+                // Reject and re-open the modal with the same buffer so the user can fix it
+                // rather than lose what they typed (no silent data loss on a typo).
+                state.status_message = Some(format!(
+                    "인식할 수 없는 verdict '{verdict}' — {} 중 하나로 시작해야 합니다",
+                    VERDICT_KEYWORDS.join("|")
+                ));
+                state.modal = Some(Modal::Confirm { buffer });
+                (state, None)
+            }
+        }
+        Some(Modal::Feedback { buffer }) => {
+            let trimmed = buffer.trim().to_string();
+            if trimmed.is_empty() {
+                state.status_message = Some("빈 피드백은 기록하지 않습니다".to_string());
+                state.modal = Some(Modal::Feedback { buffer });
+                (state, None)
+            } else {
+                state.status_message = Some(format!("feedback 기록됨: {scope}"));
+                (
+                    state,
+                    Some(Effect::SubmitFeedback {
+                        scope,
+                        message: trimmed,
+                    }),
+                )
+            }
+        }
+        None => (state, None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bathos_inspect::dashboard::viewmodel::build_vm;
+    use bathos_inspect::loader::{
+        ChainStatus, ManifestForm, ProjectMeta, ProjectStatus, ProjectView,
+    };
+
+    fn empty_pv() -> ProjectView {
+        ProjectView {
+            form: ManifestForm::Engine,
+            meta: ProjectMeta {
+                codename: Some("BATHOS".into()),
+                current_level: Some(3),
+                status: ProjectStatus::Active,
+                lang: Some("ko".into()),
+                created: None,
+                project_id: Some("bathos-0001".into()),
+            },
+            waves: vec![],
+            gates: vec![],
+            roles: vec![],
+            tasks: vec![],
+            risks: vec![],
+            artifacts: vec![],
+            routing: vec![],
+            modules: vec![],
+            stale_story_keys: vec![],
+            audit: vec![],
+            chain_status: ChainStatus::Absent,
+            audit_skipped: 0,
+            warnings: vec![],
+        }
+    }
+
+    fn vm_with_waves(wave_ids: &[&str]) -> DashboardVM {
+        use bathos_inspect::loader::{WaveStatus, WaveView};
+        let mut pv = empty_pv();
+        pv.waves = wave_ids
+            .iter()
+            .map(|w| WaveView {
+                wave_id: w.to_string(),
+                name: "x".into(),
+                status: WaveStatus::Active,
+                active_roles: vec![],
+                entry_gate: None,
+                exit_gate: None,
+                started: None,
+                ended: None,
+            })
+            .collect();
+        build_vm(&pv, &[])
+    }
+
+    fn state_with_waves(wave_ids: &[&str]) -> AppState {
+        AppState::new(vm_with_waves(wave_ids), None)
+    }
+
+    // ── tab navigation (wraps both directions) ───────────────────────────────
+
+    #[test]
+    fn next_tab_wraps_around() {
+        let state = state_with_waves(&["W2", "W5"]);
+        assert_eq!(state.tabs, vec!["Paul", "W2", "W5"]);
+        let (s1, e1) = reduce(state, AppAction::NextTab);
+        assert_eq!(s1.tab_index, 1);
+        assert!(e1.is_none());
+        let (s2, _) = reduce(s1, AppAction::NextTab);
+        assert_eq!(s2.tab_index, 2);
+        let (s3, _) = reduce(s2, AppAction::NextTab);
+        assert_eq!(s3.tab_index, 0, "3번째 NextTab은 처음(Paul)으로 순환");
+    }
+
+    #[test]
+    fn prev_tab_wraps_around_backwards() {
+        let state = state_with_waves(&["W2", "W5"]);
+        let (s1, _) = reduce(state, AppAction::PrevTab);
+        assert_eq!(s1.tab_index, 2, "index 0에서 PrevTab은 마지막 탭으로 순환");
+    }
+
+    #[test]
+    fn tabs_empty_edge_case_no_panic() {
+        // No waves at all → tabs == ["Paul"] only, still never panics on Next/Prev.
+        let state = state_with_waves(&[]);
+        assert_eq!(state.tabs, vec!["Paul"]);
+        let (s1, _) = reduce(state, AppAction::NextTab);
+        assert_eq!(s1.tab_index, 0);
+    }
+
+    // ── scroll boundaries (saturating, never underflows/panics) ─────────────
+
+    #[test]
+    fn scroll_up_saturates_at_zero() {
+        let state = state_with_waves(&["W5"]);
+        assert_eq!(state.scroll, 0);
+        let (s1, _) = reduce(state, AppAction::ScrollUp);
+        assert_eq!(s1.scroll, 0, "0에서 위로 스크롤해도 음수가 되지 않음");
+    }
+
+    #[test]
+    fn scroll_down_then_up_returns_to_zero() {
+        let state = state_with_waves(&["W5"]);
+        let (s1, _) = reduce(state, AppAction::ScrollDown);
+        assert_eq!(s1.scroll, 1);
+        let (s2, _) = reduce(s1, AppAction::ScrollUp);
+        assert_eq!(s2.scroll, 0);
+    }
+
+    #[test]
+    fn changing_tab_resets_scroll() {
+        let state = state_with_waves(&["W2", "W5"]);
+        let (s1, _) = reduce(state, AppAction::ScrollDown);
+        assert_eq!(s1.scroll, 1);
+        let (s2, _) = reduce(s1, AppAction::NextTab);
+        assert_eq!(s2.scroll, 0);
+    }
+
+    // ── modal open/close ──────────────────────────────────────────────────────
+
+    #[test]
+    fn open_confirm_modal_sets_empty_buffer() {
+        let state = state_with_waves(&["W5"]);
+        let (s1, _) = reduce(state, AppAction::OpenConfirmModal);
+        assert_eq!(
+            s1.modal,
+            Some(Modal::Confirm {
+                buffer: String::new()
+            })
+        );
+    }
+
+    #[test]
+    fn opening_modal_while_one_already_open_is_noop() {
+        let state = state_with_waves(&["W5"]);
+        let (s1, _) = reduce(state, AppAction::OpenConfirmModal);
+        let (s2, _) = reduce(s1, AppAction::ModalInput('P'));
+        let (s3, _) = reduce(s2, AppAction::OpenFeedbackModal); // must not replace/clear buffer
+        assert_eq!(s3.modal, Some(Modal::Confirm { buffer: "P".into() }));
+    }
+
+    #[test]
+    fn close_modal_clears_it_without_effect() {
+        let state = state_with_waves(&["W5"]);
+        let (s1, _) = reduce(state, AppAction::OpenFeedbackModal);
+        let (s2, _) = reduce(s1, AppAction::ModalInput('x'));
+        let (s3, effect) = reduce(s2, AppAction::CloseModal);
+        assert_eq!(s3.modal, None);
+        assert_eq!(effect, None, "닫기는 절대 디스크에 쓰지 않음(취소)");
+    }
+
+    // ── modal typing (input/backspace) ───────────────────────────────────────
+
+    #[test]
+    fn modal_input_accumulates_chars_in_order() {
+        let state = state_with_waves(&["W5"]);
+        let (s1, _) = reduce(state, AppAction::OpenFeedbackModal);
+        let (s2, _) = reduce(s1, AppAction::ModalInput('h'));
+        let (s3, _) = reduce(s2, AppAction::ModalInput('i'));
+        assert_eq!(
+            s3.modal,
+            Some(Modal::Feedback {
+                buffer: "hi".into()
+            })
+        );
+    }
+
+    #[test]
+    fn modal_backspace_removes_last_char_and_is_noop_on_empty() {
+        let state = state_with_waves(&["W5"]);
+        let (s1, _) = reduce(state, AppAction::OpenFeedbackModal);
+        let (s2, _) = reduce(s1, AppAction::ModalBackspace); // empty buffer — must not panic
+        assert_eq!(
+            s2.modal,
+            Some(Modal::Feedback {
+                buffer: String::new()
+            })
+        );
+        let (s3, _) = reduce(s2, AppAction::ModalInput('a'));
+        let (s4, _) = reduce(s3, AppAction::ModalBackspace);
+        assert_eq!(
+            s4.modal,
+            Some(Modal::Feedback {
+                buffer: String::new()
+            })
+        );
+    }
+
+    #[test]
+    fn typing_when_no_modal_open_is_silently_ignored() {
+        let state = state_with_waves(&["W5"]);
+        let (s1, effect) = reduce(state, AppAction::ModalInput('x'));
+        assert_eq!(s1.modal, None);
+        assert_eq!(effect, None);
+    }
+
+    // ── ModalSubmit: confirm ─────────────────────────────────────────────────
+
+    #[test]
+    fn confirm_submit_valid_verdict_produces_effect_and_clears_modal() {
+        let mut state = state_with_waves(&["W5"]);
+        state.tab_index = 1; // on the W5 tab
+        let (s1, _) = reduce(state, AppAction::OpenConfirmModal);
+        let (s2, _) = "PASS 사유입니다"
+            .chars()
+            .fold((s1, None), |(s, _), c| reduce(s, AppAction::ModalInput(c)));
+        let (s3, effect) = reduce(s2, AppAction::ModalSubmit);
+        assert_eq!(s3.modal, None);
+        assert_eq!(
+            effect,
+            Some(Effect::SubmitConfirm {
+                scope: "W5".into(),
+                verdict: "PASS".into(),
+                reason: "사유입니다".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn confirm_submit_on_paul_tab_uses_paul_scope() {
+        let state = state_with_waves(&["W5"]); // tab_index defaults to 0 (Paul)
+        let (s1, _) = reduce(state, AppAction::OpenConfirmModal);
+        let (s2, _) = "STOP"
+            .chars()
+            .fold((s1, None), |(s, _), c| reduce(s, AppAction::ModalInput(c)));
+        let (_s3, effect) = reduce(s2, AppAction::ModalSubmit);
+        assert_eq!(
+            effect,
+            Some(Effect::SubmitConfirm {
+                scope: "PAUL".into(),
+                verdict: "STOP".into(),
+                reason: "".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn confirm_submit_unrecognized_verdict_is_rejected_and_keeps_modal_open() {
+        let state = state_with_waves(&["W5"]);
+        let (s1, _) = reduce(state, AppAction::OpenConfirmModal);
+        let (s2, _) = "MAYBE"
+            .chars()
+            .fold((s1, None), |(s, _), c| reduce(s, AppAction::ModalInput(c)));
+        let (s3, effect) = reduce(s2, AppAction::ModalSubmit);
+        assert_eq!(effect, None, "미인식 verdict는 Effect를 만들지 않음");
+        assert!(
+            matches!(s3.modal, Some(Modal::Confirm { .. })),
+            "모달이 닫히지 않고 재입력 가능해야 함"
+        );
+        assert!(s3.status_message.unwrap().contains("인식할 수 없는"));
+    }
+
+    // ── ModalSubmit: feedback ────────────────────────────────────────────────
+
+    #[test]
+    fn feedback_submit_nonempty_produces_effect() {
+        let state = state_with_waves(&["W3"]);
+        let mut s = state;
+        s.tab_index = 1;
+        let (s1, _) = reduce(s, AppAction::OpenFeedbackModal);
+        let (s2, _) = "좋은 진행"
+            .chars()
+            .fold((s1, None), |(s, _), c| reduce(s, AppAction::ModalInput(c)));
+        let (s3, effect) = reduce(s2, AppAction::ModalSubmit);
+        assert_eq!(s3.modal, None);
+        assert_eq!(
+            effect,
+            Some(Effect::SubmitFeedback {
+                scope: "W3".into(),
+                message: "좋은 진행".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn feedback_submit_empty_buffer_is_rejected() {
+        let state = state_with_waves(&["W3"]);
+        let (s1, _) = reduce(state, AppAction::OpenFeedbackModal);
+        let (s2, effect) = reduce(s1, AppAction::ModalSubmit);
+        assert_eq!(effect, None);
+        assert!(matches!(s2.modal, Some(Modal::Feedback { .. })));
+    }
+
+    #[test]
+    fn submit_without_open_modal_is_noop() {
+        let state = state_with_waves(&["W5"]);
+        let (s1, effect) = reduce(state, AppAction::ModalSubmit);
+        assert_eq!(effect, None);
+        assert_eq!(s1.modal, None);
+    }
+
+    // ── Quit ──────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn quit_sets_should_quit_flag() {
+        let state = state_with_waves(&["W5"]);
+        let (s1, _) = reduce(state, AppAction::Quit);
+        assert!(s1.should_quit);
+    }
+
+    // ── initial tab selection from --wave ────────────────────────────────────
+
+    #[test]
+    fn new_selects_initial_wave_tab_when_present() {
+        let vm = vm_with_waves(&["W2", "W5"]);
+        let state = AppState::new(vm, Some("W5".to_string()));
+        assert_eq!(state.tab_index, 2);
+        assert_eq!(state.current_wave(), Some("W5"));
+    }
+
+    #[test]
+    fn new_falls_back_to_paul_tab_when_wave_absent() {
+        let vm = vm_with_waves(&["W2"]);
+        let state = AppState::new(vm, Some("W9-nonexistent".to_string()));
+        assert_eq!(state.tab_index, 0);
+        assert_eq!(state.current_wave(), None);
+    }
+}

--- a/core/crates/bathos-tui/src/inbox.rs
+++ b/core/crates/bathos-tui/src/inbox.rs
@@ -1,0 +1,224 @@
+//! `inbox` — the **only** module in this crate allowed to touch the filesystem for writing
+//! (ADR-D-0008 "inbox-only-write" invariant). Every write lands under
+//! `<agent_team_path>/_state/panes/inbox/` (§B2 contract, identical filename/content shape to
+//! `scripts/bathos-panes.sh`'s `__input`/`__control`, so a confirm/feedback submitted from the
+//! TUI is indistinguishable in the inbox from one submitted through the tmux frontend).
+//!
+//! Nothing else in `bathos-tui` writes to disk at all — `app.rs`/`view.rs`/`input.rs` are pure.
+
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const INBOX_REL: &str = "_state/panes/inbox";
+
+fn inbox_dir(agent_team_path: &Path) -> PathBuf {
+    agent_team_path.join(INBOX_REL)
+}
+
+/// Strips everything except ASCII alphanumerics/`-`/`_` from a caller-supplied scope/qid
+/// before it becomes part of a filename. This is the "reject path escape (`../` assert)"
+/// requirement (T6) made structural rather than a blocklist: a component built only from
+/// this alphabet cannot contain `/`, `..`, or any other path-traversal sequence — there is no
+/// escape pattern to enumerate because the allowed character set itself excludes path
+/// separators entirely.
+fn sanitize_component(s: &str) -> String {
+    let cleaned: String = s
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+        .collect();
+    if cleaned.is_empty() {
+        "UNKNOWN".to_string()
+    } else {
+        cleaned
+    }
+}
+
+/// `<unix-seconds>-<pid>` — matches `scripts/bathos-panes.sh`'s `date +%s`+`$$` convention
+/// (E10: same-second submissions from two different pane processes never collide because the
+/// pid differs; two calls from *this same* process within the same second are vanishingly
+/// unlikely in an interactive TUI and, worse case, only overwrite each other's `.tmp` before
+/// the atomic rename — never a torn/partial file on disk).
+fn timestamp_token() -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    format!("{secs}-{}", std::process::id())
+}
+
+/// Writes `<dir>/<tmp_name>` then atomically renames it to `<dir>/<final_name>` (temp file +
+/// rename — a partial write is never observable, same pattern as
+/// `bathos_state::store::StateStore::atomic_write`). Asserts the resolved path is still inside
+/// `dir` as a second, structural line of defense beyond [`sanitize_component`] (belt + braces —
+/// the assert should be unreachable given a sanitized component, and existing as a runtime
+/// check is exactly the "path escape 거부" contract T6 asks for).
+fn atomic_write_in_dir(dir: &Path, final_name: &str, content: &str) -> std::io::Result<PathBuf> {
+    std::fs::create_dir_all(dir)?;
+    let final_path = dir.join(final_name);
+    assert!(
+        final_path.starts_with(dir),
+        "bathos-tui inbox invariant violated: computed path escaped the inbox directory"
+    );
+    let tmp_path = dir.join(format!(".{final_name}.tmp"));
+    std::fs::write(&tmp_path, content)?;
+    // PANES-004 fix: restrict to owner-only before the rename — `std::fs::write` otherwise
+    // creates the file at the process umask's default (typically 0644/world-readable), which
+    // matters because this file can carry a reviewer's free-form confirm/feedback text on a
+    // shared multi-user host. Set on the `.tmp` path (pre-rename) so the final file is never
+    // observable with the wrong permissions, not even for an instant.
+    set_owner_only(&tmp_path)?;
+    std::fs::rename(&tmp_path, &final_path)?;
+    Ok(final_path)
+}
+
+/// Restricts `path` to owner read/write only (`0600`). Unix-only (`PermissionsExt::from_mode`
+/// has no cross-platform equivalent — the project's only other permission-bit call site,
+/// `bathos-cli/src/main.rs::is_executable`, uses the same `#[cfg(unix)]` split); a no-op
+/// elsewhere since this crate/tool is not shipped for non-unix targets today.
+#[cfg(unix)]
+fn set_owner_only(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+}
+
+#[cfg(not(unix))]
+fn set_owner_only(_path: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+/// Writes `confirm-<scope>-<ts>.txt` (§B2: `<PASS|CONCERNS|FAIL|OK|STOP>\t<사유>\t<author>`).
+pub fn write_confirm(
+    agent_team_path: &Path,
+    scope: &str,
+    verdict: &str,
+    reason: &str,
+    author: &str,
+) -> std::io::Result<PathBuf> {
+    let dir = inbox_dir(agent_team_path);
+    let scope = sanitize_component(scope);
+    let name = format!("confirm-{scope}-{}.txt", timestamp_token());
+    let content = format!("{verdict}\t{reason}\t{author}\n");
+    atomic_write_in_dir(&dir, &name, &content)
+}
+
+/// Writes `feedback-<scope>-<ts>.md` (§B2: free-form, title line = summary — here a single
+/// `# <message>` line, matching the tmux frontend's `__input`/`__control` convention).
+pub fn write_feedback(
+    agent_team_path: &Path,
+    scope: &str,
+    message: &str,
+) -> std::io::Result<PathBuf> {
+    let dir = inbox_dir(agent_team_path);
+    let scope = sanitize_component(scope);
+    let name = format!("feedback-{scope}-{}.md", timestamp_token());
+    let content = format!("# {message}\n");
+    atomic_write_in_dir(&dir, &name, &content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn write_confirm_creates_file_with_tab_separated_fields() {
+        let dir = TempDir::new().unwrap();
+        let path = write_confirm(dir.path(), "W5", "PASS", "이유", "tui").unwrap();
+        assert!(path.exists());
+        assert_eq!(
+            path.parent().unwrap(),
+            dir.path().join("_state/panes/inbox")
+        );
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content, "PASS\t이유\ttui\n");
+        let fname = path.file_name().unwrap().to_str().unwrap();
+        assert!(fname.starts_with("confirm-W5-"));
+        assert!(fname.ends_with(".txt"));
+    }
+
+    #[test]
+    fn write_feedback_creates_markdown_with_title_line() {
+        let dir = TempDir::new().unwrap();
+        let path = write_feedback(dir.path(), "W3", "괜찮아 보입니다").unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content, "# 괜찮아 보입니다\n");
+        assert!(path
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with("feedback-W3-"));
+    }
+
+    // PANES-004 regression: confirm/feedback files must not be group/other readable.
+    #[cfg(unix)]
+    #[test]
+    fn write_confirm_creates_file_with_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        let path = write_confirm(dir.path(), "W5", "PASS", "이유", "tui").unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "inbox 파일은 소유자만 읽기/쓰기 가능해야 함(실제: {mode:o})"
+        );
+    }
+
+    #[test]
+    fn no_tmp_file_left_behind_after_write() {
+        let dir = TempDir::new().unwrap();
+        write_confirm(dir.path(), "W5", "OK", "", "tui").unwrap();
+        let inbox = dir.path().join("_state/panes/inbox");
+        let leftover_tmp: Vec<_> = std::fs::read_dir(&inbox)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+            .collect();
+        assert!(
+            leftover_tmp.is_empty(),
+            "atomic write는 .tmp 잔여물을 남기지 않아야 함"
+        );
+    }
+
+    #[test]
+    fn scope_with_path_traversal_sequences_cannot_escape_inbox_dir() {
+        let dir = TempDir::new().unwrap();
+        let malicious = "../../../etc/passwd";
+        let path = write_confirm(dir.path(), malicious, "FAIL", "", "tui").unwrap();
+        let inbox = dir.path().join("_state/panes/inbox");
+        assert_eq!(
+            path.parent().unwrap(),
+            inbox,
+            "지문/슬래시가 모두 제거되어 inbox 밖으로 나갈 수 없어야 함"
+        );
+        assert!(!path.to_string_lossy().contains(".."));
+    }
+
+    #[test]
+    fn scope_that_sanitizes_to_empty_falls_back_to_unknown() {
+        let dir = TempDir::new().unwrap();
+        let path = write_confirm(dir.path(), "!!!///", "PASS", "", "tui").unwrap();
+        assert!(path
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with("confirm-UNKNOWN-"));
+    }
+
+    #[test]
+    fn same_second_writes_from_same_process_do_not_collide_destructively() {
+        // Both calls resolve to the *same* timestamp token (same pid, same second) — the
+        // second `atomic_write_in_dir` call overwrites the first's `.tmp` before rename, so
+        // exactly one final file exists and it is never a torn/partial write (still a valid,
+        // fully-written confirm file — see doc comment on `timestamp_token`).
+        let dir = TempDir::new().unwrap();
+        let p1 = write_confirm(dir.path(), "W5", "PASS", "first", "tui").unwrap();
+        let p2 = write_confirm(dir.path(), "W5", "OK", "second", "tui").unwrap();
+        assert!(p2.exists());
+        if p1 == p2 {
+            let content = std::fs::read_to_string(&p2).unwrap();
+            assert!(content.starts_with("OK\tsecond"));
+        }
+    }
+}

--- a/core/crates/bathos-tui/src/input.rs
+++ b/core/crates/bathos-tui/src/input.rs
@@ -1,0 +1,170 @@
+//! `input` — crossterm `KeyEvent` → [`AppAction`] (pure mapping, no state, no I/O).
+//!
+//! Split out from `app.rs` because the *meaning* of a keypress depends only on whether a
+//! modal is currently open (typing must go to the buffer) or not (keys are navigation/global
+//! commands) — a single `bool` parameter fully determines the mapping, which is exactly what
+//! makes this pure-function-over-an-enum shape worth pulling out and testing on its own
+//! (§B5 T4 "input.rs 키맵 전수").
+//!
+//! Keymap (`w2-panes-model-design-kr.md` §B4.1): `←/→`/`Tab` = tab switch, `j/k` = scroll,
+//! `c` = confirm modal, `f` = feedback modal, `r` = manual refresh, `q` = quit. Inside a modal:
+//! any printable char = buffer input, `Backspace` = delete, `Enter` = submit, `Esc` = cancel.
+
+use crate::app::AppAction;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+/// Maps one key event to an [`AppAction`]. `modal_open` selects which keymap layer applies —
+/// see module doc. An unrecognized key in either layer maps to `AppAction::Noop` (never an
+/// error; a stray keypress must never crash or desync the TUI).
+pub fn map_key(modal_open: bool, key: KeyEvent) -> AppAction {
+    if modal_open {
+        return map_modal_key(key);
+    }
+    map_normal_key(key)
+}
+
+fn map_modal_key(key: KeyEvent) -> AppAction {
+    match key.code {
+        KeyCode::Enter => AppAction::ModalSubmit,
+        KeyCode::Esc => AppAction::CloseModal,
+        KeyCode::Backspace => AppAction::ModalBackspace,
+        KeyCode::Char(c) => AppAction::ModalInput(c),
+        _ => AppAction::Noop,
+    }
+}
+
+fn map_normal_key(key: KeyEvent) -> AppAction {
+    // Ctrl-C is the universal "get me out" — checked first (guarded arms must precede the
+    // unguarded `Char('c')` arm below, or the plain-`c` arm would always shadow it — a match
+    // is evaluated top-to-bottom, so ordering here is load-bearing, not stylistic).
+    if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+        return AppAction::Quit;
+    }
+    match key.code {
+        KeyCode::Left => AppAction::PrevTab,
+        KeyCode::Right => AppAction::NextTab,
+        KeyCode::Tab => {
+            if key.modifiers.contains(KeyModifiers::SHIFT) {
+                AppAction::PrevTab
+            } else {
+                AppAction::NextTab
+            }
+        }
+        KeyCode::Char('j') => AppAction::ScrollDown,
+        KeyCode::Char('k') => AppAction::ScrollUp,
+        KeyCode::Char('c') => AppAction::OpenConfirmModal,
+        KeyCode::Char('f') => AppAction::OpenFeedbackModal,
+        KeyCode::Char('r') => AppAction::Refresh,
+        KeyCode::Char('q') => AppAction::Quit,
+        _ => AppAction::Noop,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::KeyEventKind;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn key_with(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
+        KeyEvent::new(code, modifiers)
+    }
+
+    // ── normal-mode keymap (full enumeration — T4) ───────────────────────────
+
+    #[test]
+    fn normal_mode_navigation_keys() {
+        assert_eq!(map_key(false, key(KeyCode::Left)), AppAction::PrevTab);
+        assert_eq!(map_key(false, key(KeyCode::Right)), AppAction::NextTab);
+        assert_eq!(map_key(false, key(KeyCode::Tab)), AppAction::NextTab);
+        assert_eq!(
+            map_key(false, key_with(KeyCode::Tab, KeyModifiers::SHIFT)),
+            AppAction::PrevTab
+        );
+    }
+
+    #[test]
+    fn normal_mode_scroll_keys() {
+        assert_eq!(
+            map_key(false, key(KeyCode::Char('j'))),
+            AppAction::ScrollDown
+        );
+        assert_eq!(map_key(false, key(KeyCode::Char('k'))), AppAction::ScrollUp);
+    }
+
+    #[test]
+    fn normal_mode_command_keys() {
+        assert_eq!(
+            map_key(false, key(KeyCode::Char('c'))),
+            AppAction::OpenConfirmModal
+        );
+        assert_eq!(
+            map_key(false, key(KeyCode::Char('f'))),
+            AppAction::OpenFeedbackModal
+        );
+        assert_eq!(map_key(false, key(KeyCode::Char('r'))), AppAction::Refresh);
+        assert_eq!(map_key(false, key(KeyCode::Char('q'))), AppAction::Quit);
+    }
+
+    #[test]
+    fn normal_mode_unrecognized_key_is_noop() {
+        assert_eq!(map_key(false, key(KeyCode::Char('z'))), AppAction::Noop);
+        assert_eq!(map_key(false, key(KeyCode::F(5))), AppAction::Noop);
+    }
+
+    #[test]
+    fn ctrl_c_is_quit_in_normal_mode() {
+        assert_eq!(
+            map_key(false, key_with(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+            AppAction::Quit
+        );
+    }
+
+    // ── modal-mode keymap ─────────────────────────────────────────────────────
+
+    #[test]
+    fn modal_mode_typing_and_control_keys() {
+        assert_eq!(
+            map_key(true, key(KeyCode::Char('P'))),
+            AppAction::ModalInput('P')
+        );
+        assert_eq!(map_key(true, key(KeyCode::Enter)), AppAction::ModalSubmit);
+        assert_eq!(map_key(true, key(KeyCode::Esc)), AppAction::CloseModal);
+        assert_eq!(
+            map_key(true, key(KeyCode::Backspace)),
+            AppAction::ModalBackspace
+        );
+    }
+
+    #[test]
+    fn modal_mode_navigation_keys_do_not_leak_through() {
+        // While a modal is open, `c`/`f`/`j`/`k`/arrows must all be typed into the buffer,
+        // never reinterpreted as tab/scroll commands (the core reason this dispatch exists).
+        assert_eq!(
+            map_key(true, key(KeyCode::Char('c'))),
+            AppAction::ModalInput('c')
+        );
+        assert_eq!(
+            map_key(true, key(KeyCode::Char('j'))),
+            AppAction::ModalInput('j')
+        );
+        assert_eq!(map_key(true, key(KeyCode::Left)), AppAction::Noop);
+    }
+
+    #[test]
+    fn modal_mode_unrecognized_non_char_key_is_noop() {
+        assert_eq!(map_key(true, key(KeyCode::F(1))), AppAction::Noop);
+    }
+
+    // ── KeyEventKind is irrelevant to the mapping (release/repeat behave like press) ──
+
+    #[test]
+    fn key_event_kind_does_not_affect_mapping() {
+        let mut k = key(KeyCode::Char('q'));
+        k.kind = KeyEventKind::Release;
+        assert_eq!(map_key(false, k), AppAction::Quit);
+    }
+}

--- a/core/crates/bathos-tui/src/lib.rs
+++ b/core/crates/bathos-tui/src/lib.rs
@@ -1,0 +1,384 @@
+//! # bathos-tui — BATHOS interactive TUI (`bathos panes`, ADR-D-0008)
+//!
+//! One of the two Wave-panel frontends (the other is `scripts/bathos-panes.sh`, tmux) sharing
+//! the exact same data source — `bathos-inspect`'s `DashboardVM` (ADR-D-0007). Renders a
+//! terminal UI over `crossterm` via `ratatui`, and lets the operator submit confirm/feedback
+//! into `_state/panes/inbox/` (ADR-D-0009) — the same file-based inbox the tmux frontend uses,
+//! so either frontend (or both, from different terminals) feed the same queue.
+//!
+//! ## Module map (ADR-D-0008 "테스트 가능 코어 분리")
+//! - [`app`] — pure state machine (`AppState` + `reduce`), unit-testable without a terminal.
+//! - [`input`] — pure `KeyEvent → AppAction` mapping.
+//! - [`view`] — pure `&AppState → ratatui widgets` render, TestBackend-snapshot-able.
+//! - [`inbox`] — the **only** module allowed to write to disk (`_state/panes/inbox/` only).
+//!
+//! This file is the imperative shell: it owns the crossterm terminal, the event-poll/tick
+//! loop, and dispatches `Effect`s from `reduce` to `inbox::write_*`. Nothing here is
+//! unit-testable in the traditional sense (it needs a real terminal) — that is *why* the pure
+//! core above is split out, and why [`render_dump`] exists as the non-interactive escape hatch
+//! `bathos panes --mode dump` uses for CI/tests (§B5 T5).
+
+pub mod app;
+pub mod inbox;
+pub mod input;
+pub mod view;
+
+pub use app::{reduce, AppAction, AppState, Effect, Modal};
+pub use bathos_inspect::dashboard::DashboardVM;
+
+use bathos_inspect::{load_project, InspectCtx, LoadOpts};
+use crossterm::{
+    event::{self, Event},
+    execute,
+    terminal::{self, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{backend::CrosstermBackend, backend::TestBackend, Terminal};
+use std::io;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+/// Options for [`run_tui`].
+pub struct TuiOpts {
+    /// Wave tab to select on startup (`--wave`), if it exists in the loaded project.
+    pub wave: Option<String>,
+    /// Tick interval for reloading `DashboardVM` from disk (mirrors the tmux frontend's
+    /// `--interval`, default 2s per the design doc).
+    pub interval: Duration,
+}
+
+impl Default for TuiOpts {
+    fn default() -> Self {
+        TuiOpts {
+            wave: None,
+            interval: Duration::from_secs(2),
+        }
+    }
+}
+
+/// Loads the current `DashboardVM` for `agent_team_path` (the same `load_project` +
+/// `load_story_cards` + `build_vm` pipeline `report`/`inspect vm` use — CR-2, no
+/// reimplementation). Returns a human-readable error string on a Fatal load failure (manifest
+/// absent/corrupt) — the caller decides how to surface it (stderr on first load = abort;
+/// on a tick reload, a failure is not fatal, see `run_tui`'s tick handling).
+fn load_vm(agent_team_path: &Path) -> Result<DashboardVM, String> {
+    let pv = load_project(agent_team_path, LoadOpts { verify_chain: true })
+        .map_err(|e| format!("[bathos panes] {e}"))?;
+    let ctx = InspectCtx {
+        agent_team_path: agent_team_path.to_path_buf(),
+        json: false,
+        verbose: false,
+        strict: false,
+    };
+    let stories = bathos_inspect::dashboard::load_story_cards(&ctx, &pv);
+    Ok(bathos_inspect::dashboard::viewmodel::build_vm(
+        &pv, &stories,
+    ))
+}
+
+/// Runs the interactive TUI against `agent_team_path`. Returns the process exit code.
+///
+/// # Errors surfaced as exit codes (never panics on a load failure)
+/// - Initial load Fatal (manifest missing/corrupt) → prints the error, returns 1 (no terminal
+///   is ever entered — nothing to clean up).
+/// - A **tick** reload failure (e.g. the manifest was deleted mid-session) does not exit the
+///   TUI — it is shown as a status-bar message and the previous `DashboardVM` is kept on
+///   screen (a resident panel degrades gracefully rather than crashing on a transient read
+///   error, matching `bathos-panes.sh`'s "[로드 실패] ..." resident-loop behavior, E9).
+pub fn run_tui(agent_team_path: &Path, opts: TuiOpts) -> i32 {
+    let vm = match load_vm(agent_team_path) {
+        Ok(vm) => vm,
+        Err(msg) => {
+            eprintln!("{msg}");
+            return 1;
+        }
+    };
+    let mut state = AppState::new(vm, opts.wave.clone());
+
+    if let Err(e) = terminal::enable_raw_mode() {
+        eprintln!("[bathos panes] raw mode 활성화 실패: {e}");
+        return 1;
+    }
+    let mut stdout = io::stdout();
+    if let Err(e) = execute!(stdout, EnterAlternateScreen) {
+        let _ = terminal::disable_raw_mode();
+        eprintln!("[bathos panes] 대체 화면 진입 실패: {e}");
+        return 1;
+    }
+
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = match Terminal::new(backend) {
+        Ok(t) => t,
+        Err(e) => {
+            let _ = terminal::disable_raw_mode();
+            eprintln!("[bathos panes] terminal 초기화 실패: {e}");
+            return 1;
+        }
+    };
+
+    let exit_code = event_loop(&mut terminal, agent_team_path, &mut state, opts.interval);
+
+    let _ = terminal::disable_raw_mode();
+    let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);
+    exit_code
+}
+
+/// The poll/tick loop, separated from [`run_tui`] only so terminal setup/teardown always runs
+/// (including on an early return) — this function itself never leaves the terminal in raw
+/// mode/alternate screen on exit; that is `run_tui`'s responsibility via its `let _ =` cleanup
+/// calls after this returns.
+fn event_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    agent_team_path: &Path,
+    state: &mut AppState,
+    interval: Duration,
+) -> i32 {
+    let mut last_tick = Instant::now();
+    loop {
+        if terminal.draw(|f| view::draw(f, state)).is_err() {
+            return 1;
+        }
+
+        let timeout = interval
+            .checked_sub(last_tick.elapsed())
+            .unwrap_or(Duration::from_millis(0));
+        match event::poll(timeout) {
+            Ok(true) => {
+                if let Ok(Event::Key(key)) = event::read() {
+                    let modal_open = state.modal.is_some();
+                    let action = input::map_key(modal_open, key);
+                    let owned_state = std::mem::replace(state, placeholder_state());
+                    let (new_state, effect) = reduce(owned_state, action);
+                    *state = new_state;
+                    apply_effect(agent_team_path, state, effect);
+                }
+            }
+            Ok(false) => {}
+            Err(_) => {
+                // A poll error is treated like any other transient I/O hiccup — log via the
+                // status bar (next draw) and keep looping rather than exiting the whole panel.
+                state.status_message = Some("입력 폴링 오류(무시하고 계속)".to_string());
+            }
+        }
+
+        if last_tick.elapsed() >= interval {
+            match load_vm(agent_team_path) {
+                Ok(vm) => state.vm = vm,
+                Err(msg) => state.status_message = Some(msg),
+            }
+            last_tick = Instant::now();
+        }
+
+        if state.should_quit {
+            return 0;
+        }
+    }
+}
+
+/// `std::mem::replace` needs a value to put in `state`'s place while we move it into `reduce`
+/// (which takes `AppState` by value, matching `app.rs`'s pure-function signature) — this
+/// placeholder is discarded immediately afterward and never observed/drawn.
+fn placeholder_state() -> AppState {
+    AppState {
+        tabs: Vec::new(),
+        tab_index: 0,
+        scroll: 0,
+        modal: None,
+        vm: bathos_inspect::dashboard::viewmodel::build_vm(&empty_project_view(), &[]),
+        log_tail: Vec::new(),
+        status_message: None,
+        should_quit: false,
+    }
+}
+
+fn empty_project_view() -> bathos_inspect::ProjectView {
+    use bathos_inspect::loader::{ChainStatus, ManifestForm, ProjectMeta, ProjectStatus};
+    bathos_inspect::ProjectView {
+        form: ManifestForm::Engine,
+        meta: ProjectMeta {
+            codename: None,
+            current_level: None,
+            status: ProjectStatus::Active,
+            lang: None,
+            created: None,
+            project_id: None,
+        },
+        waves: vec![],
+        gates: vec![],
+        roles: vec![],
+        tasks: vec![],
+        risks: vec![],
+        artifacts: vec![],
+        routing: vec![],
+        modules: vec![],
+        stale_story_keys: vec![],
+        audit: vec![],
+        chain_status: ChainStatus::Absent,
+        audit_skipped: 0,
+        warnings: vec![],
+    }
+}
+
+fn apply_effect(agent_team_path: &Path, state: &mut AppState, effect: Option<Effect>) {
+    match effect {
+        Some(Effect::SubmitConfirm {
+            scope,
+            verdict,
+            reason,
+        }) => {
+            if let Err(e) = inbox::write_confirm(agent_team_path, &scope, &verdict, &reason, "tui")
+            {
+                state.status_message = Some(format!("confirm 기록 실패: {e}"));
+            }
+        }
+        Some(Effect::SubmitFeedback { scope, message }) => {
+            if let Err(e) = inbox::write_feedback(agent_team_path, &scope, &message) {
+                state.status_message = Some(format!("feedback 기록 실패: {e}"));
+            }
+        }
+        None => {}
+    }
+}
+
+/// `--mode dump`: renders exactly **one frame** against a `ratatui::backend::TestBackend` and
+/// returns it as plain text (no ANSI/color codes — a stable string for CI/pipeline comparison).
+///
+/// This is the automated-testing ceiling for this crate's UI layer (§B5 T5/§ honest limits):
+/// it proves the widget tree builds and renders without panicking for a given `DashboardVM`
+/// and pins its plain-text shape, but it does **not** exercise the crossterm event loop, raw
+/// mode, or terminal resize handling — those need a real TTY (manual T10).
+pub fn render_dump(vm: &DashboardVM, wave: Option<&str>, width: u16, height: u16) -> String {
+    let state = AppState::new(vm.clone(), wave.map(str::to_string));
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).expect("TestBackend terminal must construct");
+    terminal
+        .draw(|f| view::draw(f, &state))
+        .expect("draw against TestBackend must not fail");
+    buffer_to_plain_text(terminal.backend().buffer())
+}
+
+/// Flattens a rendered `Buffer` into plain text, one cell's `symbol()` per column.
+///
+/// **Wide-character shadow cells:** a double-width grapheme (e.g. any Korean/CJK character)
+/// occupies its own cell plus a "shadow" continuation cell to its right so the terminal's own
+/// cursor math lines up; ratatui's `TestBackend` fills that shadow cell with a literal `" "`
+/// rather than an empty string. Left unhandled, that means every Korean character in the dump
+/// comes out followed by a spurious space (`"서 술 형"` instead of `"서술형"`), breaking any
+/// substring search over Korean text. This function skips exactly one shadow cell after each
+/// double-width symbol using `unicode_width` — the same width function ratatui itself uses
+/// internally to lay wide characters out, so this stays in sync with actual rendering behavior.
+fn buffer_to_plain_text(buf: &ratatui::buffer::Buffer) -> String {
+    use unicode_width::UnicodeWidthStr;
+
+    let area = buf.area();
+    let mut out = String::with_capacity((area.width as usize + 1) * area.height as usize);
+    for y in 0..area.height {
+        let mut x = 0u16;
+        while x < area.width {
+            let symbol = buf[(x, y)].symbol();
+            out.push_str(symbol);
+            let width = symbol.width().max(1) as u16;
+            x += width; // skip the shadow cell(s) a wide symbol occupies
+        }
+        out.push('\n');
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bathos_inspect::dashboard::viewmodel::build_vm;
+    use bathos_inspect::loader::{
+        ChainStatus, ManifestForm, ProjectMeta, ProjectStatus, ProjectView,
+    };
+
+    fn empty_pv() -> ProjectView {
+        ProjectView {
+            form: ManifestForm::Engine,
+            meta: ProjectMeta {
+                codename: Some("BATHOS".into()),
+                current_level: Some(3),
+                status: ProjectStatus::Active,
+                lang: Some("ko".into()),
+                created: None,
+                project_id: Some("bathos-0001".into()),
+            },
+            waves: vec![],
+            gates: vec![],
+            roles: vec![],
+            tasks: vec![],
+            risks: vec![],
+            artifacts: vec![],
+            routing: vec![],
+            modules: vec![],
+            stale_story_keys: vec![],
+            audit: vec![],
+            chain_status: ChainStatus::Absent,
+            audit_skipped: 0,
+            warnings: vec![],
+        }
+    }
+
+    // ── T5: --mode dump snapshot tests — Paul tab / wave tab / error state ──
+
+    #[test]
+    fn render_dump_paul_tab_contains_project_header() {
+        let vm = build_vm(&empty_pv(), &[]);
+        let text = render_dump(&vm, None, 80, 24);
+        assert!(text.contains("BATHOS"));
+        assert!(text.contains("Project"));
+        assert!(text.contains("Gates"));
+        assert!(text.contains("Audit"));
+    }
+
+    #[test]
+    fn render_dump_wave_tab_contains_wave_id_and_sections() {
+        use bathos_inspect::loader::{WaveStatus, WaveView};
+        let mut pv = empty_pv();
+        pv.waves = vec![WaveView {
+            wave_id: "W5".into(),
+            name: "Implement".into(),
+            status: WaveStatus::Active,
+            active_roles: vec!["Phillip".into()],
+            entry_gate: None,
+            exit_gate: None,
+            started: None,
+            ended: None,
+        }];
+        let vm = build_vm(&pv, &[]);
+        let text = render_dump(&vm, Some("W5"), 80, 24);
+        assert!(text.contains("W5"));
+        assert!(text.contains("Roles"));
+        assert!(text.contains("Stories"));
+    }
+
+    #[test]
+    fn render_dump_error_state_manifest_descriptive_shows_banner() {
+        let mut pv = empty_pv();
+        pv.form = ManifestForm::Descriptive;
+        let vm = build_vm(&pv, &[]);
+        let text = render_dump(&vm, None, 80, 24);
+        assert!(text.contains("서술형"));
+    }
+
+    #[test]
+    fn render_dump_is_deterministic_for_same_input() {
+        let vm = build_vm(&empty_pv(), &[]);
+        let a = render_dump(&vm, None, 80, 24);
+        let b = render_dump(&vm, None, 80, 24);
+        assert_eq!(
+            a, b,
+            "동일 VM·크기에 대해 dump는 결정적이어야 함(스냅샷 비교 가능성의 전제)"
+        );
+    }
+
+    #[test]
+    fn placeholder_state_is_internally_consistent() {
+        // Guards the mem::replace plumbing in event_loop: the placeholder must never be
+        // observably drawn (it's replaced within the same statement), but it must still be a
+        // well-formed AppState (no panics constructing it) in case of an early-return path.
+        let s = placeholder_state();
+        assert_eq!(s.tabs.len(), 0);
+        assert!(!s.should_quit);
+    }
+}

--- a/core/crates/bathos-tui/src/view.rs
+++ b/core/crates/bathos-tui/src/view.rs
@@ -1,0 +1,412 @@
+//! `view` — `&AppState` → ratatui widgets (pure render, no I/O, TestBackend-snapshot-able).
+//!
+//! Two tab kinds (`w2-panes-model-design-kr.md` §B4.1):
+//! - **Paul tab** (`tab_index == 0`): project header/status badge, warnings banner, the full
+//!   gate-card list, the audit timeline (+ chain badge), and a global confirm hint.
+//! - **wave tab**: that wave's cell + entry/exit gates, its role pills, artifacts/stories, a
+//!   `wave-log.md` tail, and an input hint bar.
+//!
+//! **Honest scope note (documented, not silently omitted):** the design's Paul-tab bullet list
+//! also mentions "risks" — `DashboardVM` (the shared, reused data source, ADR-D-0007) does not
+//! currently carry risk entries (only `ProjectView` does, and `build_vm` does not project them
+//! through), so this view renders no risks panel rather than fabricating one from data that
+//! isn't there. Extending `DashboardVM` for this is a bigger, separately-reviewable change to a
+//! file shared by 4 consumers (HTML report/serve/tmux/TUI) and is out of this pass's scope.
+//! Likewise, artifact/story records are not wave-scoped here for the same reason `lines.rs`
+//! doesn't scope them (`ArtifactLeafVM`/`StoryCardView` carry no `wave_id`) — see that module's
+//! doc comment for the full rationale.
+
+use crate::app::{AppState, Modal};
+use bathos_inspect::dashboard::viewmodel::{Badge, GateCardVM, RolePillVM, StoryCardView};
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Tabs, Wrap},
+    Frame,
+};
+
+/// Maps a `Badge.css_class` to a terminal color — symbol is always the primary signal (already
+/// baked into the badge text itself), color is a secondary reinforcement only (matches the
+/// "무색 원칙" carried over from the HTML dashboard's design system).
+fn badge_style(css_class: &str) -> Style {
+    match css_class {
+        "pass" => Style::default().fg(Color::Green),
+        "warn" => Style::default().fg(Color::Yellow),
+        "fail" => Style::default().fg(Color::Red),
+        "teal" => Style::default().fg(Color::Cyan),
+        _ => Style::default().add_modifier(Modifier::DIM),
+    }
+}
+
+fn badge_span(badge: &Badge) -> Span<'static> {
+    Span::styled(format!("{} ", badge.symbol), badge_style(badge.css_class))
+}
+
+/// Entry point — lays out tabs bar / body / footer, then delegates the body to the Paul or
+/// wave tab renderer, and overlays a modal popup on top when one is open.
+pub fn draw(frame: &mut Frame, state: &AppState) {
+    let area = frame.area();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(3),
+            Constraint::Length(3),
+        ])
+        .split(area);
+
+    draw_tabs(frame, chunks[0], state);
+    if state.tab_index == 0 {
+        draw_paul_tab(frame, chunks[1], state);
+    } else {
+        draw_wave_tab(frame, chunks[1], state);
+    }
+    draw_footer(frame, chunks[2], state);
+
+    if let Some(modal) = &state.modal {
+        draw_modal(frame, area, modal);
+    }
+}
+
+fn draw_tabs(frame: &mut Frame, area: Rect, state: &AppState) {
+    let titles: Vec<Line> = state.tabs.iter().map(|t| Line::from(t.as_str())).collect();
+    let tabs = Tabs::new(titles)
+        .block(Block::default().borders(Borders::ALL).title("BATHOS panes"))
+        .select(state.tab_index)
+        .highlight_style(
+            Style::default()
+                .add_modifier(Modifier::BOLD)
+                .fg(Color::Cyan),
+        );
+    frame.render_widget(tabs, area);
+}
+
+fn draw_footer(frame: &mut Frame, area: Rect, state: &AppState) {
+    let hint = "←/→·Tab 탭전환  j/k 스크롤  c confirm  f feedback  r 새로고침  q 종료";
+    let text = match &state.status_message {
+        Some(msg) => format!("{hint}\n{msg}"),
+        None => hint.to_string(),
+    };
+    let para = Paragraph::new(text)
+        .block(Block::default().borders(Borders::ALL))
+        .wrap(Wrap { trim: true });
+    frame.render_widget(para, area);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Paul tab
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn draw_paul_tab(frame: &mut Frame, area: Rect, state: &AppState) {
+    let vm = &state.vm;
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(4),
+            Constraint::Min(3),
+            Constraint::Min(3),
+        ])
+        .split(area);
+
+    // ── header + warnings banner ──
+    let mut header_lines = vec![Line::from(vec![
+        Span::raw(
+            vm.codename
+                .clone()
+                .unwrap_or_else(|| "(제목 없음)".to_string()),
+        ),
+        Span::raw("  "),
+        Span::raw(vm.level_label.clone()),
+        Span::raw("  "),
+        badge_span(&vm.status_badge),
+    ])];
+    if vm.manifest_form_descriptive {
+        header_lines.push(Line::from("(서술형 manifest — 일부 필드 미확정)"));
+    }
+    for w in &vm.warnings {
+        header_lines.push(Line::from(format!("⚠ [{}] {}", w.code, w.message)));
+    }
+    let header =
+        Paragraph::new(header_lines).block(Block::default().borders(Borders::ALL).title("Project"));
+    frame.render_widget(header, chunks[0]);
+
+    // ── gate cards ──
+    let gate_items: Vec<ListItem> = if vm.gates.is_empty() {
+        vec![ListItem::new("(게이트 없음)")]
+    } else {
+        vm.gates.iter().map(gate_list_item).collect()
+    };
+    let gates = List::new(gate_items).block(Block::default().borders(Borders::ALL).title("Gates"));
+    frame.render_widget(gates, chunks[1]);
+
+    // ── audit timeline + chain badge ──
+    let mut audit_lines: Vec<Line> = vec![Line::from(vec![
+        Span::raw("chain: "),
+        badge_span(&vm.chain_badge),
+        Span::raw(vm.chain_detail.clone().unwrap_or_default()),
+    ])];
+    if vm.audit.is_empty() {
+        audit_lines.push(Line::from("(감사 이력 없음)"));
+    } else {
+        for a in vm.audit.iter().rev().take(20) {
+            audit_lines.push(Line::from(format!(
+                "#{} {} {} {} {}",
+                a.seq, a.ts_iso, a.actor, a.action, a.target
+            )));
+        }
+    }
+    let audit = Paragraph::new(audit_lines)
+        .block(Block::default().borders(Borders::ALL).title("Audit"))
+        .scroll((state.scroll, 0));
+    frame.render_widget(audit, chunks[2]);
+}
+
+fn gate_list_item(g: &GateCardVM) -> ListItem<'static> {
+    let mut spans = vec![
+        Span::raw(format!("{} [{}] ", g.gate_id, g.wave_id)),
+        Span::raw(format!("{} ", g.gate_type_label)),
+        badge_span(&g.verdict_badge),
+        Span::raw(format!(
+            "issues={} crit={} ",
+            g.issues_total, g.issues_critical
+        )),
+    ];
+    if g.facilitator_missing {
+        spans.push(Span::styled(
+            "facilitator 미기록",
+            Style::default().fg(Color::Yellow),
+        ));
+    } else if let Some(f) = &g.facilitator {
+        spans.push(Span::raw(format!("by {f}")));
+    }
+    if g.release_critical_warning {
+        spans.push(Span::styled(
+            " ⚠ Release+critical",
+            Style::default().fg(Color::Red),
+        ));
+    }
+    ListItem::new(Line::from(spans))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// wave tab
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn draw_wave_tab(frame: &mut Frame, area: Rect, state: &AppState) {
+    let vm = &state.vm;
+    let wave_id = state.current_wave().unwrap_or("");
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(4),
+            Constraint::Min(3),
+            Constraint::Min(3),
+        ])
+        .split(area);
+
+    // ── wave cell + its gates ──
+    let cell = vm.waves.iter().find(|w| w.wave_id == wave_id);
+    let mut header_lines = Vec::new();
+    if let Some(c) = cell {
+        header_lines.push(Line::from(vec![
+            Span::raw(format!("{} {} ", c.wave_id, c.name)),
+            badge_span(&c.status_badge),
+            Span::raw(format!("roles={}", c.active_roles.join(","))),
+        ]));
+        if let Some(entry) = &c.entry_gate {
+            header_lines.push(Line::from(format!("entry: {}", entry.label)));
+        }
+        if let Some(exit) = &c.exit_gate {
+            header_lines.push(Line::from(format!("exit: {}", exit.label)));
+        }
+    } else {
+        header_lines.push(Line::from("(웨이브 셀 정보 없음)"));
+    }
+    let header = Paragraph::new(header_lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(wave_id.to_string()),
+    );
+    frame.render_widget(header, chunks[0]);
+
+    // ── roles (this wave) + stories (unscoped, see module doc) ──
+    let role_items: Vec<ListItem> = vm
+        .roles
+        .iter()
+        .filter(|r| r.wave_id.as_deref() == Some(wave_id))
+        .map(role_list_item)
+        .collect();
+    let role_items = if role_items.is_empty() {
+        vec![ListItem::new("(배정된 역할 없음)")]
+    } else {
+        role_items
+    };
+    let roles = List::new(role_items).block(Block::default().borders(Borders::ALL).title("Roles"));
+    frame.render_widget(roles, chunks[1]);
+
+    let story_items: Vec<ListItem> = if vm.stories.is_empty() {
+        vec![ListItem::new("(스토리 없음)")]
+    } else {
+        vm.stories.iter().map(story_list_item).collect()
+    };
+    let stories = List::new(story_items).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title("Stories (전체 — wave 미분류)"),
+    );
+    frame.render_widget(stories, chunks[2]);
+}
+
+fn role_list_item(r: &RolePillVM) -> ListItem<'static> {
+    ListItem::new(Line::from(vec![
+        Span::raw(format!("{} ", r.name)),
+        badge_span(&r.status_badge),
+        Span::raw(r.model_label.clone().unwrap_or_default()),
+    ]))
+}
+
+fn story_list_item(s: &StoryCardView) -> ListItem<'static> {
+    let mut spans = vec![
+        Span::raw(format!("{} [{}] ", s.story_key, s.status_label)),
+        badge_span(&s.ready_badge),
+        badge_span(&s.lint_badge),
+        Span::raw(s.lint_summary_text.clone()),
+    ];
+    if s.stale {
+        spans.push(Span::styled(" STALE", Style::default().fg(Color::Yellow)));
+    }
+    ListItem::new(Line::from(spans))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// modal popup (confirm/feedback)
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vertical[1])[1]
+}
+
+fn draw_modal(frame: &mut Frame, area: Rect, modal: &Modal) {
+    let popup_area = centered_rect(60, 20, area);
+    frame.render_widget(Clear, popup_area);
+
+    let (title, hint, buffer) = match modal {
+        Modal::Confirm { buffer } => (
+            "Confirm (PASS|CONCERNS|FAIL|OK|STOP [사유], Enter=제출 Esc=취소)",
+            "",
+            buffer,
+        ),
+        Modal::Feedback { buffer } => ("Feedback (자유 서술, Enter=제출 Esc=취소)", "", buffer),
+    };
+    let text = format!("{hint}{buffer}_");
+    let para = Paragraph::new(text)
+        .block(Block::default().borders(Borders::ALL).title(title))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(para, popup_area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bathos_inspect::dashboard::viewmodel::build_vm;
+    use bathos_inspect::loader::{
+        ChainStatus, ManifestForm, ProjectMeta, ProjectStatus, ProjectView,
+    };
+    use ratatui::{backend::TestBackend, Terminal};
+
+    fn empty_pv() -> ProjectView {
+        ProjectView {
+            form: ManifestForm::Engine,
+            meta: ProjectMeta {
+                codename: Some("BATHOS".into()),
+                current_level: Some(3),
+                status: ProjectStatus::Active,
+                lang: Some("ko".into()),
+                created: None,
+                project_id: Some("bathos-0001".into()),
+            },
+            waves: vec![],
+            gates: vec![],
+            roles: vec![],
+            tasks: vec![],
+            risks: vec![],
+            artifacts: vec![],
+            routing: vec![],
+            modules: vec![],
+            stale_story_keys: vec![],
+            audit: vec![],
+            chain_status: ChainStatus::Absent,
+            audit_skipped: 0,
+            warnings: vec![],
+        }
+    }
+
+    #[test]
+    fn draw_paul_tab_does_not_panic_on_empty_vm() {
+        let vm = build_vm(&empty_pv(), &[]);
+        let state = AppState::new(vm, None);
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| draw(f, &state)).unwrap();
+    }
+
+    #[test]
+    fn draw_wave_tab_does_not_panic() {
+        use bathos_inspect::loader::{WaveStatus, WaveView};
+        let mut pv = empty_pv();
+        pv.waves = vec![WaveView {
+            wave_id: "W5".into(),
+            name: "Implement".into(),
+            status: WaveStatus::Active,
+            active_roles: vec!["Phillip".into()],
+            entry_gate: None,
+            exit_gate: None,
+            started: None,
+            ended: None,
+        }];
+        let vm = build_vm(&pv, &[]);
+        let state = AppState::new(vm, Some("W5".to_string()));
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| draw(f, &state)).unwrap();
+    }
+
+    #[test]
+    fn draw_with_open_modal_does_not_panic() {
+        let vm = build_vm(&empty_pv(), &[]);
+        let mut state = AppState::new(vm, None);
+        state.modal = Some(Modal::Confirm {
+            buffer: "PASS reason".into(),
+        });
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| draw(f, &state)).unwrap();
+    }
+
+    #[test]
+    fn draw_with_tiny_terminal_does_not_panic() {
+        // A degenerate (very small) terminal size must not crash the layout math.
+        let vm = build_vm(&empty_pv(), &[]);
+        let state = AppState::new(vm, None);
+        let backend = TestBackend::new(10, 6);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| draw(f, &state)).unwrap();
+    }
+}

--- a/docs/COMMANDS-kr.md
+++ b/docs/COMMANDS-kr.md
@@ -99,6 +99,79 @@
 
 ---
 
+## 10. `bathos` CLI 서브커맨드 — 역할별 모델(A) + Wave 패널(B)
+
+> 위 1~9는 **슬래시 커맨드**(`.claude/commands/*.md`, Paul이 대화로 실행)이고 여기부터는
+> **`bathos` 엔진 바이너리**(`core/target/release/bathos`)를 직접 호출하는 CLI 서브커맨드다
+> (총 35개 슬래시 커맨드 집계에는 포함되지 않음). 설계 원본:
+> `.agent-team/04-architecture/w2-panes-model-design-kr.md`(James) — 구현: Phillip.
+> 각 웨이브 커맨드(`/wave0-analysis` ~ `/wave6-verify-report`)는 스폰 직전에 "## 모델 선택"
+> 절차로 `model detect/show/set/validate`를 호출하고, 스폰 완료 직후 `bathos panes` 관측을
+> 안내한다(§A2.3·§B4.3 정본 텍스트, 7개 웨이브 커맨드 모두 삽입 완료).
+
+### 10.1 `bathos model` — 역할별 모델/런타임 선택 (ADR-D-0005/0006)
+
+`_state/model-plan.json`(schema `bathos/model-plan@1`)을 SSOT로 삼아 역할별 `runtime`
+(`claude`/`glm`/`codex`)·`model`을 배정한다. **plan 파일이 없거나 그 역할이 미등재면 항상
+agent frontmatter `model:`로 폴백** — 이 기능을 한 번도 쓰지 않은 프로젝트는 이전과 100%
+동일하게 동작한다(하위호환이 최우선 제약).
+
+```
+bathos model show    [--wave W5] [--json]                 # 역할별 유효값 표 (source: plan|default|frontmatter|runtime-default)
+bathos model set     <slug> --runtime <r> [--model <m>] [--reasoning-effort <e>]   # plan에 기록(변경분만)
+bathos model unset   <slug>                                # plan에서 제거 → frontmatter 폴백
+bathos model detect                                        # session_backend 판별·기록(env ANTHROPIC_BASE_URL 검사)
+bathos model validate [--wave W5]                          # GLM/Codex 혼합 배치 규칙 검증. PASS=exit 0 / 위반=exit 2 + 해소 선택지
+bathos model resolve  <slug> [--json]                      # 한 역할의 유효 runtime/model/적용채널 1줄 출력(스크립트 소비용)
+```
+
+- **claude**: 팀원 스폰 파라미터로 역할별 상이 모델 지정 가능(fable5/sonnet5/haiku, 제약 없음).
+- **glm**: `ANTHROPIC_BASE_URL`이 프로세스 전역이라 **역할 단위 지정 불가** — 웨이브·세션 단위만.
+  같은 배치에 `claude`+`glm`이 섞이면 `validate`가 `E-MODEL-MIX`(exit 2)로 차단하고 해소
+  선택지 3종(배치 전체 GLM/역할 이동/순차 분할)을 제시한다. 상세·제약의 물리적 근거는
+  `docs/glm-backend-kr.md` §"모델/런타임 혼합 제약(ADR-D-0005)" 참고.
+- **codex**: 별도 CLI 프로세스라 Claude 팀원과 병행 무충돌(GLM과의 비대칭) — 팀원으로
+  스폰하지 않고 `codex-adapter/run-role.sh <slug> <task-file>`로 위임한다.
+- 오류 코드: `E-MODEL-ROLE-UNKNOWN`·`E-MODEL-RUNTIME-INVALID`·`E-MODEL-MIX`·
+  `E-MODEL-BACKEND-MISMATCH`·`E-MODEL-PLAN-CORRUPT`(파손 시 `.bak` 백업 후 재생성 안내).
+
+### 10.2 `bathos inspect vm` — Wave 패널 공유 데이터원 (ADR-D-0007)
+
+4개 프론트엔드(HTML report·live serve·tmux 패널·bathos TUI)가 공유하는 단일 데이터원
+`DashboardVM`을 노출한다. 새 상태 계층을 발명하지 않고 기존 `build_dashboard_vm_json`을
+재사용한다(Search Before Building).
+
+```
+bathos inspect vm [--path <.agent-team>] [--wave W5] [--format json|lines]
+```
+
+- `--format json`(기본) = `bathos inspect report --json`과 바이트 동일(기존 하위호환 유지).
+- `--format lines` = bash 3.2/jq-금지 환경용 TSV 라인 프로토콜(`proto`/`meta`/`wave`/`gate`/
+  `role`/`story`/`artifact`/`audit`/`chain` 레코드, 필드는 항상 뒤에만 추가). `scripts/bathos-panes.sh`가
+  이 출력을 `grep`/`cut`/`read`로만 소비한다(jq 불요).
+- `--wave W5`로 해당 웨이브 관련 레코드(웨이브 셀+게이트+역할/산출물/스토리)만 필터.
+
+### 10.3 `bathos panes` — Wave 패널 프론트엔드 선택 (ADR-D-0008/0009)
+
+```
+bathos panes [--mode tui|tmux|dump] [--path <.agent-team>] [--wave W5] [--interval 2]
+```
+
+- `--mode tui`(TTY 기본) = 내장 `bathos-tui` 크레이트(ratatui+crossterm) 대화식 패널.
+  탭 구성 = `Paul | W0…W6`(라우팅된 웨이브만), 키맵 `←/→·Tab`=탭 전환·`j/k`=스크롤·
+  `c`=confirm 모달·`f`=feedback 모달·`r`=새로고침·`q`=종료.
+- `--mode tmux` = `scripts/bathos-panes.sh up`으로 위임 — tmux 3.7 분할 패널(제어/상태/입력).
+  Windows 네이티브는 tmux 부재로 미지원(WSL 또는 `--mode tui` 권장).
+- `--mode dump` = 비대화 1프레임 렌더 스냅샷(테스트/CI/파이프 소비용).
+- 모드 미지정 + TTY: 대화형으로 tmux/TUI 중 선택받고 `_state/panes/prefs`에 기억(다음 기본값).
+- **패널의 confirm/feedback은 "제안 채널"**이다 — `_state/panes/inbox/`에 파일로 쌓이고
+  웨이브 흐름이 게이트 체크포인트에서 소비한다. 게이트 판정 정본 기록은 여전히
+  `bathos gate`(FACILITATOR 원칙, 근거 없는 자동 PASS 금지)이며 패널이 대신 기록하지 않는다.
+- 자동 기동 안 함 — Paul(Claude Code) 자신은 이미 자기 TTY를 점유 중이므로, 패널은
+  **사람이 여는 두 번째 터미널**의 관측/입력 도구다(각 웨이브 커맨드 말미의 힌트 1줄 참고).
+
+---
+
 ## 권장 흐름
 
 ```

--- a/docs/glm-backend-kr.md
+++ b/docs/glm-backend-kr.md
@@ -55,6 +55,36 @@ BATHOS 에이전트 정의(`.claude/agents/_base/*.md`)의 `model` 필드는 **`
 unset ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN API_TIMEOUT_MS
 ```
 
+## 5. 역할별 모델 혼합 제약 — `bathos model validate` (ADR-D-0005)
+
+이 문서의 "모델 스왑" 성격에는 **물리적 한계**가 하나 있다: 위 §1의 `ANTHROPIC_BASE_URL`은
+**프로세스 전역**이다 — 같은 Claude Code 프로세스 안에서 팀원 A는 GLM, 팀원 B는 Claude로
+나가게 하는 것은 불가능하다(env가 하나뿐이라 전 팀원+Paul 자신이 같은 백엔드를 공유).
+`_state/model-plan.json`(§A1, `bathos model`)으로 역할별 `runtime`을 지정할 수 있게 된
+뒤에도 이 제약은 사라지지 않으므로, `bathos model validate --wave <W>`가 웨이브 스폰
+전에 이를 강제한다:
+
+- **R1(불변식)**: 한 세션의 모든 인프로세스 팀원은 같은 백엔드를 쓴다 — "이 역할만 GLM"은
+  물리적으로 불가하며 이 사실을 UI/문서에서 숨기지 않는다.
+- **R2(충족 조건)**: `runtime=glm` 역할이 스폰 가능하려면 `session_backend=glm`이어야
+  한다(= 위 §1처럼 `source scripts/glm-env.sh` 후 `claude`를 띄운 세션). 이때 같은 배치의
+  `runtime=claude` 역할도 **사실상 GLM으로 구동**되므로 `validate`가 `E-MODEL-MIX`(exit 2)로
+  차단한다.
+- **R3(해소 선택지, `validate`가 출력)**: ① 배치 전체 GLM로 통일 ② GLM 희망 역할을
+  `claude`/`codex`로 재배정 ③ `mixed_policy=sequential` — claude 배치를 현 세션에서 먼저
+  끝내고 shutdown → 사용자가 `source scripts/glm-env.sh && claude`로 재기동한 새 세션에서
+  GLM 배치를 이어감(세션 재기동은 사람의 행동이라 자동화 불가 — 정직한 한계).
+- **R4(mismatch)**: `session_backend=glm`인 세션에서 `runtime=claude`를 명시한 역할이
+  있으면 `E-MODEL-BACKEND-MISMATCH` — "이 세션에서 claude 지정은 이행 불가(전부 GLM으로
+  나감)"를 알리고 사용자 확인 후 표기를 정정한다(침묵 오차단·침묵 오표기 둘 다 금지).
+
+Codex(`runtime=codex`)는 **별도 프로세스**라 이 제약에서 예외다 — GLM처럼 env를 공유하지
+않으므로 같은 배치의 Claude/GLM 팀원과 병행 무충돌(`codex-adapter/run-role.sh`로 위임,
+`docs/codex-adapter-kr.md` 참고).
+
+상세 설계·엣지케이스 전수: `.agent-team/04-architecture/w2-panes-model-design-kr.md`
+§A3.2(R1~R4 원문)·§B6(E1~E14)·ADR-D-0005. CLI 레퍼런스: `docs/COMMANDS-kr.md` §10.1.
+
 ## 상태 — 실연결 검증 하네스 (2026-07-16, Phillip)
 
 `scripts/glm-smoke-test.sh`가 이 문서의 "환경변수 2개면 GLM으로 구동된다"는

--- a/scripts/_test-bathos-panes.sh
+++ b/scripts/_test-bathos-panes.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# =============================================================================
+# BATHOS  scripts/_test-bathos-panes.sh  —  tmux 헤드리스 스모크 테스트 (T7)
+#
+# 실제 사용자 없이 `bathos-panes.sh`의 핵심 계약만 검증한다:
+#   1) __control 서브커맨드가 "confirm <W> <VERDICT> <사유>" 입력을 받아
+#      inbox/confirm-<W>-*.txt 파일을 실제로 생성하는가(내용까지)
+#   2) __input 서브커맨드도 동일 계약을 지키는가(웨이브별 입력 pane)
+#   3) 자유서술 입력은 feedback-*.md로 떨어지는가
+#   4) up의 프리플라이트(E-TMUX-ABSENT/E-BATHOS-ABSENT)가 실제로 정확한 exit code를 내는가
+#
+# tmux가 없는 CI 환경에서도 죽지 않도록 SKIP(exit 0)한다 — 이 프로젝트의 fail-safe 관례
+# (codex-adapter/hooks/_test-codex-hooks.sh와 동일 원칙: 도구 부재는 실패가 아니다).
+#
+# 실행: bash scripts/_test-bathos-panes.sh
+# =============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PANES_SH="$SCRIPT_DIR/bathos-panes.sh"
+
+PASS=0
+FAIL=0
+
+ok()   { PASS=$((PASS+1)); printf '  ✓ %s\n' "$*"; }
+bad()  { FAIL=$((FAIL+1)); printf '  ✗ %s\n' "$*" >&2; }
+
+if ! command -v tmux >/dev/null 2>&1; then
+  printf '[SKIP] tmux 미설치 — 헤드리스 스모크를 건너뜁니다(CI fail-safe, exit 0)\n'
+  exit 0
+fi
+
+WORK="$(mktemp -d 2>/dev/null || mktemp -d -t bathospanes)"
+ALL_SESSIONS=""
+cleanup() {
+  for s in $ALL_SESSIONS; do
+    tmux kill-session -t "$s" >/dev/null 2>&1 || true
+  done
+  # WORK is a mktemp-created scratch dir under the OS temp root — removing it (not a
+  # project path) is the intended teardown, not the "careful" destructive-command class.
+  rm -rf "$WORK" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+AGENT_TEAM="$WORK/.agent-team"
+mkdir -p "$AGENT_TEAM/_state/panes/inbox"
+cat > "$AGENT_TEAM/_state/manifest.json" <<'JSON'
+{"project_id":"bathos-test-panes","codename":"BATHOS-TEST","current_level":3,"status":"active","lang":"ko","created":"2026-07-16T00:00:00Z"}
+JSON
+
+SESSION="test-bathos-panes-$$"
+ALL_SESSIONS="$ALL_SESSIONS $SESSION"
+
+printf '== T7a: __control confirm → inbox 파일 생성 ==\n'
+# The pane runs __control directly as its command (not typed into an interactive login
+# shell) — this keeps the test independent of the operator's shell rc/startup behavior.
+tmux new-session -d -s "$SESSION" -x 200 -y 50 "'$PANES_SH' __control '$AGENT_TEAM'"
+sleep 1
+tmux send-keys -t "$SESSION" "confirm W5 PASS 사유동작확인" Enter
+sleep 1
+
+OUT="$(tmux capture-pane -p -t "$SESSION" 2>/dev/null || true)"
+if printf '%s' "$OUT" | grep -q "inbox 기록됨"; then
+  ok "pane echo에 'inbox 기록됨' 출력됨"
+else
+  bad "pane echo에 'inbox 기록됨' 누락: $OUT"
+fi
+
+CONFIRM_FILE="$(find "$AGENT_TEAM/_state/panes/inbox" -name 'confirm-W5-*.txt' 2>/dev/null | head -1)"
+if [ -n "$CONFIRM_FILE" ] && [ -f "$CONFIRM_FILE" ]; then
+  ok "confirm-W5-*.txt 파일 생성됨: $(basename "$CONFIRM_FILE")"
+  CONTENT="$(cat "$CONFIRM_FILE")"
+  if printf '%s' "$CONTENT" | grep -q "^PASS"; then
+    ok "파일 내용 첫 필드=PASS"
+  else
+    bad "파일 내용 첫 필드 불일치: $CONTENT"
+  fi
+  if printf '%s' "$CONTENT" | grep -q "사유동작확인"; then
+    ok "파일 내용에 사유 텍스트 포함"
+  else
+    bad "파일 내용에 사유 텍스트 누락: $CONTENT"
+  fi
+else
+  bad "confirm-W5-*.txt 파일이 생성되지 않음"
+fi
+
+tmux kill-session -t "$SESSION" >/dev/null 2>&1 || true
+
+printf '\n== T7b: __input(웨이브별 입력 pane) — 자유서술은 feedback-*.md ==\n'
+SESSION2="test-bathos-panes-input-$$"
+ALL_SESSIONS="$ALL_SESSIONS $SESSION2"
+tmux new-session -d -s "$SESSION2" -x 200 -y 50 "'$PANES_SH' __input '$AGENT_TEAM' 'W3'"
+sleep 1
+tmux send-keys -t "$SESSION2" "이건 자유 서술 피드백입니다" Enter
+sleep 1
+
+FEEDBACK_FILE="$(find "$AGENT_TEAM/_state/panes/inbox" -name 'feedback-W3-*.md' 2>/dev/null | head -1)"
+if [ -n "$FEEDBACK_FILE" ] && [ -f "$FEEDBACK_FILE" ]; then
+  ok "feedback-W3-*.md 파일 생성됨: $(basename "$FEEDBACK_FILE")"
+  if grep -q "자유 서술 피드백" "$FEEDBACK_FILE"; then
+    ok "feedback 파일 내용에 원문 포함"
+  else
+    bad "feedback 파일 내용 불일치: $(cat "$FEEDBACK_FILE")"
+  fi
+else
+  bad "feedback-W3-*.md 파일이 생성되지 않음"
+fi
+
+tmux kill-session -t "$SESSION2" >/dev/null 2>&1 || true
+
+printf '\n== T7c: __input 웨이브별 verdict 키워드도 confirm-*.txt로 ==\n'
+SESSION3="test-bathos-panes-input2-$$"
+ALL_SESSIONS="$ALL_SESSIONS $SESSION3"
+tmux new-session -d -s "$SESSION3" -x 200 -y 50 "'$PANES_SH' __input '$AGENT_TEAM' 'W6'"
+sleep 1
+tmux send-keys -t "$SESSION3" "STOP 긴급" Enter
+sleep 1
+
+STOP_FILE="$(find "$AGENT_TEAM/_state/panes/inbox" -name 'confirm-W6-*.txt' 2>/dev/null | head -1)"
+if [ -n "$STOP_FILE" ]; then
+  ok "confirm-W6-*.txt(STOP) 생성됨: $(basename "$STOP_FILE")"
+else
+  bad "confirm-W6-*.txt(STOP)이 생성되지 않음"
+fi
+tmux kill-session -t "$SESSION3" >/dev/null 2>&1 || true
+
+printf '\n== T8-lite: up 프리플라이트 — E-BATHOS-ABSENT(exit 4) ==\n'
+EMPTY_PROJECT="$WORK/empty-project"
+mkdir -p "$EMPTY_PROJECT"
+# tmux가 있는 디렉터리는 남기되(E-TMUX-ABSENT 아닌 E-BATHOS-ABSENT를 유도해야 하므로),
+# bathos 바이너리는 어디서도 못 찾도록 PATH를 좁힌다(BATHOS_BIN도 비움).
+TMUX_DIR="$(dirname "$(command -v tmux)")"
+if env -i PATH="/usr/bin:/bin:$TMUX_DIR" BATHOS_PANES_NO_ATTACH=1 \
+     "$PANES_SH" up --project "$EMPTY_PROJECT" >/tmp/bathos-panes-preflight.$$ 2>&1; then
+  EXIT_CODE=0
+else
+  EXIT_CODE=$?
+fi
+if [ "$EXIT_CODE" = "4" ]; then
+  ok "bathos 바이너리 없는 프로젝트에서 up → exit 4(E-BATHOS-ABSENT)"
+else
+  bad "기대 exit 4, 실제 exit $EXIT_CODE ($(cat /tmp/bathos-panes-preflight.$$ 2>/dev/null))"
+fi
+rm -f "/tmp/bathos-panes-preflight.$$" 2>/dev/null || true
+
+printf '\n== T7d: PANES-002 회귀 — 경로 이탈(../) 시도한 wave 토큰이 inbox 밖에 쓰지 못함 ==\n'
+EVIL_TARGET="$WORK/evil-outside-inbox"
+mkdir -p "$EVIL_TARGET"
+SESSION4="test-bathos-panes-traversal-$$"
+ALL_SESSIONS="$ALL_SESSIONS $SESSION4"
+# The malicious "wave" token below is exactly what a manipulated `--waves`/auto-detected wave id
+# would look like reaching `__input` positionally (§B3.1) — a real attack does not need shell
+# metacharacters here, just enough `../` segments to walk out of `_state/panes/inbox/`.
+tmux new-session -d -s "$SESSION4" -x 200 -y 50 \
+  "'$PANES_SH' __input '$AGENT_TEAM' '../../../../../../$EVIL_TARGET'"
+sleep 1
+tmux send-keys -t "$SESSION4" "PASS should-not-escape" Enter
+sleep 1
+if find "$EVIL_TARGET" -type f 2>/dev/null | grep -q .; then
+  bad "PANES-002 회귀: evil target 디렉터리에 파일이 생성됨(경로 이탈 발생)"
+else
+  ok "evil target 디렉터리는 비어 있음(경로 이탈 없음)"
+fi
+INBOX_TRAVERSAL_FILE="$(find "$AGENT_TEAM/_state/panes/inbox" -name 'confirm-*evil-outside-inbox*.txt' 2>/dev/null | head -1)"
+if [ -n "$INBOX_TRAVERSAL_FILE" ]; then
+  ok "sanitize된 이름으로 inbox 안에만 기록됨: $(basename "$INBOX_TRAVERSAL_FILE")"
+else
+  bad "sanitize된 confirm 파일을 inbox에서 찾지 못함"
+fi
+tmux kill-session -t "$SESSION4" >/dev/null 2>&1 || true
+
+printf '\n== T7e: PANES-001 회귀 — 작은따옴표가 포함된 --project 경로에서도 인젝션 없이 정상 기동 ==\n'
+find_release_bathos() {
+  local repo_root
+  repo_root="$(cd "$SCRIPT_DIR/.." && pwd)"
+  for cand in "$repo_root/core/target/release/bathos" "$repo_root/core/target/debug/bathos"; do
+    if [ -x "$cand" ]; then printf '%s' "$cand"; return 0; fi
+  done
+  return 1
+}
+BATHOS_FOR_T7E="$(find_release_bathos || true)"
+if [ -z "$BATHOS_FOR_T7E" ]; then
+  printf '[SKIP] bathos 바이너리 미빌드 — T7e 생략(cargo build --release 후 재실행 권장)\n'
+else
+  CANARY="$WORK/PANES001_CANARY"
+  rm -f "$CANARY"
+  # This directory name is exactly the shape of the PANES-001 PoC in the security finding
+  # (`.agent-team/10-security/panes-model-findings.json` PANES-001 `evidence`): a single quote
+  # followed by a shell command, followed by a re-opening quote. On a filesystem this is just
+  # an unusual (but entirely legal) directory name — `mkdir` never interprets it as shell. The
+  # only question this test answers is whether `bathos-panes.sh` does.
+  QUOTE_PROJECT="$WORK/evil'; touch $CANARY; echo '"
+  mkdir -p "$QUOTE_PROJECT/.agent-team/_state"
+  cat > "$QUOTE_PROJECT/.agent-team/_state/manifest.json" <<'JSON'
+{"project_id":"quote-test","codename":"T","current_level":3,"status":"active","lang":"ko","created":"2026-07-16T00:00:00Z"}
+JSON
+  SESSION5="test-bathos-panes-quote-$$"
+  ALL_SESSIONS="$ALL_SESSIONS $SESSION5"
+  # Before the PANES-001 fix, this --project value broke out of the `'$AGENT_TEAM'` pane
+  # command interpolation and ran `touch $CANARY` as a real shell command in the spawned pane's
+  # shell. After the fix it must be treated as an inert, single opaque argument end-to-end.
+  BATHOS_BIN="$BATHOS_FOR_T7E" BATHOS_PANES_NO_ATTACH=1 \
+    "$PANES_SH" up --project "$QUOTE_PROJECT" --waves "W5" --interval 2 \
+    >/tmp/bathos-panes-quote.$$ 2>&1
+  sleep 1
+  if [ -f "$CANARY" ]; then
+    bad "PANES-001 회귀: 작은따옴표 경로로 인젝션 발생(canary 파일 생성됨)"
+    rm -f "$CANARY"
+  else
+    ok "작은따옴표 경로에서도 인젝션 없음(canary 미생성)"
+  fi
+  QUOTE_SESSION="$(tmux ls 2>/dev/null | grep '^bathos-quote-test' | cut -d: -f1 | head -1)"
+  if [ -n "$QUOTE_SESSION" ]; then
+    ALL_SESSIONS="$ALL_SESSIONS $QUOTE_SESSION"
+    PANE_COUNT="$(tmux list-panes -t "$QUOTE_SESSION" 2>/dev/null | wc -l | tr -d ' ')"
+    if [ "${PANE_COUNT:-0}" -ge 2 ]; then
+      ok "작은따옴표 경로에서도 세션이 정상 기동됨(panes=$PANE_COUNT)"
+    else
+      bad "세션은 생겼으나 pane 수가 예상보다 적음(panes=${PANE_COUNT:-0})"
+    fi
+    tmux kill-session -t "$QUOTE_SESSION" >/dev/null 2>&1 || true
+  else
+    bad "작은따옴표 경로에서 세션이 생성되지 않음: $(cat /tmp/bathos-panes-quote.$$ 2>/dev/null)"
+  fi
+  rm -f "/tmp/bathos-panes-quote.$$" 2>/dev/null || true
+fi
+
+printf '\n=========================================\n'
+printf '결과: PASS=%d FAIL=%d\n' "$PASS" "$FAIL"
+if [ "$FAIL" -eq 0 ]; then
+  printf '전체 통과\n'
+  exit 0
+else
+  printf '실패 항목 있음\n' >&2
+  exit 1
+fi

--- a/scripts/bathos-panes.sh
+++ b/scripts/bathos-panes.sh
@@ -1,0 +1,510 @@
+#!/usr/bin/env bash
+# =============================================================================
+# BATHOS  scripts/bathos-panes.sh  —  tmux Wave 패널 프론트엔드 (B3, ADR-D-0007/0009)
+#
+# 사용:
+#   bathos-panes.sh up      [--project <절대경로>] [--waves "W2 W5"] [--interval 2]
+#   bathos-panes.sh attach  [--project <절대경로>]
+#   bathos-panes.sh down    [--project <절대경로>]
+#   bathos-panes.sh status  [--project <절대경로>]
+#
+# exit 0=성공 / 1=실행 실패 / 3=E-TMUX-ABSENT / 4=E-BATHOS-ABSENT
+#
+# 무엇을 하는가: `bathos inspect vm --format lines`(bathos-inspect DashboardVM, ADR-D-0007)
+# 하나의 데이터원을 tmux 분할 패널에 2초 간격으로 렌더링하고, 패널에서 입력한
+# confirm/feedback/answer를 `_state/panes/inbox/`에 파일로 흘린다(ADR-D-0009). 게이트
+# 정본 기록은 여전히 `bathos gate`(웨이브 흐름) — 이 패널의 confirm은 "제안 채널"이다.
+#
+# 왜 파일 기반 입력인가: 팀원(Claude Code 서브에이전트)에는 TTY가 없다 — 이 스크립트는
+# **사람이 여는 두 번째 터미널**의 관측/입력 도구다(F9). Paul(리드) 자신의 세션이 이
+# 스크립트를 자동 기동하지 않는 이유도 같다(자기 TTY를 이미 점유 중).
+#
+# 이식성: bash 3.2(macOS 기본) 호환 — mapfile/연관배열(`declare -A`)/`${var,,}`/`&>` 금지.
+# jq 금지 — `bathos inspect vm --format lines`의 TSV를 awk/grep/cut/read로만 소비한다.
+# Windows 네이티브는 tmux가 없어 미지원 — WSL(`scripts/wsl-setup.sh`) 또는
+# `bathos panes --mode tui`(§B4, crossterm)를 대신 쓴다.
+# =============================================================================
+set -uo pipefail
+
+PROG="bathos-panes.sh"
+SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+
+say()  { printf '[%s] %s\n' "$PROG" "$*"; }
+warn() { printf '[%s] ⚠ %s\n' "$PROG" "$*" >&2; }
+err()  { printf '[%s] ✗ %s\n' "$PROG" "$*" >&2; }
+
+# POSIX single-quote escaping (PANES-001 fix). tmux `new-session`/`split-window`'s final
+# positional argument is a *shell-command* string — tmux hands it to a brand-new pane shell
+# ($SHELL -c "<string>"), which parses it a second time. The naive `'$var'` interpolation this
+# script used to do breaks (and lets an attacker or an unlucky path with an apostrophe inject
+# arbitrary commands) the instant $var itself contains a single quote. This closes the current
+# quote, appends an escaped literal quote, then reopens quoting — the standard POSIX idiom for
+# embedding a value inside single quotes safely: `'%s'` with every `'` in the value replaced by
+# `'\''`. Always call this on every value interpolated into a pane spawn command below.
+sh_quote() { printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"; }
+
+# Filename-component sanitizer (PANES-002 fix) — mirrors `bathos-tui/src/inbox.rs`'s
+# `sanitize_component` exactly (strip everything but ASCII alnum/-/_ , empty result -> UNKNOWN).
+# Applied to every user/caller-supplied token (`$wave`/`$w`/`$w2`/`$qid`) right before it becomes
+# part of an inbox file path, so the three independent inbox writers (TUI/tmux/run-role.sh) all
+# enforce the same "cannot escape `_state/panes/inbox/`" invariant the design doc requires —
+# a component built only from this alphabet cannot contain `/` or `..`, so there is no traversal
+# pattern to block, only an allowed character set.
+sanitize() {
+  local cleaned
+  cleaned="$(printf '%s' "$1" | tr -cd 'A-Za-z0-9_-')"
+  if [ -z "$cleaned" ]; then
+    printf 'UNKNOWN'
+  else
+    printf '%s' "$cleaned"
+  fi
+}
+
+# Guards a computed inbox file path against ever landing outside `$inbox` (belt-and-braces —
+# PANES-002 defense-in-depth on top of `sanitize`, mirroring `bathos-tui/src/inbox.rs`'s
+# `assert!(final_path.starts_with(dir))`). Given a sanitized component this branch should be
+# unreachable; it exists anyway so a future change that forgets to sanitize fails loudly
+# instead of silently writing outside the inbox. $1=candidate path, $2=inbox dir.
+assert_in_inbox() {
+  case "$1" in
+    "$2"/*) return 0 ;;
+    *) err "경로 이탈 감지 — 기록 거부: $1"; return 1 ;;
+  esac
+}
+
+# Atomically writes a `printf`-formatted record to `$1` via a same-directory `.tmp` + `mv`
+# (never a partial/torn file on disk — pre-existing convention) and additionally chmod's it to
+# 0600 before the rename (PANES-004 fix): these files carry free-form confirm/feedback/answer
+# text that previously inherited the process umask (typically 0644, world-readable), which
+# matters on a shared multi-user host even though this is a local single-user tool by default.
+# $1=dest path, remaining args are `printf`'s own format + arguments (kept separate, not
+# pre-expanded into a string, so this never strips/mangles a trailing newline).
+write_atomic600() {
+  local dest="$1"
+  shift
+  printf "$@" > "$dest.tmp" || return 1
+  chmod 600 "$dest.tmp" 2>/dev/null || true
+  mv "$dest.tmp" "$dest"
+}
+
+usage() {
+  cat <<'EOF'
+사용: bathos-panes.sh <up|attach|down|status> [--project <절대경로>] [--waves "W2 W5"] [--interval 2]
+
+  up      tmux 세션 생성(기존재 시 재사용) + attach
+  attach  기존 세션에 attach만
+  down    세션 종료 + session.info 정리
+  status  세션 존재 여부 + pane 수 출력
+
+옵션:
+  --project <DIR>   대상 프로젝트 절대경로(기본: 현재 디렉터리)
+  --waves "W2 W5"   렌더할 웨이브(공백 구분). 미지정 시 active|gated 웨이브 자동 선택
+                    (없으면 가장 최근 done 웨이브 1개 + 안내)
+  --interval N      렌더 루프 주기(초, 기본 2)
+
+exit 0=성공 / 1=실행 실패 / 3=E-TMUX-ABSENT(tmux 미설치) / 4=E-BATHOS-ABSENT(bathos 바이너리 없음)
+
+Windows 네이티브는 tmux가 없어 미지원 — WSL(scripts/wsl-setup.sh) 또는
+`bathos panes --mode tui`(crossterm, Windows Terminal 지원)를 대신 쓴다.
+EOF
+}
+
+# --------------------------------------------------------------------------
+# 0. bathos 바이너리 탐색 (codex-adapter/hooks/pretooluse-gate.sh와 동일 순서)
+# --------------------------------------------------------------------------
+find_bathos_bin() {
+  local project="$1"
+  if [ -n "${BATHOS_BIN:-}" ] && [ -x "${BATHOS_BIN:-}" ]; then
+    printf '%s' "$BATHOS_BIN"
+    return 0
+  fi
+  local cand
+  for cand in "$project/core/target/release/bathos" "$project/core/target/debug/bathos"; do
+    if [ -x "$cand" ]; then
+      printf '%s' "$cand"
+      return 0
+    fi
+  done
+  if command -v bathos >/dev/null 2>&1; then
+    command -v bathos
+    return 0
+  fi
+  return 1
+}
+
+# --------------------------------------------------------------------------
+# internal subcommands — invoked by tmux `send-keys` inside a fresh pane shell
+# (panes don't inherit this script's function definitions, so each pane re-execs
+# this same script file with a hidden `__*` verb).
+# --------------------------------------------------------------------------
+
+# renders one wave's `--format lines` output + a best-effort wave-log tail,
+# looping every INTERVAL seconds. Never exits on a transient bathos failure
+# (shows "[로드 실패] ..." and keeps polling) — a panel that crashes on one bad
+# read is worse than one that shows a stale/error frame and keeps going (E9).
+__render() {
+  local at="$1" wave="$2" interval="$3" bathos_bin="$4"
+  while :; do
+    local out
+    if out="$("$bathos_bin" inspect vm --path "$at" --wave "$wave" --format lines 2>&1)"; then
+      :
+    else
+      out="[로드 실패] $out"
+    fi
+    printf '\033[2J\033[H'
+    printf '=== BATHOS panel — wave %s (%ss 주기, Ctrl-C로 이 pane만 종료) ===\n' "$wave" "$interval"
+    render_lines "$out"
+    printf -- '--- wave-log.md tail (최선노력 필터: %s) ---\n' "$wave"
+    if [ -f "$at/_state/wave-log.md" ]; then
+      tail -n 15 "$at/_state/wave-log.md" 2>/dev/null | grep -i "$wave" || printf '(해당 웨이브 언급 없음)\n'
+    else
+      printf '(wave-log.md 없음)\n'
+    fi
+    sleep "$interval"
+  done
+}
+
+# formats the TSV lines protocol (§B1) into human-readable text via awk (no jq).
+render_lines() {
+  local text="$1"
+  printf '%s\n' "$text" | awk -F'\t' '
+    $1=="proto" { printf "proto: %s v%s\n", $2, $3; next }
+    $1=="meta"  { printf "meta   %-10s %s %s\n", $2, $3, (NF>=4?$4:""); next }
+    $1=="warn"  { printf "WARN   [%s] %s\n", $2, $3; next }
+    $1=="wave"  { printf "wave   %-4s %-10s %s %-16s roles=%s\n", $2, $3, $4, $5, $6; next }
+    $1=="gate"  { printf "gate   %-14s wave=%-4s %-16s %-9s %s %s facilitator=%s\n", $2, $3, $4, $5, $6, $7, $8; next }
+    $1=="role"  { printf "role   %-20s %-10s %s wave=%s\n", $2, $3, $4, $5; next }
+    $1=="story" { printf "story  %-30s %-14s %s %s\n", $2, $3, $4, $5; next }
+    $1=="artifact" { printf "artifact %-40s owner=%-12s %s\n", $2, $3, $4; next }
+    $1=="audit" { printf "audit  #%-4s %s %-14s %-20s %s\n", $2, $3, $4, $5, $6; next }
+    $1=="chain" { printf "chain  %s %s\n", $2, $3; next }
+    { print }
+  '
+}
+
+# tiny input REPL — `read`s one line at a time; a recognized verdict keyword
+# writes a `confirm-<wave>-<ts>.txt`, anything else writes a `feedback-<wave>-<ts>.md`
+# (§B2 contract). ts includes `$$` (pid) so same-second submissions never collide (E10).
+__input() {
+  local at="$1" wave="$2"
+  local inbox="$at/_state/panes/inbox"
+  mkdir -p "$inbox"
+  # PANES-002: sanitize the wave token *once* into the value that actually becomes part of a
+  # file path — the unsanitized $wave is still used in the human-facing prompt text below,
+  # where it is display-only and never touches the filesystem.
+  local wave_safe
+  wave_safe="$(sanitize "$wave")"
+  printf '[%s 입력] PASS|CONCERNS|FAIL|OK|STOP [사유] 또는 자유 서술(feedback)\n' "$wave"
+  while :; do
+    printf '%s> ' "$wave"
+    IFS= read -r line || break
+    [ -z "$line" ] && continue
+    local first="${line%% *}"
+    local ts
+    ts="$(date +%s)-$$"
+    case "$first" in
+      PASS|CONCERNS|FAIL|OK|STOP)
+        local rest="${line#* }"
+        [ "$rest" = "$line" ] && rest=""
+        local f="$inbox/confirm-$wave_safe-$ts.txt"
+        assert_in_inbox "$f" "$inbox" || continue
+        write_atomic600 "$f" '%s\t%s\t%s\n' "$first" "$rest" "panel"
+        printf '→ inbox 기록됨: %s\n' "$(basename "$f")"
+        ;;
+      *)
+        local f2="$inbox/feedback-$wave_safe-$ts.md"
+        assert_in_inbox "$f2" "$inbox" || continue
+        write_atomic600 "$f2" '# %s\n' "$line"
+        printf '→ inbox 기록됨: %s\n' "$(basename "$f2")"
+        ;;
+    esac
+  done
+}
+
+# Paul's control REPL (pane 0) — vocabulary: confirm/feedback/answer/waves/quit.
+# Unrecognized input still gets recorded (as feedback-PAUL-*.md) rather than
+# silently dropped — an unrecognized command is still user intent worth keeping.
+__control() {
+  local at="$1"
+  local inbox="$at/_state/panes/inbox"
+  mkdir -p "$inbox"
+  printf '[Paul 제어] 명령: confirm <W> <VERDICT> [사유] | feedback <W> <메시지> | answer <qid> <메시지> | waves | quit\n'
+  while :; do
+    printf 'paul> '
+    IFS= read -r line || break
+    [ -z "$line" ] && continue
+    local ts
+    ts="$(date +%s)-$$"
+    # shellcheck disable=SC2086 (word-splitting into positional params is intentional here)
+    set -- $line
+    local cmd="${1:-}"
+    case "$cmd" in
+      confirm)
+        local w="${2:-}" verdict="${3:-}"
+        shift 3 2>/dev/null || true
+        local reason="$*"
+        if [ -z "$w" ] || [ -z "$verdict" ]; then
+          printf '사용법: confirm <W> <PASS|CONCERNS|FAIL|OK|STOP> [사유]\n'
+          continue
+        fi
+        # PANES-002: sanitize before it becomes part of a path (display uses raw "$w" above).
+        local w_safe
+        w_safe="$(sanitize "$w")"
+        local f="$inbox/confirm-$w_safe-$ts.txt"
+        assert_in_inbox "$f" "$inbox" || continue
+        write_atomic600 "$f" '%s\t%s\t%s\n' "$verdict" "$reason" "Paul"
+        printf '→ inbox 기록됨: %s\n' "$(basename "$f")"
+        ;;
+      feedback)
+        local w2="${2:-}"
+        shift 2 2>/dev/null || true
+        local msg="$*"
+        if [ -z "$w2" ]; then
+          printf '사용법: feedback <W> <메시지>\n'
+          continue
+        fi
+        local w2_safe
+        w2_safe="$(sanitize "$w2")"
+        local f2="$inbox/feedback-$w2_safe-$ts.md"
+        assert_in_inbox "$f2" "$inbox" || continue
+        write_atomic600 "$f2" '# %s\n' "$msg"
+        printf '→ inbox 기록됨: %s\n' "$(basename "$f2")"
+        ;;
+      answer)
+        local qid="${2:-}"
+        shift 2 2>/dev/null || true
+        local amsg="$*"
+        if [ -z "$qid" ]; then
+          printf '사용법: answer <qid> <메시지>\n'
+          continue
+        fi
+        local qid_safe
+        qid_safe="$(sanitize "$qid")"
+        local f3="$inbox/answer-$qid_safe-$ts.txt"
+        assert_in_inbox "$f3" "$inbox" || continue
+        write_atomic600 "$f3" '%s\n' "$amsg"
+        printf '→ inbox 기록됨: %s\n' "$(basename "$f3")"
+        ;;
+      waves)
+        printf '(웨이브 재구성: 다른 터미널에서 `%s up --waves "W.. W.."` 재실행)\n' "$PROG"
+        ;;
+      quit)
+        printf '이 pane에서는 세션을 내릴 수 없습니다 — 다른 터미널에서 `%s down`을 실행하세요.\n' "$PROG"
+        ;;
+      *)
+        local f4="$inbox/feedback-PAUL-$ts.md"
+        assert_in_inbox "$f4" "$inbox" || continue
+        write_atomic600 "$f4" '# %s\n' "$line"
+        printf '→ 미인식 명령 — inbox 기록됨: %s\n' "$(basename "$f4")"
+        ;;
+    esac
+  done
+}
+
+# --------------------------------------------------------------------------
+# 1. dispatch — internal (__*) subcommands bypass the up/attach/down/status
+#    argument parsing entirely (different calling convention: positional args).
+# --------------------------------------------------------------------------
+CMD="${1:-}"
+case "$CMD" in
+  __render) shift; __render "$@"; exit $? ;;
+  __input)  shift; __input "$@";  exit $? ;;
+  __control) shift; __control "$@"; exit $? ;;
+  up|attach|down|status) shift ;;
+  -h|--help) usage; exit 0 ;;
+  "")
+    usage
+    exit 1
+    ;;
+  *)
+    err "알 수 없는 명령: $CMD"
+    usage
+    exit 1
+    ;;
+esac
+
+# --------------------------------------------------------------------------
+# 2. 공통 인자 파싱 (up/attach/down/status)
+# --------------------------------------------------------------------------
+PROJECT="$(pwd)"
+WAVES_ARG=""
+INTERVAL=2
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project) shift; PROJECT="${1:-$PROJECT}" ;;
+    --waves) shift; WAVES_ARG="${1:-}" ;;
+    --interval) shift; INTERVAL="${1:-2}" ;;
+    -h|--help) usage; exit 0 ;;
+    *) warn "알 수 없는 옵션 무시: $1" ;;
+  esac
+  shift || true
+done
+
+# PANES-001 defense-in-depth: --interval is later interpolated into a pane spawn command
+# (via sh_quote below, which makes it *safe*, not merely "expected to be numeric") — but a
+# render loop's sleep interval has no legitimate reason to be anything but a small non-negative
+# integer, so reject anything else outright rather than trying to reason about what else it
+# might contain.
+case "$INTERVAL" in
+  *[!0-9]*|'')
+    err "잘못된 --interval 값: '$INTERVAL' (0 이상의 정수만 허용)"
+    exit 1
+    ;;
+esac
+
+AGENT_TEAM="$PROJECT/.agent-team"
+PANES_DIR="$AGENT_TEAM/_state/panes"
+
+# --------------------------------------------------------------------------
+# 3. 프리플라이트 — tmux · bathos 바이너리
+# --------------------------------------------------------------------------
+if ! command -v tmux >/dev/null 2>&1; then
+  err "tmux가 설치돼 있지 않습니다(E-TMUX-ABSENT)."
+  err "  macOS : brew install tmux"
+  err "  Linux : apt-get install tmux  (또는 배포판 패키지 매니저)"
+  err "  Windows: tmux 네이티브 미지원 — WSL(scripts/wsl-setup.sh) 또는 \`bathos panes --mode tui\` 사용"
+  exit 3
+fi
+
+BATHOS_BIN_RESOLVED="$(find_bathos_bin "$PROJECT")" || {
+  err "bathos 바이너리를 찾을 수 없습니다(E-BATHOS-ABSENT)."
+  err "  빌드: cd \"$PROJECT/core\" && cargo build --release"
+  err "  또는 BATHOS_BIN=<절대경로>를 지정하세요."
+  exit 4
+}
+
+# --------------------------------------------------------------------------
+# 4. 세션명 — bathos-<project_id> (jq 금지: grep으로 manifest.json에서 직접 추출)
+# --------------------------------------------------------------------------
+MANIFEST="$AGENT_TEAM/_state/manifest.json"
+PROJECT_ID=""
+if [ -f "$MANIFEST" ]; then
+  PROJECT_ID="$(grep -o '"project_id"[[:space:]]*:[[:space:]]*"[^"]*"' "$MANIFEST" 2>/dev/null \
+    | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
+fi
+[ -z "$PROJECT_ID" ] && PROJECT_ID="local"
+SESSION="bathos-${PROJECT_ID}"
+
+mkdir -p "$PANES_DIR/inbox" "$PANES_DIR/processed"
+
+session_exists() { tmux has-session -t "$SESSION" 2>/dev/null; }
+
+# stale session.info 정리(has-session과 불일치하면 재생성 대상 — E8/멱등성)
+if [ -f "$PANES_DIR/session.info" ] && ! session_exists; then
+  rm -f "$PANES_DIR/session.info"
+fi
+
+# --------------------------------------------------------------------------
+# 5. 웨이브 자동 선택 (--waves 미지정 시)
+# --------------------------------------------------------------------------
+select_waves() {
+  if [ -n "$WAVES_ARG" ]; then
+    printf '%s' "$WAVES_ARG"
+    return 0
+  fi
+  local vm_lines
+  vm_lines="$("$BATHOS_BIN_RESOLVED" inspect vm --path "$AGENT_TEAM" --format lines 2>/dev/null || true)"
+  local active
+  active="$(printf '%s\n' "$vm_lines" | awk -F'\t' '$1=="wave" && ($3=="active" || $3=="gated") {printf "%s ", $2}')"
+  active="$(printf '%s' "$active" | sed 's/[[:space:]]*$//')"
+  if [ -n "$active" ]; then
+    printf '%s' "$active"
+    return 0
+  fi
+  local last_done
+  last_done="$(printf '%s\n' "$vm_lines" | awk -F'\t' '$1=="wave" && $3=="done" {w=$2} END{if (w!="") print w}')"
+  if [ -n "$last_done" ]; then
+    warn "활성/게이트 웨이브 없음 — 최근 완료 웨이브 1개만 표시: $last_done"
+    printf '%s' "$last_done"
+    return 0
+  fi
+  printf ''
+}
+
+# --------------------------------------------------------------------------
+# 6. 커맨드 구현
+# --------------------------------------------------------------------------
+case "$CMD" in
+  up)
+    if session_exists; then
+      say "세션 이미 존재 — 재사용(attach): $SESSION"
+    else
+      local_waves="$(select_waves)"
+      set -- $local_waves # word-split into positional params (bash 3.2-safe "array")
+      say "세션 생성: $SESSION (웨이브: ${*:-없음})"
+
+      # Panes run our own script directly as the pane's command (tmux's shell-command
+      # argument) rather than being *typed* into the pane's interactive login shell via
+      # `send-keys`. This sidesteps any slow/prompting rc-file behavior the user's default
+      # shell (zsh/oh-my-zsh, pyenv/nvm hooks, etc.) might have on startup — that startup is
+      # entirely orthogonal to what these panes need to do, and a hung/slow rc file must not
+      # be able to swallow the launch command. `send-keys` is still used below, but only to
+      # feed genuine runtime input (confirm/feedback lines) into the already-running script.
+      # PANES-001: every interpolated value is passed through sh_quote — the pane command
+      # string below is parsed a *second* time by the pane's own shell once tmux spawns it,
+      # so an unescaped single quote in any of these values (a project path is the realistic
+      # case) would otherwise break out of the intended argument and inject commands.
+      tmux new-session -d -s "$SESSION" -n main \
+        "$(sh_quote "$SCRIPT_PATH") __control $(sh_quote "$AGENT_TEAM")"
+
+      if [ $# -eq 0 ]; then
+        warn "렌더할 웨이브가 없습니다 — control pane만 기동합니다(대기 — 활성 웨이브 없음, E7)."
+      else
+        for w in "$@"; do
+          render_pane="$(tmux split-window -h -t "${SESSION}:main.0" -P -F '#{pane_id}' \
+            "$(sh_quote "$SCRIPT_PATH") __render $(sh_quote "$AGENT_TEAM") $(sh_quote "$w") $(sh_quote "$INTERVAL") $(sh_quote "$BATHOS_BIN_RESOLVED")")"
+          input_pane="$(tmux split-window -v -t "$render_pane" -P -F '#{pane_id}' \
+            "$(sh_quote "$SCRIPT_PATH") __input $(sh_quote "$AGENT_TEAM") $(sh_quote "$w")")"
+        done
+        tmux select-layout -t "${SESSION}:main" tiled >/dev/null 2>&1 || true
+      fi
+
+      write_atomic600 "$PANES_DIR/session.info" \
+        'session=%s\npid=%s\nstarted=%s\nwaves=%s\n' "$SESSION" "$$" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${*:-}"
+    fi
+
+    if [ -t 0 ] && [ -z "${BATHOS_PANES_NO_ATTACH:-}" ]; then
+      tmux attach -t "$SESSION"
+    else
+      say "비대화형 환경(또는 BATHOS_PANES_NO_ATTACH) — attach 생략. 수동: tmux attach -t $SESSION"
+    fi
+    ;;
+
+  attach)
+    if ! session_exists; then
+      err "세션이 없습니다: $SESSION — 먼저 \`$PROG up\`을 실행하세요."
+      exit 1
+    fi
+    tmux attach -t "$SESSION"
+    ;;
+
+  down)
+    if session_exists; then
+      tmux kill-session -t "$SESSION"
+      say "세션 종료: $SESSION"
+    else
+      say "이미 종료 상태: $SESSION"
+    fi
+    rm -f "$PANES_DIR/session.info"
+    # wave-log.md는 리드 소유 — 종료 스탬프는 별도 파일에만 남긴다(소유권 침범 금지).
+    printf 'closed %s session=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SESSION" \
+      >> "$PANES_DIR/session.info.last" 2>/dev/null || true
+    # PANES-004: this file accumulates across every `down` invocation via append (`>>`, not a
+    # tmp+rename write — write_atomic600 doesn't fit an append), so re-assert 0600 after each
+    # append rather than only at creation (a stale 0644 from an old umask would otherwise
+    # persist indefinitely once set).
+    chmod 600 "$PANES_DIR/session.info.last" 2>/dev/null || true
+    ;;
+
+  status)
+    if session_exists; then
+      pane_count="$(tmux list-panes -t "$SESSION" 2>/dev/null | wc -l | tr -d ' ')"
+      say "up — session=$SESSION panes=$pane_count"
+    else
+      say "down — session $SESSION 없음"
+    fi
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
작업 ⑦ — W2(James) 설계 → W5(Phillip) 구현 → W6(Michael) 보안 감사·리메디에이션.

## 기능
- **A. 역할별 모델 선택:** `model_plan.rs`(스키마+lenient 로더+4단계 resolve+혼합검증) · `bathos model {show,set,unset,detect,validate,resolve}` (ADR-D-0005/0006)
- **B. Wave 패널:** `inspect vm --format lines`(TSV, ADR-D-0007) · `scripts/bathos-panes.sh`(tmux, ADR-D-0009) · `bathos-tui` 크레이트(ratatui/crossterm, read-only+inbox-only-write, ADR-D-0008)
- **C. Codex 위임:** `codex-adapter/run-role.sh`(§A3.3, dry-run·프리플라이트 fail-safe)
- **D. 웨이브 커맨드 7개:** 대화형 모델 선택 블록 + 패널 힌트

## 보안 리메디에이션 (W6 Michael 감사 확정 5건, 동작보존)
- PANES-001(Critical): tmux 커맨드 인젝션 → `sh_quote` POSIX 이스케이프 + interval 숫자검증
- PANES-002(High): inbox 경로탈출 → `sanitize`(tr -cd) + 사후검증
- PANES-003(Medium): TSV 새니타이즈 단일강제점(`push_line`)
- PANES-004/005(Low): 파일권한 0600 + dry-run `.kept` 정리

## 검증
cargo fmt/clippy/build/test green · T7 12/12 · T8 24/24 · PANES-001 PoC 무해화 실측.

> 무관 워킹트리 변경(`.claude/agents/_base/*` Michael→Mishael 개명 등)은 이 PR에서 제외(별도 작업).