### PR TITLE
fix(ci): drift-guard 복구 — YAML 구문 오류(#32) + test-manifests 오탐 3건(#35)

### DIFF
--- a/.github/workflows/drift-guard.yml
+++ b/.github/workflows/drift-guard.yml
@@ -58,7 +58,10 @@ jobs:
       - name: test-uninstall.sh (CF-B4 §5, 4 픽스처)
         run: bash dist/tests/test-uninstall.sh
 
-      - name: test-check-rule-copies.sh (CF-B3 §5, 4 픽스처: byte/invariant/제외)
+      # 이 값은 반드시 인용한다 — 인용 없는 YAML 스칼라에 ": "(콜론+공백)이 들어가면
+      # "mapping values are not allowed here"로 파싱이 실패하고, 워크플로가 job을
+      # 하나도 만들지 못한 채 0초에 죽는다(로그도 남지 않아 원인 추적이 어렵다). #32
+      - name: "test-check-rule-copies.sh (CF-B3 §5, 4 픽스처: byte/invariant/제외)"
         run: bash dist/tests/test-check-rule-copies.sh
 
   mcp-reference-tests:

--- a/dist/tests/test-manifests.sh
+++ b/dist/tests/test-manifests.sh
@@ -46,6 +46,29 @@ for f in "${TARGETS[@]}"; do
   rel="${f#"$BATHOS_ROOT"/}"
   fdir="$(cd "$(dirname "$f")" && pwd)"
 
+  # --- 0) 폐지(deprecated) 매니페스트은 스키마 검사에서 제외 ------------------
+  # 스스로 `"deprecated": true` 를 선언하고 후속 정본을 가리키는 스켈레톤에까지
+  # 현행 필수 필드를 요구하면 오탐이 된다(#35). 예:
+  # dist/manifests/codex/plugin.json 은 `_note` 로 "실스키마 불일치로 폐기 예정,
+  # 정본은 dist/codex-plugin/.codex-plugin/plugin.json" 을 명시하고 `_removal` 로
+  # 삭제 계획까지 적어 둔 파일이다 — 그 파일에 version/sources 를 요구할 이유가 없다.
+  # 암묵 제외 금지 원칙에 따라 건너뛴 사실을 로그로 남긴다(조용히 통과시키지 않음).
+  if [[ "$(jq -r '.deprecated // false' "$f")" == "true" ]]; then
+    info "$rel — deprecated=true → 스키마 검사 제외(정본으로 대체된 스켈레톤, #35). 파일 삭제는 각 매니페스트의 _removal 계획을 따른다"
+    continue
+  fi
+
+  # --- 0-b) 호스트 판별 — 필수 필드가 호스트마다 다르다 ----------------------
+  # Codex 플러그인 스키마에는 `sources`·`capability_tier` 가 **존재하지 않는다**
+  # (PR #27 실측 — scripts/build-codex-plugin.sh 헤더 주석, codex-mechanisms.md §4.3).
+  # Codex 는 상대 포인터 대신 `skills`/`hooks` 를 번들로 직접 담는 구조다. 따라서
+  # Claude 플러그인 규약(`sources` 포인터)을 Codex 매니페스트에 적용하면 올바른
+  # 파일을 실패로 판정한다(#35). 호스트별로 요구 필드를 분기한다.
+  case "$rel" in
+    *.codex-plugin/*|*/codex-plugin/*|*/manifests/codex/*) host="codex" ;;
+    *)                                                     host="claude" ;;
+  esac
+
   # --- 1) 공통 필드 존재 -----------------------------------------------------
   name="$(jq -r '.name // empty' "$f")"
   version="$(jq -r '.version // empty' "$f")"
@@ -55,7 +78,14 @@ for f in "${TARGETS[@]}"; do
   [[ -n "$name" ]] && ok "$rel — name 존재" || error "$rel — name 필드 없음"
   [[ -n "$version" ]] && ok "$rel — version 존재" || error "$rel — version 필드 없음"
 
-  if [[ "$has_sources" != "true" ]]; then
+  if [[ "$host" == "codex" ]]; then
+    # Codex: `skills` 번들이 포인터 역할을 대신한다. `sources` 부재는 정상이다.
+    if [[ "$(jq -r 'has("skills")' "$f")" == "true" ]]; then
+      ok "$rel — (codex) skills 번들 존재 — sources 포인터는 이 호스트 스키마에 없음(정상)"
+    else
+      error "$rel — (codex) skills 필드 없음(Codex 플러그인은 skills 번들로 스킬을 노출한다)"
+    fi
+  elif [[ "$has_sources" != "true" ]]; then
     error "$rel — sources 필드 없음(포인터 규약 위반, CF-B1 AC1)"
   else
     ok "$rel — sources 필드 존재"


### PR DESCRIPTION
Fixes #32
Fixes #35

이 PR은 **drift-guard 게이트를 실제로 동작하게 만든다.** 두 커밋으로 나뉜다 — 첫 커밋이 워크플로를 살리고, 그 결과 드러난 오탐을 두 번째 커밋이 제거한다.

---

## 커밋 1 — `084181f` : YAML 구문 오류 (#32)

61행 `name:` 값이 인용부호 없이 `": "`(콜론+공백)을 포함해 YAML 파싱이 실패했다:

```yaml
- name: test-check-rule-copies.sh (CF-B3 §5, 4 픽스처: byte/invariant/제외)
                                                      ^ 57열
```

인용 없는 스칼라의 `": "`는 중첩 매핑으로 해석돼 `ScannerError: mapping values are not allowed here`가 된다. **워크플로가 파싱 단계에서 죽으므로 job이 하나도 생성되지 않고**(`jobs=0`), 로그도 남지 않은 채 0초에 실패했다 — 그동안 "0초 실패, 원인 불명"으로만 기록돼 있던 증상 세 가지가 모두 이 한 줄로 설명된다.

| | 결과 |
|---|---|
| 수정 전 `yaml.safe_load` | ❌ `ScannerError` line 61 column 57 |
| 수정 후 | ✅ 파싱 성공 |
| 생성 job | **0개 → 3개** |
| 생성 step | **0개 → 14개** |

## 커밋 2 — `8db5420` : test-manifests 오탐 3건 (#35)

커밋 1로 워크플로가 **처음 실제 실행**되자 아무도 몰랐던 실패가 드러났다(run 34323274457). 진단 결과 **매니페스트가 틀린 게 아니라 테스트가 낡았다.**

**(1) 폐지 매니페스트를 테스트가 모른다 — 2건**

`dist/manifests/codex/plugin.json`은 스스로 `"deprecated": true`를 선언하고 `_note`로 "실스키마 불일치로 폐기 예정, 정본은 `dist/codex-plugin/.codex-plugin/plugin.json`", `_removal`로 삭제 계획까지 명시한 스켈레톤이다. 그런데 `test-manifests.sh`에 `deprecated` 처리가 전혀 없어 `version`/`sources`를 계속 요구했다.

**(2) Codex에 없는 필드를 요구한다 — 1건**

Codex 플러그인 스키마에는 `sources`·`capability_tier`가 **존재하지 않는다**(PR #27 실측 — `scripts/build-codex-plugin.sh` 헤더 주석, `codex-mechanisms.md` §4.3). Codex는 상대 포인터 대신 `skills`/`hooks`를 번들로 담는 구조인데, 테스트가 **Claude 플러그인 규약을 Codex에 그대로 적용**해 올바른 파일을 실패로 판정했다.

**수정 방식**

- `deprecated: true` 매니페스트는 스키마 검사에서 제외하되 **건너뛴 사실을 로그로 남긴다**(암묵 제외 금지 원칙 — 조용히 통과시키지 않는다)
- 호스트를 경로로 판별해 **Codex는 `skills` 번들 존재**를, 그 외는 기존대로 `sources` 포인터를 요구
- 두 결정의 근거를 주석에 인용

## 검증 (전부 실측)

```
test-manifests.sh          ✓ 통과   (22건 통과·실패 0 — 수정 전 23통과/3실패)
test-host-detect.sh        ✓ 통과
test-uninstall.sh          ✓ 통과
test-check-rule-copies.sh  ✓ 통과
```

출력으로 확인한 동작:
```
✓ dist/codex-plugin/.codex-plugin/plugin.json — (codex) skills 번들 존재 — sources 포인터는 이 호스트 스키마에 없음(정상)
  dist/manifests/codex/plugin.json — deprecated=true → 스키마 검사 제외(정본으로 대체된 스켈레톤, #35)
```

## ⚠️ 병합 후에도 남는 실패 하나 — 의도된 것

drift-guard의 3개 job 중 **`check-rule-copies + check-versions`만 red로 남는다** (`--dup-scan` 152건 = **#33**).

**#33을 이 PR에서 함께 고치지 않은 이유:** 그건 버그가 아니라 **설계 결정**이 필요한 사안이다 — PR #27이 `codex-skills-drift-exclusions.json`에 15개 스킬을 "hand-authored 정본"으로 이미 등재했으므로 (A) 의도된 복제이니 dup-scan 검사 범위를 조정해야 하는지, (B) 진짜 위반이니 포인터 참조로 바꿔야 하는지(단 Codex 런타임이 포인터를 못 따라갈 위험) 판단이 갈린다. 제3자가 정할 일이 아니다.

**게이트를 `continue-on-error` 등으로 가리지 않았다.** 실패가 드러나는 것이 이 PR의 목적이며, 병합 후 red는 **정확히 하나의 실제 부채(#33)만** 가리킨다 — 오탐이 제거됐으므로 그 red는 신뢰할 수 있다.

## 절차 메모

`.github/workflows/`는 freeze-guard 위험 경로이므로 `bathos fingerprint approve --actor Paul --scope ci`로 정식 승인 후 편집했다.
