### PR TITLE
feat(state): add schema-valid manifest initialization

### DIFF
--- a/.claude/commands/team-kickoff.md
+++ b/.claude/commands/team-kickoff.md
@@ -25,8 +25,17 @@ $1/.agent-team/{00-plan,00-analysis,01-reverse,02-market-analysis,
 **3) task-graph.md 작성** → `$1/.agent-team/00-plan/task-graph.md`
 7웨이브(W0~W6) 태스크 분해 + 의존성 + 파일 소유 경계 초안(특히 W5 src 경로 겹침 0).
 
-**4) manifest.json 초기화** → `$1/.agent-team/_state/manifest.json`
-필드: project, created, lead, current_level(null — /route로 확정), waves_status(전체 pending), gates[], routing[].
+**4) manifest.json 초기화 — 반드시 엔진 `bathos state init`으로 시딩** → `$1/.agent-team/_state/manifest.json`
+manifest는 **손으로 작성하지 마세요.** LLM 수기 작성은 런타임마다 스키마 결과가 달라 무효 manifest를 낳고(예: Codex 킥오프가 `E-STATE-CORRUPT` 유발), 이후 `bathos gate/wave/route show`를 붕괴시킵니다. 엔진이 `Project::new` + `StateStore::create`(쓰기 전 스키마 검증)로 **항상 유효한 seed**를 만듭니다.
+
+```bash
+# $BATHOS_BIN(없으면 PATH의 bathos). CODENAME=서비스 컨셉에서 뽑은 짧은 ASCII 코드명(예: 프로젝트 디렉터리 basename).
+"${BATHOS_BIN:-bathos}" -s "$1/.agent-team/_state" state init --codename "<CODENAME>"
+#   --level 은 지정하지 않음 → 기본 0(잠정). 실제 레벨은 다음 단계 /route에서 확정.
+#   기존 manifest가 있으면 --force 없이는 [E-STATE-EXISTS]로 거부(비파괴적).
+```
+
+성공 출력(`[bathos state init] ✓ manifest.json 생성: … (project_id=bathos-…, level=0)`)을 확인하세요. seed에는 project_id(`bathos-<uuid>`)·codename·created(RFC3339)·status·lang·current_level=0(잠정)과 빈 waves/gates/routing 배열이 스키마대로 채워집니다. 엔진 미발견 시에만 예외적으로 리드가 스키마를 준수해 수기 작성하되, 즉시 `bathos state validate`로 검증합니다.
 
 **5) wave-log.md 초기화** → `$1/.agent-team/_state/wave-log.md`
 "킥오프 완료 — BATHOS 7웨이브 파이프라인 초기화. 다음: /route 로 Scale-Adaptive 레벨 확정."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`bathos state init`** — creates a schema-valid `manifest.json` seed for
+  `/team-kickoff`, replacing error-prone LLM hand-authoring across runtimes.
+  Existing state is preserved unless `--force` is explicitly supplied.
+
 - **팀 역할 체계 16역할 → 17역할** — Thomas(#12) 다음에 **Michael (#13, Security
   Specialist)** 을 신설했다. 방어적(defensive) 웹·사이버 보안 감사·하드닝 전담 —
   승인 범위 내 취약점을 증거 기반으로 식별·분류·보고(CWE/OWASP/CVSS·SARIF)하고

--- a/README-de.md
+++ b/README-de.md
@@ -215,7 +215,7 @@ Exit-Codes: `0` Erfolg · `1` Fehler · `2` Gate FAIL (von Hooks zum Blockieren 
 
 | Befehl | Unterbefehle | Zweck |
 |---|---|---|
-| `state` | `validate`, `show` | Einzige Wahrheitsquelle — Schema-Validierung & Inspektion von `manifest.json` |
+| `state` | `init`, `validate`, `show` | Erstellen, validieren und prüfen der zentralen `manifest.json` |
 | `route` | `decide`, `show` | Skalenadaptive Level-Empfehlung (stdin/`--stakes-json`; `--confirm <0-4>` hält fest) |
 | `wave` | `init`, `activate`, `show` | 7-Wellen-Zustandsübergänge (Parallelität ≤ 3 erzwungen) |
 | `gate` | `verdict`, `show` | Gate-Urteile aufzeichnen / lesen (PASS/CONCERNS/FAIL; FAIL → Exit 2) |
@@ -225,6 +225,7 @@ Exit-Codes: `0` Erfolg · `1` Fehler · `2` Gate FAIL (von Hooks zum Blockieren 
 | `doctor` | — | **Installations-/Verdrahtungs-Preflight** — `BATHOS_BIN`, `jq`, Agent-Teams-Flag, `settings.json`-Hooks-Block (Kommentar-Key-Hänger), Hook-Ausführungsbits, Manifest-Schema, Audit-Kette |
 
 ```bash
+bathos -s _state state init --codename MYPROJECT       # schema-validen Manifest-Seed erstellen
 bathos -s _state state validate                       # validate manifest.json
 bathos -s _state gate verdict Implementation PASS Matthew
 bathos -s _state gate show                            # latest Implementation gate (JSON)

--- a/README-es.md
+++ b/README-es.md
@@ -215,7 +215,7 @@ Códigos de salida: `0` éxito · `1` error · `2` puerta FAIL (usado por los ho
 
 | Comando | Subcomandos | Propósito |
 |---|---|---|
-| `state` | `validate`, `show` | Fuente única de verdad — validación e inspección del esquema de `manifest.json` |
+| `state` | `init`, `validate`, `show` | Crea, valida e inspecciona la fuente única de verdad `manifest.json` |
 | `route` | `decide`, `show` | Recomendación de nivel adaptable a la escala (stdin/`--stakes-json`; `--confirm <0-4>` registra) |
 | `wave` | `init`, `activate`, `show` | Transiciones de estado de las 7 olas (concurrencia ≤ 3 aplicada) |
 | `gate` | `verdict`, `show` | Registrar / leer veredictos de puerta (PASS/CONCERNS/FAIL; FAIL → salida 2) |
@@ -225,6 +225,7 @@ Códigos de salida: `0` éxito · `1` error · `2` puerta FAIL (usado por los ho
 | `doctor` | — | **Preverificación de instalación/conexión** — `BATHOS_BIN`, `jq`, flag de Agent Teams, bloque de hooks de `settings.json` (cuelgue por clave de comentario), bits de ejecución de hooks, esquema del manifest, cadena de auditoría |
 
 ```bash
+bathos -s _state state init --codename MYPROJECT       # crea un manifest seed válido según el esquema
 bathos -s _state state validate                       # validate manifest.json
 bathos -s _state gate verdict Implementation PASS Matthew
 bathos -s _state gate show                            # latest Implementation gate (JSON)

--- a/README-ja.md
+++ b/README-ja.md
@@ -215,7 +215,7 @@ BATHOS はタスクが実際に必要とするウェーブだけを起動しま�
 
 | コマンド | サブコマンド | 目的 |
 |---|---|---|
-| `state` | `validate`, `show` | 単一の真実の源 — `manifest.json` のスキーマ検証と検査 |
+| `state` | `init`, `validate`, `show` | 信頼できる唯一の情報源 `manifest.json` の作成・検証・表示 |
 | `route` | `decide`, `show` | スケール適応型レベルの推奨（stdin/`--stakes-json`; `--confirm <0-4>` で記録） |
 | `wave` | `init`, `activate`, `show` | 7 ウェーブの状態遷移（並列度 ≤ 3 を強制） |
 | `gate` | `verdict`, `show` | ゲート判定の記録 / 読み取り（PASS/CONCERNS/FAIL; FAIL → 終了 2） |
@@ -225,6 +225,7 @@ BATHOS はタスクが実際に必要とするウェーブだけを起動しま�
 | `doctor` | — | **インストール/配線のプリフライト** — `BATHOS_BIN`、`jq`、Agent Teams フラグ、`settings.json` の hooks ブロック（コメントキーによるハング）、フックの実行ビット、manifest スキーマ、監査チェーン |
 
 ```bash
+bathos -s _state state init --codename MYPROJECT       # スキーマ準拠の manifest seed を作成
 bathos -s _state state validate                       # validate manifest.json
 bathos -s _state gate verdict Implementation PASS Matthew
 bathos -s _state gate show                            # latest Implementation gate (JSON)

--- a/README-kr.md
+++ b/README-kr.md
@@ -215,7 +215,7 @@ Exit 코드: `0` 성공 · `1` 오류 · `2` 게이트 FAIL (훅이 차단에 �
 
 | 커맨드 | 서브커맨드 | 목적 |
 |---|---|---|
-| `state` | `validate`, `show` | 단일 진실 원천 — `manifest.json` 스키마 검증 및 검사 |
+| `state` | `init`, `validate`, `show` | 단일 진실 원천 `manifest.json` 생성·스키마 검증·검사 |
 | `route` | `decide`, `show` | Scale-Adaptive 레벨 추천 (stdin/`--stakes-json`; `--confirm <0-4>`로 기록) |
 | `wave` | `init`, `activate`, `show` | 7웨이브 상태 전이 (동시성 ≤ 3 강제) |
 | `gate` | `verdict`, `show` | 게이트 판정 기록 / 조회 (PASS/CONCERNS/FAIL; FAIL → exit 2) |
@@ -225,6 +225,7 @@ Exit 코드: `0` 성공 · `1` 오류 · `2` 게이트 FAIL (훅이 차단에 �
 | `doctor` | — | **설치/연결 프리플라이트** — `BATHOS_BIN`, `jq`, Agent Teams 플래그, `settings.json` hooks 블록(주석 키 무한대기), 훅 실행 비트, manifest 스키마, 감사 체인 |
 
 ```bash
+bathos -s _state state init --codename MYPROJECT       # 스키마 유효 manifest seed 생성
 bathos -s _state state validate                       # validate manifest.json
 bathos -s _state gate verdict Implementation PASS Matthew
 bathos -s _state gate show                            # latest Implementation gate (JSON)

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Exit codes: `0` success · `1` error · `2` gate FAIL (used by hooks to block).
 
 | Command | Subcommands | Purpose |
 |---|---|---|
-| `state` | `validate`, `show` | Single source of truth — `manifest.json` schema validation & inspection |
+| `state` | `init`, `validate`, `show` | Create, validate, and inspect the `manifest.json` single source of truth |
 | `route` | `decide`, `show` | Scale-adaptive level recommendation (stdin/`--stakes-json`; `--confirm <0-4>` records) |
 | `wave` | `init`, `activate`, `show` | 7-wave state transitions (concurrency ≤ 3 enforced) |
 | `gate` | `verdict`, `show` | Record / read gate verdicts (PASS/CONCERNS/FAIL; FAIL → exit 2) |
@@ -274,6 +274,7 @@ Exit codes: `0` success · `1` error · `2` gate FAIL (used by hooks to block).
 | `doctor` | — | **Install/wiring preflight** — `BATHOS_BIN`, `jq`, Agent Teams flag, `settings.json` hooks block (comment-key hang), hook exec bits, manifest schema, audit chain |
 
 ```bash
+bathos -s _state state init --codename MYPROJECT       # create a schema-valid manifest seed
 bathos -s _state state validate                       # validate manifest.json
 bathos -s _state gate verdict Implementation PASS Matthew
 bathos -s _state gate show                            # latest Implementation gate (JSON)

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -140,6 +140,7 @@ dependencies = [
  "clap",
  "crossterm",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/core/crates/bathos-cli/Cargo.toml
+++ b/core/crates/bathos-cli/Cargo.toml
@@ -24,3 +24,6 @@ serde_json          = { workspace = true }
 anyhow              = { workspace = true }
 chrono              = { workspace = true }
 crossterm           = "0.29"
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/core/crates/bathos-cli/src/main.rs
+++ b/core/crates/bathos-cli/src/main.rs
@@ -5,6 +5,7 @@
 //!
 //! ## Subcommand structure
 //! ```text
+//! bathos state init       # Create a schema-valid manifest.json seed
 //! bathos state validate   # Validate manifest.json schema (B1)
 //! bathos state show       # Print current manifest.json state (B1)
 //! bathos gate verdict     # Record gate verdict (B3 implementation)
@@ -37,7 +38,7 @@ use anyhow::{Context, Result};
 use bathos_gate_engine::{GateEngine, GateIssue, VerdictAggregator};
 use bathos_plug::{ModuleRegistry, PlugManager};
 use bathos_state::{
-    model::GateType,
+    model::{GateType, Project},
     model_plan::{self, ModelPlan, Runtime, SessionBackend},
     schema::validate_manifest,
     store::StateStore,
@@ -213,6 +214,27 @@ enum StateAction {
     Validate,
     /// manifest.json의 현재 상태를 JSON으로 출력한다.
     Show,
+    /// 스키마 유효 manifest.json seed를 생성한다 (kickoff 부트스트랩).
+    ///
+    /// `Project::new` + `StateStore::create`(쓰기 전 스키마 검증)로 항상 유효한 seed를 만든다.
+    /// 기존 manifest가 있으면 `--force` 없이는 덮어쓰지 않는다.
+    Init {
+        /// 제품 코드명 (codename, 예: BATHOS).
+        #[arg(long)]
+        codename: String,
+        /// Scale-Adaptive 레벨 (0~4). 미지정 시 0 (잠정 — /route에서 확정).
+        #[arg(long, default_value_t = 0)]
+        level: u8,
+        /// 주 언어 코드 (기본 ko).
+        #[arg(long, default_value = "ko")]
+        lang: String,
+        /// 프로젝트 ID (미지정 시 bathos-<uuid> 자동생성; 지정 시 'bathos-' 접두 필수).
+        #[arg(long)]
+        project_id: Option<String>,
+        /// 기존 manifest.json을 덮어쓴다.
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 // ── gate subcommands (B3 implementation) ─────────────────────────────────────
@@ -772,6 +794,64 @@ fn handle_state(action: StateAction, state_dir: &Path) -> Result<i32> {
             let json = serde_json::to_string_pretty(project).context("프로젝트 직렬화 실패")?;
 
             println!("{}", json);
+            Ok(0)
+        }
+
+        StateAction::Init {
+            codename,
+            level,
+            lang,
+            project_id,
+            force,
+        } => {
+            // Schema-valid manifest seed for kickoff bootstrap.
+            // Rationale: the engine previously had no create/init command, so the very
+            // first manifest.json was hand-authored by an LLM against a strict schema —
+            // unreliable across runtimes (Codex-run kickoff produced an invalid
+            // manifest). This stamps a guaranteed-valid seed.
+            let manifest_path = state_dir.join("manifest.json");
+            if manifest_path.exists() && !force {
+                eprintln!(
+                    "[E-STATE-EXISTS] manifest.json이 이미 존재합니다: {}",
+                    manifest_path.display()
+                );
+                eprintln!("[bathos state init] 덮어쓰려면 --force 를 지정하세요.");
+                return Ok(1);
+            }
+            if level > 4 {
+                eprintln!("[E-ARG] --level 은 0~4 여야 합니다 (받음: {level}).");
+                return Ok(1);
+            }
+            if codename.is_empty() {
+                eprintln!("[E-ARG] --codename 은 비어 있을 수 없습니다.");
+                return Ok(1);
+            }
+            if lang.chars().count() < 2 {
+                eprintln!("[E-ARG] --lang 은 두 글자 이상이어야 합니다 (받음: {lang}).");
+                return Ok(1);
+            }
+            // Project::new fills the schema-required defaults (project_id=bathos-<uuid>,
+            // status=Active, created=now(RFC3339), empty relation vecs).
+            let mut project = Project::new(codename, level);
+            project.lang = lang;
+            if let Some(pid) = project_id {
+                if pid.strip_prefix("bathos-").is_none_or(str::is_empty) {
+                    eprintln!(
+                        "[E-ARG] --project-id 는 'bathos-' 뒤에 식별자가 있어야 합니다 (받음: {pid})."
+                    );
+                    return Ok(1);
+                }
+                project.project_id = pid;
+            }
+            let project_id = project.project_id.clone();
+            // StateStore::create validates the manifest against the JSON Schema before
+            // the atomic write, so a successful return guarantees a valid seed.
+            StateStore::create(state_dir, project)
+                .with_context(|| format!("state seed 생성 실패: {}", state_dir.display()))?;
+            println!(
+                "[bathos state init] ✓ manifest.json 생성: {} (project_id={project_id}, level={level})",
+                manifest_path.display()
+            );
             Ok(0)
         }
     }
@@ -1957,6 +2037,7 @@ fn is_executable(p: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     fn keys(v: &[&str]) -> Vec<String> {
         v.iter().map(|s| s.to_string()).collect()
@@ -1991,5 +2072,102 @@ mod tests {
         let (bad, unknown) = classify_hook_keys(k.iter());
         assert!(bad.is_empty());
         assert_eq!(unknown, vec!["BogusEvent".to_string()]);
+    }
+
+    fn state_init_action(
+        codename: &str,
+        level: u8,
+        project_id: Option<&str>,
+        force: bool,
+    ) -> StateAction {
+        StateAction::Init {
+            codename: codename.to_string(),
+            level,
+            lang: "en".to_string(),
+            project_id: project_id.map(str::to_string),
+            force,
+        }
+    }
+
+    #[test]
+    fn state_init_creates_schema_valid_manifest_for_all_levels() {
+        for level in 0..=4 {
+            let dir = TempDir::new().unwrap();
+            let code = handle_state(
+                state_init_action("BATHOS", level, Some("bathos-cli-test"), false),
+                dir.path(),
+            )
+            .unwrap();
+            assert_eq!(code, 0);
+
+            let manifest = std::fs::read_to_string(dir.path().join("manifest.json")).unwrap();
+            let value: serde_json::Value = serde_json::from_str(&manifest).unwrap();
+            validate_manifest(&value).unwrap();
+            assert_eq!(value["codename"], "BATHOS");
+            assert_eq!(value["current_level"], level);
+            assert_eq!(value["lang"], "en");
+            assert_eq!(value["project_id"], "bathos-cli-test");
+        }
+    }
+
+    #[test]
+    fn state_init_preserves_existing_manifest_without_force_and_replaces_with_force() {
+        let dir = TempDir::new().unwrap();
+        assert_eq!(
+            handle_state(
+                state_init_action("ORIGINAL", 1, Some("bathos-original"), false),
+                dir.path(),
+            )
+            .unwrap(),
+            0
+        );
+        let manifest_path = dir.path().join("manifest.json");
+        let original = std::fs::read_to_string(&manifest_path).unwrap();
+
+        assert_eq!(
+            handle_state(
+                state_init_action("REPLACEMENT", 2, Some("bathos-replacement"), false),
+                dir.path(),
+            )
+            .unwrap(),
+            1
+        );
+        assert_eq!(std::fs::read_to_string(&manifest_path).unwrap(), original);
+
+        assert_eq!(
+            handle_state(
+                state_init_action("REPLACEMENT", 2, Some("bathos-replacement"), true),
+                dir.path(),
+            )
+            .unwrap(),
+            0
+        );
+        let replaced: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&manifest_path).unwrap()).unwrap();
+        assert_eq!(replaced["codename"], "REPLACEMENT");
+        assert_eq!(replaced["current_level"], 2);
+        assert_eq!(replaced["project_id"], "bathos-replacement");
+    }
+
+    #[test]
+    fn state_init_rejects_invalid_level_and_project_id_without_writing() {
+        for action in [
+            state_init_action("BATHOS", 5, Some("bathos-valid"), false),
+            state_init_action("BATHOS", 0, Some("invalid"), false),
+            state_init_action("BATHOS", 0, Some("bathos-"), false),
+            state_init_action("", 0, Some("bathos-valid"), false),
+        ] {
+            let dir = TempDir::new().unwrap();
+            assert_eq!(handle_state(action, dir.path()).unwrap(), 1);
+            assert!(!dir.path().join("manifest.json").exists());
+        }
+
+        let dir = TempDir::new().unwrap();
+        let mut invalid_lang = state_init_action("BATHOS", 0, Some("bathos-valid"), false);
+        if let StateAction::Init { lang, .. } = &mut invalid_lang {
+            *lang = "x".to_string();
+        }
+        assert_eq!(handle_state(invalid_lang, dir.path()).unwrap(), 1);
+        assert!(!dir.path().join("manifest.json").exists());
     }
 }

--- a/docs/USAGE-en.md
+++ b/docs/USAGE-en.md
@@ -212,9 +212,15 @@ Global options (common to all subcommands):
 
 ### 6.1 `bathos state` — state SSOT (B1)
 ```bash
+bathos --state-dir .agent-team/_state state init \
+       --codename MYPROJECT                            # create a schema-valid manifest.json seed
 bathos --state-dir .agent-team/_state state validate   # validate manifest.json against the JSON Schema (VALID/violation list)
 bathos --state-dir .agent-team/_state state show        # print the current state JSON
 ```
+
+`state init` creates the minimal valid state with defaults `level=0`, `lang=ko`,
+and an automatic `project_id=bathos-<uuid>`. It refuses to replace an existing
+manifest unless `--force` is given. `/team-kickoff` calls it for normal use.
 
 ### 6.2 `bathos gate` — gate verdicts (B3)
 ```bash

--- a/docs/USAGE-es.md
+++ b/docs/USAGE-es.md
@@ -212,9 +212,15 @@ Opciones globales (comunes a todos los subcomandos):
 
 ### 6.1 `bathos state` — SSOT de estado (B1)
 ```bash
+bathos --state-dir .agent-team/_state state init \
+       --codename MYPROJECT                            # crea un manifest.json seed válido según el esquema
 bathos --state-dir .agent-team/_state state validate   # validación JSON Schema de manifest.json (VALID/lista de violaciones)
 bathos --state-dir .agent-team/_state state show        # imprime el JSON del estado actual
 ```
+
+`state init` crea el estado mínimo válido con `level=0`, `lang=ko` y un
+`project_id=bathos-<uuid>` automático. No reemplaza un manifest existente
+sin `--force`. `/team-kickoff` lo invoca durante el uso normal.
 
 ### 6.2 `bathos gate` — veredictos de gate (B3)
 ```bash

--- a/docs/USAGE-kr.md
+++ b/docs/USAGE-kr.md
@@ -212,9 +212,15 @@ stakes를 레벨로 옮기는 추천 규칙은 `bathos-router`가 계산한다. 
 
 ### 6.1 `bathos state` — 상태 SSOT (B1)
 ```bash
+bathos --state-dir .agent-team/_state state init \
+       --codename MYPROJECT                            # 스키마 유효 manifest.json seed 생성
 bathos --state-dir .agent-team/_state state validate   # manifest.json JSON Schema 검증 (VALID/위반목록)
 bathos --state-dir .agent-team/_state state show        # 현재 상태 JSON 출력
 ```
+
+`state init`은 기본 `level=0`, `lang=ko`, 자동 `project_id=bathos-<uuid>`로
+최소 유효 상태를 만든다. 기존 manifest는 `--force` 없이는 덮어쓰지 않는다.
+`/team-kickoff`가 이 명령을 호출하므로 일반 사용자는 직접 실행할 필요가 없다.
 
 ### 6.2 `bathos gate` — 게이트 판정 (B3)
 ```bash

--- a/install.ps1
+++ b/install.ps1
@@ -183,12 +183,14 @@ Write-Host '  2) Enable Claude Code Agent Teams (the bundled settings.json alrea
 Write-Host '       $env:CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1"'
 Write-Host ''
 Write-Host '  3) Open Claude Code in your project and drive the pipeline:'
-Write-Host '       /team-kickoff'
+Write-Host '       /team-kickoff                     # seeds a schema-valid manifest via bathos state init'
 Write-Host '       /route /abs/path/to/project'
 Write-Host '       /wave1-discovery /abs/path   ...  /wave6-verify-report /abs/path'
 Write-Host '       /team-confirm'
 Write-Host ''
 Write-Host '  Try the engine directly:'
+Write-Host "       & `"$Bin`" -s .agent-team\_state state init --codename MYPROJECT"
+Write-Host ''
 Write-Host "     '{`"scope`":`"feature`",`"novelty`":true,`"regulation_ip`":false,`"team_size`":`"medium`"}' |"
 Write-Host "       & `"$Bin`" --state-dir .agent-team\_state route decide"
 Write-Host ''

--- a/install.sh
+++ b/install.sh
@@ -70,12 +70,15 @@ $(say "Done. Next steps:")
        export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
 
   3) Open Claude Code in your project and drive the pipeline:
-       /team-kickoff
+       /team-kickoff                     # seeds a schema-valid manifest via 'bathos state init'
        /route /abs/path/to/project
        /wave1-discovery /abs/path   …  /wave6-verify-report /abs/path
        /team-confirm
 
   Try the engine directly:
+     # Seed a schema-valid manifest.json (kickoff does this for you):
+     "$BIN" -s .agent-team/_state state init --codename MYPROJECT
+
      echo '{"scope":"feature","novelty":true,"regulation_ip":false,"team_size":"medium"}' \\
        | "$BIN" --state-dir .agent-team/_state route decide
 


### PR DESCRIPTION
## What & why

Add `bathos state init` so `/team-kickoff` can create the first schema-valid `manifest.json` through the Rust engine instead of asking an LLM to hand-author strict state JSON.

The missing bootstrap path made kickoff unreliable across runtimes: a malformed initial manifest causes `E-STATE-CORRUPT`, after which `gate`, `wave`, and `route` commands cannot operate. The new command builds a `Project` and persists it through `StateStore::create`, reusing the existing schema-validation and atomic-write path.

Closes #24

## Changes

- add `state init --codename <NAME>` with optional `--level`, `--lang`, `--project-id`, and `--force`
- preserve existing state unless `--force` is explicitly supplied
- reject invalid level, empty codename, short language code, and malformed project ID with general error exit 1
- test the CLI handler for all levels, overrides, schema validity, non-destructive behavior, force replacement, and invalid inputs
- wire `/team-kickoff` and both platform installers to the engine command
- update CHANGELOG, multilingual READMEs, and EN/KR/ES usage guides

## Impact

Kickoff now produces a valid machine SSOT consistently across Claude Code, Codex, and other runtimes. Existing projects are unaffected because initialization is non-destructive by default. The core-to-plugin A9 dependency boundary is unchanged.

## Scale

- [x] Lv0 (trivial) · [x] Lv1 (small) · [ ] Lv2 (standard) · [ ] Lv3+ (large)

## Type

- [x] Engine (Rust crate) · [ ] Hook / settings · [x] Slash command · [ ] Role / asset · [ ] Plugin module · [x] Docs

## Checklist

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --all` green; added CLI-layer regression tests
- [x] `cargo build --release` green
- [x] `bash .claude/hooks/_test-hooks.sh` green (79/79)
- [x] `bash codex-adapter/hooks/_test-codex-hooks.sh` green (40/40)
- [x] drift-guard scripts and distribution tests green
- [x] Core stays slim — no new core → plugin dependency (A9)
- [x] Docs updated and `CHANGELOG.md` Unreleased entry added
- [x] Gate vocabulary and safety hooks not weakened

## Notes for reviewers

- The repository currently uses `develop` for feature integration and `prod` for releases, so this targets `develop` even though `CONTRIBUTING.md` still mentions branching from `main`.
- Manual smoke testing confirmed create → validate → show, existing-file protection, and invalid-argument exit codes.
- The contributor's local environment did not have `pwsh`; Windows build/test and PowerShell parsing are left to the repository's Windows CI job.
