### PR TITLE
fix(codex): enforce failed gates for absolute apply_patch paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
           BATHOS_BIN: ${{ github.workspace }}/core/target/release/bathos
         run: bash .claude/hooks/_test-hooks.sh
 
+      - name: Run Codex adapter hook harness (self-stubbed, no binary)
+        run: bash codex-adapter/hooks/_test-codex-hooks.sh
+
   windows:
     name: Windows (engine build · test · PowerShell hook lint)
     runs-on: windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   management), `docs/MODULE-GUIDE-{en,kr}.md` (custom plugin authoring), and a
   Documentation navigation hub in `README.md`.
 
+### Fixed
+
+- **Codex adapter W3 gate no longer fails open on absolute `apply_patch` paths.**
+  Real Codex `apply_patch` PreToolUse input carries the patch in `tool_input.command`
+  and names files by absolute path (`/…/project/src/…`). The old `SRC_ERE` boundary
+  class excluded `/`, so `src/` preceded by `/` never matched — the T1 source-write
+  trigger stayed silent and a `FAIL` W3 gate let source edits through
+  (`hook_exit=0`). `SRC_ERE` now treats `/` as a source-path boundary, so absolute
+  and nested source paths trigger the block (`hook_exit=2`). Guarded by new
+  regression cases **B-19/B-20** in `codex-adapter/hooks/_test-codex-hooks.sh`
+  (20 cases · 40 assertions), and the Codex adapter harness is now run in CI
+  (`.github/workflows/ci.yml` `hooks` job) so this can't silently regress.
+
 ## [0.1.0] — 2026-06-30
 
 First public release. BATHOS builds and runs end-to-end on Claude Code.

--- a/codex-adapter/README.md
+++ b/codex-adapter/README.md
@@ -22,7 +22,7 @@ codex-adapter/
 ├── hooks/
 │   ├── pretooluse-gate.sh       # W3 Implementation 게이트: FAIL이면 구현 진입 exit 2 차단
 │   ├── stop-save.sh             # SessionEnd 근사: 턴마다 증분 저장(state show 덤프)
-│   └── _test-codex-hooks.sh     # 시뮬레이션 테스트(실제 Codex 설치 불요, 18케이스: 게이트 B-1~B-10·B-15~B-18 + 저장 B-11~B-14, 37 assertion)
+│   └── _test-codex-hooks.sh     # 시뮬레이션 테스트(실제 Codex 설치 불요, 20케이스: 게이트 B-1~B-10·B-15~B-20 + 저장 B-11~B-14, 40 assertion)
 ├── run-role.sh                  # runtime=codex 역할 위임 러너(ADR-D-0006, §A3.3) — Claude Code 팀원이 아닌 별도 프로세스로 역할 실행
 ├── _test-run-role.sh            # run-role.sh 스모크 테스트(T8, 10케이스·24 assertion, 스텁 codex로 실제 설치 불요)
 └── config.toml.example          # ~/.codex/config.toml 등록 예시(실측 스키마)
@@ -124,6 +124,11 @@ codex-adapter/run-role.sh <role-slug> <task-file.md> [--project <절대경로>] 
   게이트가 무력화되는 버그가 실측으로 확정됐다. `pretooluse-gate.sh`를
   실측 3종 tool_name(`shell`/`exec_command`/`apply_patch`)으로 갱신하고
   `_test-codex-hooks.sh`에 회귀 케이스(B-15~B-18)를 추가해 재발을 감시한다.
+  **P5.1(2026-07-17) 후속 수정:** 실제 `apply_patch`는 패치를
+  `tool_input.command`에 싣고 대상 파일을 **절대경로**로 지목하는데, 옛
+  `SRC_ERE` 경계 `[^A-Za-z0-9_./-]`가 `/`를 경계로 인정하지 않아 절대경로 앞의
+  `src/`가 T1에서 미발화(fail-open)했다. 경계에 `/`를 추가해 수정하고
+  회귀 케이스 B-19~B-20으로 잠갔다.
   **단, 이 해소는 v0.144.5(macos-x86_64) 기준이다 — 다른 버전/플랫폼으로
   업그레이드하면 `codex features list`·PreToolUse stdin을 재실측할 것.**
 - **라이브 인증 세션 미실행(남은 미실증)** — 이번 실측은 로컬 API 키 없이
@@ -147,13 +152,16 @@ bash codex-adapter/hooks/_test-codex-hooks.sh
 ```
 
 실제 Codex 설치나 실제 `bathos` 빌드 없이도 동작한다(스텁 `bathos`를
-`mktemp` 디렉터리에 생성해 `gate show`/`state show` 출력을 재생). 18개
-설계 테스트 케이스(게이트 B-1~B-10·B-15~B-18, 저장 B-11~B-14)를 세분화한
-37개 assertion으로 검증하며, 전부 통과 시 `전체 통과` + exit 0으로 끝난다.
+`mktemp` 디렉터리에 생성해 `gate show`/`state show` 출력을 재생). 20개
+설계 테스트 케이스(게이트 B-1~B-10·B-15~B-20, 저장 B-11~B-14)를 세분화한
+40개 assertion으로 검증하며, 전부 통과 시 `전체 통과` + exit 0으로 끝난다.
 B-15~B-18은 P5(2026-07-16) 실측 회귀 케이스로, (a) `exec_command`의 웨이브
 진입 명령 차단, (b) `shell`의 소스 직접쓰기(`sed -i`) 차단, (c) 폐기된
 `Bash` 가정이 여전히 무해함(비트리거·bathos 미호출), (d) 무관 tool_name
-통과를 계약화한다.
+통과를 계약화한다. B-19~B-20은 P5.1(2026-07-17) 절대경로 회귀로, 실제
+`apply_patch`가 `tool_input.command`에 싣는 **절대경로**(`/…/src/…`)가
+소스쓰기(T1)로 발화하는지(FAIL→exit 2)와, 넓어진 경계가 게이트 판정을
+넘어 과차단하지 않는지(PASS→exit 0)를 계약화한다.
 
 추가로 실제 `bathos` 바이너리(`core/target/release/bathos`)를 빌드해 두면
 두 훅을 실제 프로젝트 state 사본에 대해 수동으로 돌려 통합 확인도 가능하다

--- a/codex-adapter/hooks/_test-codex-hooks.sh
+++ b/codex-adapter/hooks/_test-codex-hooks.sh
@@ -16,6 +16,11 @@
 # 진입 명령을 검증하고, B-15는 옛 P4 가정이던 Bash가 더 이상 필요/유효하지
 # 않음 — 오지 않는 값이므로 무해 통과만 확인 — 을 별도로 남겨 둔다).
 #
+# P5.1 갱신(2026-07-17): B-19~B-20을 추가해 절대경로 apply_patch 회귀를
+# 계약화한다 — 실제 Codex는 패치를 tool_input.command에 싣고 파일을 절대경로로
+# 지목하는데, 옛 SRC_ERE 경계가 '/'를 인정하지 않아 T1이 미발화(fail-open)했다.
+# 경계에 '/'를 추가한 수정을 B-19(FAIL->exit2)·B-20(PASS->exit0)으로 잠근다.
+#
 # 실행: bash codex-adapter/hooks/_test-codex-hooks.sh
 # =============================================================================
 set -uo pipefail
@@ -147,6 +152,13 @@ json_legacy_bash_wave() {
 json_unrelated_tool() {
   # 게이트 트리거와 무관한 tool_name(가상의 read 계열 도구) -> 항상 통과.
   printf '{"session_id":"s1","turn_id":"t1","hook_event_name":"PreToolUse","tool_name":"read_file","cwd":"%s","tool_input":{"path":"README.md"}}' "$1"
+}
+json_apply_patch_abspath() {
+  # T1 절대경로 회귀: 실제 Codex apply_patch는 패치를 tool_input.command에 싣고
+  # `*** Update File:` 헤더는 파일을 **절대경로**로 지목한다(/Users/.../src/...).
+  # $1 = 픽스처 프로젝트 절대경로. src/ 앞이 '/'인 절대경로가 SRC_ERE 경계에
+  # 걸려 source-write로 발화하는지(= 옛 ERE의 fail-open 재발 방지)를 계약화한다.
+  printf '{"session_id":"s1","turn_id":"t1","hook_event_name":"PreToolUse","tool_name":"apply_patch","cwd":"%s","tool_input":{"command":"*** Begin Patch *** Update File: %s/src/main.rs @@ -BASELINE +MODIFIED *** End Patch"}}' "$1" "$1"
 }
 json_stop() {
   printf '{"session_id":"s1","turn_id":"t9","hook_event_name":"Stop","stop_hook_active":false,"cwd":"%s","last_assistant_message":"done"}' "$1"
@@ -324,6 +336,34 @@ if [ ! -s "$STUB18/calls.log" ]; then
 else
   assert_true "B-18 calls.log 비어있음(비트리거 -> bathos 미호출)" 0
 fi
+
+# --------------------------------------------------------------------------
+# B-19 ~ B-20: 절대경로 apply_patch 회귀(2026-07-17) — SRC_ERE '/' 경계
+# --------------------------------------------------------------------------
+# 실제 Codex apply_patch는 패치를 tool_input.command에 싣고 대상 파일을
+# **절대경로**(/Users/.../src/...)로 지목한다. 옛 SRC_ERE 경계 [^A-Za-z0-9_./-]는
+# '/'를 경계로 인정하지 않아 절대경로 앞의 src/가 매치되지 않았고(T1 미발화),
+# FAIL 게이트에서도 소스 편집이 exit 0으로 통과하는 fail-open 버그였다. 경계에
+# '/'를 추가한 수정을 계약화한다 — B-19는 옛 ERE에서 반드시 red가 되는 케이스다.
+
+# --- B-19: apply_patch + 절대경로 src/, verdict=FAIL -> exit 2, stderr에 source-write ---
+P19="$(make_fixture_project b19)"
+STUB19="$TMPDIR_BASE/stub-b19"; make_stub_bathos "$STUB19" "FAIL"
+RES="$(BATHOS_BIN="$STUB19/bathos" run_hook "$HOOKS_DIR/pretooluse-gate.sh" "$(json_apply_patch_abspath "$P19")")"
+EC="$(get_exit "$RES")"; ERR="$(get_stderr "$RES")"
+assert_exit "B-19 apply_patch 절대경로 src/ + FAIL -> 차단(exit 2)" 2 "$EC"
+if printf '%s' "$ERR" | grep -q 'source-write'; then
+  assert_true "B-19 stderr에 source-write 포함" 1
+else
+  assert_true "B-19 stderr에 source-write 포함" 0
+fi
+
+# --- B-20: apply_patch + 절대경로 src/, verdict=PASS -> exit 0 (넓어진 경계가 게이트 판정을 넘어서 과차단하지 않음) ---
+P20="$(make_fixture_project b20)"
+STUB20="$TMPDIR_BASE/stub-b20"; make_stub_bathos "$STUB20" "PASS"
+RES="$(BATHOS_BIN="$STUB20/bathos" run_hook "$HOOKS_DIR/pretooluse-gate.sh" "$(json_apply_patch_abspath "$P20")")"
+EC="$(get_exit "$RES")"
+assert_exit "B-20 apply_patch 절대경로 src/ + PASS -> 통과(exit 0)" 0 "$EC"
 
 # ==========================================================================
 # B-11 ~ B-14: stop-save.sh

--- a/codex-adapter/hooks/pretooluse-gate.sh
+++ b/codex-adapter/hooks/pretooluse-gate.sh
@@ -92,7 +92,9 @@ fi
 # --------------------------------------------------------------------------
 # T1 소스 경로 패턴(env로 오버라이드 가능). ".agent-team/" 전용 언급은 제외
 # (문서·산출물 쓰기는 게이트 대상이 아니다).
-SRC_ERE="${BATHOS_GATE_SRC_ERE:-(^|[^A-Za-z0-9_./-])(src|core/crates|core/src|codex-adapter/hooks)/}"
+# 상대 경로(src/...)뿐 아니라 Codex apply_patch가 전달하는 절대 경로(.../src/...)도 감지한다.
+# `/`를 명시적인 경계로 허용하지 않으면 절대 경로가 fail-open으로 통과한다.
+SRC_ERE="${BATHOS_GATE_SRC_ERE:-(^|/|[^A-Za-z0-9_./-])(src|core/crates|core/src|codex-adapter/hooks)/}"
 
 # T2 웨이브 진입 명령 ERE (gate-enforce.sh is_w5_entry와 정렬). 매칭 대상은
 # INPUT_FLAT 전체(= tool_input.command/argv를 포함한 stdin 원문의 개행제거본)

--- a/docs/codex-adapter-kr.md
+++ b/docs/codex-adapter-kr.md
@@ -99,6 +99,14 @@ CLAUDE.md §9(종료 시 저장→리포트→종료 강제)는 Codex에 Session
   세션(auth 부재로 미실행) — 스키마·계약까지만 실측했고, 실제 인증 세션에서
   config 등록이 배선대로 동작하는지는 다음 실사용 시 확인 필요. 또한 이
   해소는 **v0.144.5 버전 고정**이므로 업그레이드 시 재확인 필요.
+- **P5.1: 완료(2026-07-17)** — 라이브 인증 Codex 세션에서 실제
+  `apply_patch` PreToolUse 입력을 확인한 결과, 패치는 `tool_input.command`에
+  실리고 대상 파일은 **절대경로**(`/Users/…/project/src/…`)로 온다. 옛
+  `SRC_ERE` 경계 `[^A-Za-z0-9_./-]`가 `/`를 경계로 인정하지 않아 절대경로
+  앞의 `src/`가 T1 소스쓰기로 발화하지 못하고 FAIL 게이트에서도 편집이
+  통과(fail-open)했다. 경계에 `/`를 추가해 수정하고, `_test-codex-hooks.sh`에
+  회귀 케이스 B-19~B-20 2건을 추가(→ 20케이스·40 assertion)했으며, 이
+  하네스를 **CI(`ci.yml` hooks job)에 연결**해 재발을 CI에서 강제한다.
 - P6: Codex+GLM 프록시 연동, 커맨드→skills 마이그레이션(공식 방향), 네이티브
   마이그레이션(AGENTS_MD/HOOKS/COMMANDS/SUBAGENTS/MCP import)을 `to-codex.sh`
   스캐폴드 변환의 대안으로 검토.


### PR DESCRIPTION
## What & why

Codex 어댑터의 `pretooluse-gate.sh`는 Codex CLI 런타임용 W3 Implementation 게이트를 재구현합니다. 게이트 verdict가 `FAIL`인 동안 제품 소스를 변경하는 도구 호출은 `exit 2`로 차단돼야 하지만, 실제 `apply_patch` 편집에서는 이 차단이 동작하지 않았습니다.

실제 Codex `apply_patch`의 PreToolUse 입력은 패치 내용을 `tool_input.command`에 담고, `*** Update File:` 헤더에서 대상 파일을 절대경로로 전달합니다.

```text
*** Update File: /Users/.../project/src/file
```

기존 `SRC_ERE`의 경계식은 다음과 같았습니다.

```regex
(^|[^A-Za-z0-9_./-])...
```

이 경계식은 `/`를 경계로 인정하지 않아 절대경로에서 `/` 뒤에 위치한 `src/`를 탐지하지 못했습니다. 그 결과 T1 source-write 트리거가 동작하지 않았고, W3 게이트가 `FAIL`인 상태에서도 소스 편집이 `hook_exit=0`으로 통과하는 **fail-open 결함**이 발생했습니다.

### 최소 수정

경계식에 `/`를 명시적인 분기로 추가했습니다.

```regex
(^|/|[^A-Za-z0-9_./-])...
```

이제 절대경로와 중첩 경로에서도 소스 경로가 정상적으로 탐지되며, 게이트 verdict가 `FAIL`이면 `hook_exit=2`로 차단됩니다.

넓어진 경계식에 따른 보수적인 탐지는 실제 차단이 필요한 `FAIL` 상태에서만 적용되며, 어댑터에 문서화된 `careful` 원칙인 **과차단보다 누락 방지를 우선한다**는 방향과 일치합니다.

### 회귀 가드

다음 두 테스트를 추가했습니다.

- **B-19**
  - `tool_input.command`에 절대경로 `/…/src/…`를 포함한 `apply_patch` 입력
  - 게이트 verdict: `FAIL`
  - 기대 결과: `exit 2`
  - stderr에서 `source-write` 트리거 확인
  - 수정 전 ERE를 적용하면 실패하므로 실제 회귀를 탐지합니다.

- **B-20**
  - B-19와 동일한 절대경로 입력
  - 게이트 verdict: `PASS`
  - 기대 결과: `exit 0`
  - 넓어진 경계식이 게이트 판정을 무시하고 과잉 차단하지 않는지 확인합니다.

Codex 훅 하네스인 `_test-codex-hooks.sh`는 총 20개 케이스, 40개 assertion으로 확장했습니다. 또한 기존 `hooks` CI job에 해당 하네스를 연결해 동일한 문제가 재발하면 CI에서 탐지되도록 했습니다.

하네스는 자체 스텁을 사용하므로 별도의 `bathos` 바이너리가 필요하지 않습니다.

> 참고: 동일한 결함은 Claude Code 훅인 `.claude/hooks/gate-enforce.sh`에는 없습니다. 해당 훅은 소스 경로 정규식이 아니라 태스크 제목과 설명의 키워드로 W5 진입을 감지하므로 별도 수정이 필요하지 않습니다.

## Scale

- [x] Lv0 (trivial)
- [ ] Lv1 (small)
- [ ] Lv2 (standard)
- [ ] Lv3+ (large)

## Type

- [ ] Engine (Rust crate)
- [x] Hook / settings
- [ ] Slash command
- [ ] Role / asset
- [ ] Plugin module
- [x] Docs

## Checklist

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --all` green
- [x] B-19/B-20 회귀 테스트 추가
- [x] `bash .claude/hooks/_test-hooks.sh` green
- [x] 엔진 변경 없이 Hook, CI, 문서 범위로 유지
- [x] `codex-adapter/README.md` 업데이트
- [x] `docs/codex-adapter-kr.md` 업데이트
- [x] `CHANGELOG.md`의 `Unreleased` 항목 업데이트
- [x] PASS / CONCERNS / FAIL 게이트 정책과 안전 훅을 약화하지 않음

## Verification

로컬 macOS Apple Silicon 환경에서 검증했습니다.

| 검증 항목 | 결과 |
|---|---|
| `cargo fmt --all -- --check` | PASS, exit 0 |
| `cargo clippy --all-targets -- -D warnings` | PASS, 경고 0 |
| `cargo test --all` | PASS, 0 failed |
| `cargo build --release` | PASS, exit 0 |
| `bash .claude/hooks/_test-hooks.sh` | 79 PASS / 0 FAIL |
| `bash codex-adapter/hooks/_test-codex-hooks.sh` | 40 / 40 PASS |
| `bash codex-adapter/_test-run-role.sh` | 24 PASS / 0 FAIL |
| `git diff --check` | PASS |

추가로 `BATHOS_GATE_SRC_ERE`에 수정 전 ERE를 주입하면 B-19가 예상한 `exit 2`가 아닌 `exit 0`으로 실패합니다. 이를 통해 추가된 테스트가 실제 결함을 탐지하는 회귀 가드임을 확인했습니다.

Windows CI job의 PowerShell 파싱 및 하네스는 macOS 로컬 환경에서 실행하지 않았습니다. 이번 PR은 `.ps1` 파일을 수정하지 않으며, Windows 관련 검증은 GitHub Actions에서 최종 확인합니다.

## Notes for reviewers

- Codex CLI `v0.144.5`의 실제 PreToolUse 입력을 기준으로 검증했습니다.
- 검증 환경은 macOS Apple Silicon입니다.
- Codex CLI 버전 또는 플랫폼이 변경될 경우 PreToolUse stdin 스키마를 다시 확인할 필요가 있습니다.