### PR TITLE
fix(comments): 오늘 커밋분 코드 주석 영어화 — 명문화된 규칙 위반 정정

### DIFF
--- a/.github/workflows/drift-guard.yml
+++ b/.github/workflows/drift-guard.yml
@@ -1,14 +1,15 @@
 # =============================================================================
-# BATHOS Dynamis — drift-guard CI (스켈레톤, 실퍼블리시 아님)
-# CF-B3 / US7 AC3 — "드리프트 = CI 실패"를 로컬뿐 아니라 CI에서도 강제한다.
+# BATHOS Dynamis — drift-guard CI (a skeleton, not a real publish)
+# CF-B3 / US7 AC3 — enforces "drift = CI failure" in CI, not just locally.
 #
-# 주의(story-b3 §4 인계 메모): `.github/workflows/`는 Phillip이 심화하는
-# careful-guard(A1)의 "위험 경로" 후보에 포함될 수 있다. 본 워크플로는
-# Andrew 소유 경로(risk-log §C)로 스폰 시 명시 승인되었으나, careful-guard
-# 최종 규칙과 충돌 시 Phillip과 메시지 합의 필요(미해결 — 아래 impl-notes 참조).
+# Note (story-b3 §4 handover memo): `.github/workflows/` may end up among the "risky paths"
+# of the careful-guard (A1) that Phillip is deepening. This workflow was explicitly approved
+# at spawn time as a path owned by Andrew (risk-log §C), but if it conflicts with the final
+# careful-guard rules it must be agreed with Phillip by message (open — see impl-notes below).
 #
-# 이 워크플로는 기존 bathos/.github/workflows/ci.yml(Rust 엔진 CI, Phillip
-# 축A 소관)과 별개다 — 배포 레이어(축B) 전용 job만 담는다(소유 경계 준수).
+# This workflow is separate from the existing bathos/.github/workflows/ci.yml (the Rust engine
+# CI, Phillip's axis A) — it holds only distribution-layer (axis B) jobs, respecting the
+# ownership boundary.
 # =============================================================================
 name: drift-guard
 
@@ -58,9 +59,10 @@ jobs:
       - name: test-uninstall.sh (CF-B4 §5, 4 픽스처)
         run: bash dist/tests/test-uninstall.sh
 
-      # 이 값은 반드시 인용한다 — 인용 없는 YAML 스칼라에 ": "(콜론+공백)이 들어가면
-      # "mapping values are not allowed here"로 파싱이 실패하고, 워크플로가 job을
-      # 하나도 만들지 못한 채 0초에 죽는다(로그도 남지 않아 원인 추적이 어렵다). #32
+      # This value must stay quoted — an unquoted YAML scalar containing ": " (colon + space)
+      # fails to parse with "mapping values are not allowed here", and the workflow then dies
+      # at 0s without ever creating a job (and leaves no logs, which makes the cause hard to
+      # track down). #32
       - name: "test-check-rule-copies.sh (CF-B3 §5, 4 픽스처: byte/invariant/제외)"
         run: bash dist/tests/test-check-rule-copies.sh
 

--- a/.gitignore
+++ b/.gitignore
@@ -103,8 +103,9 @@ Desktop.ini
 # 민감/불필요 파일이 커밋되는 것을 방지(예: "settings.local 2.json").
 * [0-9].*
 * [0-9]
-# 두 자리(10회 이상 복제 — " 10.ext" 이후)도 차단. 2026-09-09 실측으로 이 빈틈 확인:
-# 기존 한 자리 패턴은 "bar 10.json"을 통과시켰다. 세 자리 이상은 현실성이 없어 두지 않는다.
+# Also block two-digit copies (" 10.ext" and beyond). Verified by measurement 2026-09-09:
+# the existing single-digit pattern let "bar 10.json" through. Three digits or more is not
+# realistic, so it is left out.
 * [0-9][0-9].*
 * [0-9][0-9]
 

--- a/core/crates/bathos-cli/src/main.rs
+++ b/core/crates/bathos-cli/src/main.rs
@@ -426,7 +426,7 @@ enum ModelAction {
     },
 }
 
-// `waves.<W?>` 역할군(role↔wave 배정) — moved to `bathos_state::wave_roles` (§4-4 of the W5 task
+// `waves.<W?>` role rosters (role↔wave assignment) — moved to `bathos_state::wave_roles` (§4-4 of the W5 task
 // brief) so `model_plan`'s wave-aware resolve/validate and this CLI share one definition instead
 // of two. Use `wave_roles::wave_role_slugs`/`wave_roles::role_wave` directly; nothing left here.
 
@@ -669,7 +669,7 @@ fn handle_panes(
 }
 
 /// No `--mode` given: honors a previously-saved preference (`_state/panes/prefs`) if present;
-/// otherwise, on a real TTY, asks once and saves the answer (§B4.2 "선택 결과를 기억"). On a
+/// otherwise, on a real TTY, asks once and saves the answer (§B4.2 "remember the choice"). On a
 /// non-TTY with no saved preference, defaults to `dump` — the only mode that is always safe to
 /// run unattended (matches `--mode tui`'s own E-PANES-NOTTY guard: a script/CI invocation with
 /// no prior preference should get inert, pipeable text, never an interactive prompt it can't
@@ -2146,7 +2146,7 @@ fn handle_doctor(root: &Path, state_dir: &Path, modules_dir: &Path) -> Result<i3
     }
 }
 
-/// SS13 "Codex 서브체크" (runtime-abstraction-design.md §7) — additive to `handle_doctor`: a new
+/// SS13 "Codex sub-checks" (runtime-abstraction-design.md §7) — additive to `handle_doctor`: a new
 /// helper + the single call site above. Every check 1-8 above stays byte-identical; these five
 /// are informational for non-Codex users. Absence of Codex-specific assets is `⚠` (expected for
 /// anyone not using Codex), never `✗` — the one exception is a hooks.json that exists but fails
@@ -2216,7 +2216,7 @@ fn doctor_codex_section(root: &Path) -> (u32, u32) {
         warns += 1;
     }
 
-    // 9e. RuntimeHost detection — informational only, unknown is never ⚠/✗ (§5 unknown 의미론).
+    // 9e. RuntimeHost detection — informational only, unknown is never ⚠/✗ (§5 unknown semantics).
     let detection = runtime_host::detect(&|k| std::env::var(k).ok());
     match detection.host {
         runtime_host::RuntimeHost::Unknown => {

--- a/core/crates/bathos-state/src/model_plan.rs
+++ b/core/crates/bathos-state/src/model_plan.rs
@@ -34,7 +34,8 @@ use std::path::Path;
 
 /// The only schema string this module writes. A file with a different (or missing) `schema`
 /// value is treated as **absent** (lenient — same as no file at all) rather than erroring, per
-/// `w2-panes-model-design-kr.md` §A1.2 "불일치 시 lenient 경고 후 무시하고 frontmatter 폴백".
+/// `w2-panes-model-design-kr.md` §A1.2 ("on mismatch, warn leniently, ignore the file, and
+/// fall back to frontmatter").
 pub const SCHEMA_ID: &str = "bathos/model-plan@1";
 
 /// The runtimes a role can be assigned to. `Copy`/`Eq` because resolve/validate compare these
@@ -124,7 +125,7 @@ impl Runtime {
 
 /// The **actual backend** the current Claude Code process is running under. Determined by
 /// `bathos model detect` inspecting `ANTHROPIC_BASE_URL` — this is a process-wide fact
-/// (`[실측 F2]` in the design doc: env-global vars are not per-teammate), never a per-role
+/// (`[measured F2]` in the design doc: env-global vars are not per-teammate), never a per-role
 /// choice. Mirrors [`Runtime`]'s env-global variants 1:1 (see [`Runtime::env_backend`]) but
 /// deliberately has **no** `Codex` variant: Codex is a subprocess, never "the backend this
 /// Claude Code process is running under".
@@ -144,7 +145,7 @@ impl SessionBackend {
     ///
     /// Host substrings come from the user-confirmed integration table (W5 task brief §3):
     /// `api.z.ai` (GLM), `api.moonshot.ai` (Kimi), `api.deepseek.com` (Deepseek). An
-    /// unrecognized/unset host falls back to `Claude` — lenient by design (§A1.1 "정직한 한계":
+    /// unrecognized/unset host falls back to `Claude` — lenient by design (§A1.1 "honest limits":
     /// a typo'd or future host must never silently become an *error*, only an
     /// under-detection).
     ///
@@ -301,10 +302,11 @@ fn plan_path(state_dir: &Path) -> std::path::PathBuf {
 /// Loads `<state_dir>/model-plan.json` leniently.
 ///
 /// - **Absent file** → `ModelPlan::empty()`, no warning (this is the expected steady state for
-///   every project that hasn't opted in — E1 "정상" case, not an error).
+///   every project that hasn't opted in — E1 "normal" case, not an error).
 /// - **Unparseable JSON** → `ModelPlan::empty()` + `W-MODELPLAN-CORRUPT` warning (E1).
 /// - **Parses but `schema` field mismatched/missing** → `ModelPlan::empty()` +
-///   `W-MODELPLAN-SCHEMA` warning (§A1.1 "불일치 시 lenient 경고 후 무시하고 frontmatter 폴백").
+///   `W-MODELPLAN-SCHEMA` warning (§A1.1 "on mismatch, warn leniently, ignore, fall back to
+///   frontmatter").
 /// - Otherwise the parsed plan is returned as-is.
 ///
 /// Never panics, never returns `Err` — this mirrors `bathos-inspect::loader`'s "only a truly
@@ -363,7 +365,8 @@ pub fn load(state_dir: &Path) -> (ModelPlan, Vec<PlanWarning>) {
 /// Whether an on-disk `model-plan.json` exists but is unparseable JSON (distinct from
 /// "well-formed but wrong schema" and from "absent"). `bathos model set` uses this to decide
 /// whether to back up the existing file to `.bak` before overwriting it (E1 second half:
-/// "set 시엔 .bak 백업 후 재생성 물음") — a schema-mismatch file is well-formed JSON and does
+/// "on set, back up to .bak, then ask before regenerating") — a schema-mismatch file is
+/// well-formed JSON and does
 /// not need this protection (overwriting it loses nothing unrecoverable-looking).
 pub fn is_corrupt_json(state_dir: &Path) -> bool {
     let path = plan_path(state_dir);
@@ -378,7 +381,7 @@ pub fn is_corrupt_json(state_dir: &Path) -> bool {
 ///
 /// Deliberately **no file lock**: unlike `manifest.json` (written by multiple concurrent
 /// engines/hooks), `model-plan.json` is written only by the lead's sequential `bathos model
-/// set/unset/detect` calls (§A1.3 "쓰기 주체는 `bathos model set` 단일 경로"). Adding a lock
+/// set/unset/detect` calls (§A1.3 "the single write path is `bathos model set`"). Adding a lock
 /// here would be complexity with no corresponding risk to mitigate — a deliberate simplicity
 /// call, not an oversight.
 pub fn save(state_dir: &Path, plan: &ModelPlan) -> std::io::Result<()> {
@@ -522,11 +525,11 @@ pub struct EffectiveModel {
 ///
 /// ```text
 /// effective(role, wave) =
-///   1. model-plan.roles[slug]         (존재·유효 시)
-///   2. model-plan.waves[wave]          (wave 지정 시, waves[wave].runtime != null일 때)
-///   3. model-plan.defaults             (defaults.model != null 시)
-///   4. agent frontmatter `model`       (현행 동작 — plan 부재/파손 시 여기로 폴백)
-///   5. 런타임 기본 (claude=세션 기본 모델)
+///   1. model-plan.roles[slug]         (if present and valid)
+///   2. model-plan.waves[wave]          (if a wave is given and waves[wave].runtime != null)
+///   3. model-plan.defaults             (if defaults.model != null)
+///   4. agent frontmatter `model`       (current behavior — fallback when the plan is absent/corrupt)
+///   5. runtime default                 (claude = the session's default model)
 /// ```
 ///
 /// `wave_id` is an **explicit** parameter rather than something this function infers on its
@@ -746,7 +749,7 @@ fn multi_env_global_resolutions(conflicting: &[&str]) -> Vec<String> {
 ///   that backend). A role with no plan entry at all (implicit claude via the runtime default)
 ///   does **not** trigger this — only an explicit, contradicted choice is a violation.
 /// - **Codex roles never block**: a separate process, no env conflict either direction
-///   (ADR-D-0006 "정직한 비대칭") — `is_env_global()` is `false` for `Codex`, so it's simply
+///   (ADR-D-0006 "honest asymmetry") — `is_env_global()` is `false` for `Codex`, so it's simply
 ///   never a candidate in Rule 1/2 and never `session_backend`'s value in Rule 3.
 ///
 /// `role_slugs` should be the wave's role roster (see `bathos_state::wave_roles`, sourced from
@@ -881,7 +884,7 @@ mod tests {
     #[test]
     fn resolve_step1_plan_role_wins_even_over_a_matching_wave_entry() {
         // roles[slug] is more specific than waves[wave] — it must win even when a wave policy
-        // for the same wave also exists (§4-5 "더 구체적인 것이 이김").
+        // for the same wave also exists (§4-5 "the more specific one wins").
         let mut plan = plan_with_role("phillip-backend-engineer", Runtime::Codex, None);
         plan.waves.insert(
             "W5".into(),
@@ -972,7 +975,7 @@ mod tests {
     #[test]
     fn resolve_step3_skipped_when_defaults_model_is_null() {
         // defaults.model == None → step 3 is a no-op even though defaults.runtime is set —
-        // this is the literal reading of "(defaults.model != null 시)" that keeps an empty
+        // this is the literal reading of "(if defaults.model != null)" that keeps an empty
         // plan behaviorally identical to no plan at all.
         let plan = ModelPlan::empty("Paul");
         let eff = resolve_effective(

--- a/core/crates/bathos-state/src/wave_roles.rs
+++ b/core/crates/bathos-state/src/wave_roles.rs
@@ -21,7 +21,7 @@ const WAVE_IDS: [&str; 7] = ["W0", "W1", "W2", "W3", "W4", "W5", "W6"];
 /// `"W5"` both match), or `None` if `wave_id` isn't a recognized wave.
 ///
 /// W3/W6's overlap (Thomas/Matthias/Timothy appear in both) is intentional and documented in
-/// `CLAUDE.md` §1 ("+W3 독립 리뷰"/"+W3 보조") — this table transcribes that overlap verbatim
+/// `CLAUDE.md` §1 ("+W3 independent review"/"+W3 assist") — this table transcribes that overlap verbatim
 /// rather than picking one wave per role, so `bathos model show/validate --wave W3` and `--wave
 /// W6` both correctly include them.
 pub fn wave_role_slugs(wave_id: &str) -> Option<&'static [&'static str]> {

--- a/dist/tests/test-manifests.sh
+++ b/dist/tests/test-manifests.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
 # =============================================================================
 # BATHOS Dynamis — dist/tests/test-manifests.sh
-# Story B1·B2 §5 "테스트 접근" 구현: 매니페스트 스키마 자기검증 + 포인터 유효성.
+# Implements Story B1/B2 §5 "test approach": manifest schema self-check + pointer validity.
 #
-#   1) 공통 필드(name/version/sources/capability_tier) 존재 확인 + 산문 필드 없음
-#      (behavior 텍스트가 통째로 박혀있지 않은지 — 필드 값 길이로 간이 검사)
-#   2) sources.* 의 상대경로가 실제 존재하는 디렉터리를 가리키는지 확인
-#      (깨진 포인터 = 실패). LD-5(최종 조립 전) 갭 처리: 제품 트리에 대상이 아직
-#      없으면 원본 bathos/의 동일 상대경로로 폴백 확인 후 "조립 대기" 로 표기.
-#   3) capability_tier 값이 폐쇄 어휘(full-hook/instruction-only/mcp) 안에 있는지
+#   1) Required fields (name/version/sources/capability_tier) exist, and no prose fields
+#      (checks that behavior text isn't embedded wholesale — a rough field-length test)
+#   2) The relative paths under sources.* point at directories that actually exist
+#      (a broken pointer fails). LD-5 gap handling (before final assembly): if the target
+#      isn't in the product tree yet, fall back to the same relative path under the original
+#      bathos/ and mark it "awaiting assembly".
+#   3) capability_tier is inside the closed vocabulary (full-hook/instruction-only/mcp)
 #
-# marketplace.json은 sources/capability_tier가 없는 것이 정상 스키마이므로
-# plugin.json/manifest.json만 검사한다(check-versions.sh와 동일 대상 규약).
+# For marketplace.json, having no sources/capability_tier is the correct schema, so only
+# plugin.json/manifest.json are checked (same target convention as check-versions.sh).
 # =============================================================================
 set -uo pipefail
 
@@ -46,30 +47,31 @@ for f in "${TARGETS[@]}"; do
   rel="${f#"$BATHOS_ROOT"/}"
   fdir="$(cd "$(dirname "$f")" && pwd)"
 
-  # --- 0) 폐지(deprecated) 매니페스트은 스키마 검사에서 제외 ------------------
-  # 스스로 `"deprecated": true` 를 선언하고 후속 정본을 가리키는 스켈레톤에까지
-  # 현행 필수 필드를 요구하면 오탐이 된다(#35). 예:
-  # dist/manifests/codex/plugin.json 은 `_note` 로 "실스키마 불일치로 폐기 예정,
-  # 정본은 dist/codex-plugin/.codex-plugin/plugin.json" 을 명시하고 `_removal` 로
-  # 삭제 계획까지 적어 둔 파일이다 — 그 파일에 version/sources 를 요구할 이유가 없다.
-  # 암묵 제외 금지 원칙에 따라 건너뛴 사실을 로그로 남긴다(조용히 통과시키지 않음).
+  # --- 0) Deprecated manifests are excluded from the schema check --------------------
+  # Demanding today's required fields from a skeleton that declares `"deprecated": true`
+  # and points at its replacement produces a false positive (#35). Example:
+  # dist/manifests/codex/plugin.json uses `_note` to state that it is slated for removal
+  # (its schema does not match the real host) and that the canonical file is
+  # dist/codex-plugin/.codex-plugin/plugin.json, and records a `_removal` plan — there is
+  # no reason to require version/sources of it.
+  # Per the no-implicit-exclusions rule, the skip is logged (never a silent pass).
   if [[ "$(jq -r '.deprecated // false' "$f")" == "true" ]]; then
     info "$rel — deprecated=true → 스키마 검사 제외(정본으로 대체된 스켈레톤, #35). 파일 삭제는 각 매니페스트의 _removal 계획을 따른다"
     continue
   fi
 
-  # --- 0-b) 호스트 판별 — 필수 필드가 호스트마다 다르다 ----------------------
-  # Codex 플러그인 스키마에는 `sources`·`capability_tier` 가 **존재하지 않는다**
-  # (PR #27 실측 — scripts/build-codex-plugin.sh 헤더 주석, codex-mechanisms.md §4.3).
-  # Codex 는 상대 포인터 대신 `skills`/`hooks` 를 번들로 직접 담는 구조다. 따라서
-  # Claude 플러그인 규약(`sources` 포인터)을 Codex 매니페스트에 적용하면 올바른
-  # 파일을 실패로 판정한다(#35). 호스트별로 요구 필드를 분기한다.
+  # --- 0-b) Host detection — required fields differ per host -------------------------
+  # The Codex plugin schema has **no** `sources` or `capability_tier` field (measured in
+  # PR #27 — see the scripts/build-codex-plugin.sh header, codex-mechanisms.md §4.3).
+  # Instead of relative pointers, Codex bundles `skills`/`hooks` directly. So applying the
+  # Claude plugin convention (`sources` pointers) to a Codex manifest fails a correct file
+  # (#35). Branch the required fields per host.
   case "$rel" in
     *.codex-plugin/*|*/codex-plugin/*|*/manifests/codex/*) host="codex" ;;
     *)                                                     host="claude" ;;
   esac
 
-  # --- 1) 공통 필드 존재 -----------------------------------------------------
+  # --- 1) Required fields exist ----------------------------------------------------
   name="$(jq -r '.name // empty' "$f")"
   version="$(jq -r '.version // empty' "$f")"
   tier="$(jq -r '.capability_tier // empty' "$f")"
@@ -79,7 +81,7 @@ for f in "${TARGETS[@]}"; do
   [[ -n "$version" ]] && ok "$rel — version 존재" || error "$rel — version 필드 없음"
 
   if [[ "$host" == "codex" ]]; then
-    # Codex: `skills` 번들이 포인터 역할을 대신한다. `sources` 부재는 정상이다.
+    # Codex: the `skills` bundle takes the place of pointers; a missing `sources` is normal.
     if [[ "$(jq -r 'has("skills")' "$f")" == "true" ]]; then
       ok "$rel — (codex) skills 번들 존재 — sources 포인터는 이 호스트 스키마에 없음(정상)"
     else
@@ -91,8 +93,8 @@ for f in "${TARGETS[@]}"; do
     ok "$rel — sources 필드 존재"
   fi
 
-  # --- 2) 산문 필드 없음(간이 검사: description을 제외한 값 중 200자 초과 문자열
-  #        필드가 없는지) — behavior 텍스트 임베드 금지(CF-B1 AC1 "<20줄 목표")
+  # --- 2) No prose fields (rough check: no string field longer than 200 chars, description
+  #        aside) — behavior text must not be embedded (CF-B1 AC1 "<20 lines" goal)
   long_field="$(jq -r '
     to_entries
     | map(select(.key != "sources" and .key != "_skeleton_note"))
@@ -105,7 +107,7 @@ for f in "${TARGETS[@]}"; do
     ok "$rel — 산문 임베드 없음(필드 길이 검사 통과)"
   fi
 
-  # --- 3) capability_tier 폐쇄 어휘 검사 --------------------------------------
+  # --- 3) capability_tier closed-vocabulary check ------------------------------------
   if [[ -n "$tier" ]]; then
     if [[ " $VALID_TIERS " == *" $tier "* ]]; then
       ok "$rel — capability_tier=$tier (폐쇄 어휘 내)"
@@ -114,7 +116,7 @@ for f in "${TARGETS[@]}"; do
     fi
   fi
 
-  # --- 4) 포인터 유효성 -------------------------------------------------------
+  # --- 4) Pointer validity ----------------------------------------------------------
   if [[ "$has_sources" == "true" ]]; then
     for key in roles skills commands hooks; do
       ptr="$(jq -r ".sources.${key} // empty" "$f")"
@@ -124,8 +126,9 @@ for f in "${TARGETS[@]}"; do
         ok "$rel — sources.$key -> $ptr (존재)"
         continue
       fi
-      # LD-5 폴백: 제품 트리 미조립 상태에서는 원본 bathos/ 동일 상대 위치로 확인.
-      # (fdir가 dist/... 이므로, "target"의 .claude/xxx 접미사만 뽑아 원본과 대조)
+      # LD-5 fallback: while the product tree is unassembled, check the same relative
+      # location under the original bathos/. (fdir is dist/..., so take only the
+      # .claude/xxx suffix of "target" and compare it against the original.)
       suffix="${ptr##*.claude/}"
       orig_target="$BATHOS_ROOT/../../bathos/.claude/$suffix"
       if [[ -d "$orig_target" ]]; then

--- a/scripts/build-codex-plugin.sh
+++ b/scripts/build-codex-plugin.sh
@@ -1,22 +1,27 @@
 #!/usr/bin/env bash
 # ---------------------------------------------------------------------------
-# BATHOS  scripts/build-codex-plugin.sh  —  dist/codex-plugin/ 정식 플러그인 번들 조립(story-17)
+# BATHOS  scripts/build-codex-plugin.sh  —  assembles the dist/codex-plugin/ bundle (story-17)
 #
-# 무엇을·왜: `codex plugin marketplace add` 1줄 설치 경로(F1-b)의 내용물을 조립한다. 이 스크립트가
-# 만드는 파일은 전부 **복사 생성물**이다 — 정본은 `.agents/skills/**`(skills 정본, to-codex.sh 산출 +
-# story-10 수기)과 `.codex/hooks.json`(Phillip 소유, CT-WIRE-HOOKS 배선 정본)이며, 이 스크립트는 그것을
-# CT-PLUGIN 레이아웃(adapter-contracts.md §9)으로 재배치할 뿐 새 내용을 만들지 않는다(이중 정본화 금지).
+# What and why: assembles the payload behind the one-line `codex plugin marketplace add`
+# install path (F1-b). Every file this script produces is a **copy** — the canonical sources
+# are `.agents/skills/**` (canonical skills: to-codex.sh output + story-10 hand-authored) and
+# `.codex/hooks.json` (owned by Phillip, the canonical CT-WIRE-HOOKS wiring). This script only
+# rearranges them into the CT-PLUGIN layout (adapter-contracts.md §9); it creates no new
+# content (never a second canonical copy).
 #
-# plugin.json은 이 스크립트가 직접 쓰는 유일한 "신규 내용"이다 — 구 스켈레톤(dist/manifests/codex/
-# plugin.json)이 3중 불일치로 FAIL 판정을 받은 반면교사(codex-mechanisms.md §4.3: `.codex-plugin/` 규약
-# 미준수·`sources`/`capability_tier` 비실재 필드·상대 포인터 방식 상이)를 반복하지 않도록, CT-PLUGIN
-# manifest_schema의 필수 3필드(name/version/description)와 근거 있는 선택 필드만 쓴다.
+# plugin.json is the only "new content" this script writes itself. To avoid repeating the old
+# skeleton's mistake (dist/manifests/codex/plugin.json was judged FAIL on a three-way mismatch
+# — codex-mechanisms.md §4.3: it ignored the `.codex-plugin/` convention, carried the
+# non-existent `sources`/`capability_tier` fields, and used a different relative-pointer
+# scheme), it writes only manifest_schema's three required fields (name/version/description)
+# plus optional fields we have evidence for.
 #
-# 사용:
-#   bash scripts/build-codex-plugin.sh            # 조립(멱등 — 재실행 시 diff 0)
+# Usage:
+#   bash scripts/build-codex-plugin.sh            # assemble (idempotent — a re-run diffs to 0)
 #
-# 전제: `.agents/skills/**`(scripts/to-codex.sh --write 로 최신화됨) · `.codex/hooks.json`(Phillip 산출,
-# 없으면 스킵하고 경고만 — fail-safe, 이 스크립트가 Phillip 소유 파일을 만들지 않는다).
+# Prerequisites: `.agents/skills/**` (kept current by scripts/to-codex.sh --write) and
+# `.codex/hooks.json` (Phillip's output; if absent this warns and skips — fail-safe, this
+# script never creates a file Phillip owns).
 # ---------------------------------------------------------------------------
 set -euo pipefail
 
@@ -33,24 +38,27 @@ say(){ printf '%s\n' "$*"; }
 [ -d "$SRC_SKILLS" ] || { echo "오류: $SRC_SKILLS 없음 — 먼저 'bash scripts/to-codex.sh --write' 실행" >&2; exit 1; }
 
 # ---------------------------------------------------------------------------
-# 1) 기존 번들 비우고 재조립(멱등 — 이전 실행의 잔여 파일이 남지 않도록 항상 클린 리빌드)
+# 1) Empty the existing bundle and reassemble (idempotent — always a clean rebuild, so no
+#    leftovers from a previous run survive)
 # ---------------------------------------------------------------------------
 rm -rf "$DST"
 mkdir -p "$DST/.codex-plugin" "$DST/skills" "$DST/hooks"
 
 # ---------------------------------------------------------------------------
-# 2) plugin.json — CT-PLUGIN manifest_schema(필수 3필드 + 근거 있는 선택 필드만)
+# 2) plugin.json — CT-PLUGIN manifest_schema (3 required fields + evidence-backed optionals)
 #
-# story-20 라이브 검증(SS18 실측)에서 "skills"/"hooks" 컴포넌트 포인터 누락 시
-# `codex plugin marketplace add` 등록은 성공해도 `codex plugin list`에 노출되지 않음이
-# 확인됨 — adapter-contracts.md §9 manifest_schema의 optional 필드(skills/hooks)를
-# 명시 포인터로 채운다(레퍼런스: Codex 내장 visualize 플러그인의 "skills": "./skills/").
+# story-20's live verification (SS18, measured) confirmed that without the "skills"/"hooks"
+# component pointers, `codex plugin marketplace add` registers fine but the plugin never shows
+# up in `codex plugin list` — so the optional fields (skills/hooks) of adapter-contracts.md §9
+# manifest_schema are filled in with explicit pointers (reference: Codex's built-in visualize
+# plugin uses "skills": "./skills/").
 # ---------------------------------------------------------------------------
-# version 은 dist/VERSION(축 B 배포 레이어의 단일 버전 핀)에서 읽는다.
-# 이전에는 여기에 "0.1.0" 이 하드코딩돼 있어, dist/VERSION 이 0.2.0 으로 올라간 뒤에도
-# 빌드마다 낡은 값을 다시 써 넣었다 — check-versions.sh 가 이를 잡아내지만 그 검사가
-# drift-guard 안에 있었고 워크플로가 파싱 오류로 죽어 있어(#32) 드리프트가 가려졌다(#33).
-# JSON 만 손으로 고치면 다음 빌드에서 되돌아가므로 생성기 쪽을 고친다(근본 원인).
+# The version is read from dist/VERSION (the single version pin of the axis-B distribution
+# layer). It used to be hardcoded here as "0.1.0", so every build rewrote the stale value even
+# after dist/VERSION had moved to 0.2.0 — check-versions.sh catches exactly that, but the check
+# lived inside drift-guard and that workflow was dead from a parse error (#32), which masked
+# the drift (#33). Fixing only the JSON would regress on the next build, so the generator is
+# fixed instead (the root cause).
 _PLUGIN_VERSION="$(tr -d '[:space:]' < "$PROJ/dist/VERSION" 2>/dev/null || true)"
 if [[ -z "$_PLUGIN_VERSION" ]]; then
   printf '[build-codex-plugin] ✗ dist/VERSION 을 읽을 수 없습니다 — 버전 핀 없이 번들을 만들지 않습니다.\n' >&2
@@ -73,8 +81,9 @@ JSONEOF
 say "[plugin.json] $DST/.codex-plugin/plugin.json"
 
 # ---------------------------------------------------------------------------
-# 3) skills 번들 — .agents/skills/** 전량 복사(generated 15 + hand-authored 15 = 30, 발견 경로만
-#    다를 뿐 내용은 정본과 동일 — story-17 Dev Notes "이중 정본화 금지").
+# 3) skills bundle — copies all of .agents/skills/** (generated 15 + hand-authored 15 = 30;
+#    only the discovery path differs, the content is identical to the canonical files —
+#    story-17 Dev Notes, "never a second canonical copy").
 # ---------------------------------------------------------------------------
 nskill=0
 for d in "$SRC_SKILLS"/*/; do
@@ -87,34 +96,35 @@ done
 say "[skills] $nskill 개 → $DST/skills/**"
 
 # ---------------------------------------------------------------------------
-# 4) hooks 번들 — story-20 라이브 127 결함(SS18 3차) 수정.
+# 4) hooks bundle — fixes story-20's live exit-127 defect (SS18, third round).
 #
-# 무엇이 문제였나: .codex/hooks.json(Phillip 소유, repo-스코프)은 command를
-# 상대경로 `codex-adapter/hooks/*.sh`로 참조한다 — repo-스코프 배선은 cwd가
-# 항상 repo 루트라 문제없지만, 이 값을 **그대로 복사**해 플러그인에 실었던
-# 구버전은 설치 후 cwd가 사용자 프로젝트(플러그인 설치 위치가 아님)가 되므로
-# `codex-adapter/hooks/*.sh`가 어디서도 발견되지 않아 전 훅이 exit 127이었다
-# (라이브 실측: `~/.codex/plugins/cache/.../bathos/0.1.0/`엔 codex-adapter/가
-# 아예 없음 — story-20 SS18).
+# What was wrong: .codex/hooks.json (owned by Phillip, repo-scoped) references its commands by
+# the relative path `codex-adapter/hooks/*.sh`. For repo-scoped wiring that is fine, since cwd
+# is always the repo root — but the older version that shipped those values into the plugin
+# **verbatim** broke after installation, because cwd is then the user's project (not the
+# plugin's install location), so `codex-adapter/hooks/*.sh` was nowhere to be found and every
+# hook exited 127 (measured live: `~/.codex/plugins/cache/.../bathos/0.1.0/` contains no
+# codex-adapter/ at all — story-20 SS18).
 #
-# 고친 방법: (a) 훅 스크립트 5종 실물을 hooks.json과 같은 디렉터리로 번들해
-# 상대경로 문제 자체를 없애고, (b) command를 플러그인 설치 루트 기준 절대
-# 참조로 재작성한다. 정책(matcher/timeout/이벤트 순서)은 여전히 Phillip의
-# SSOT(.codex/hooks.json)에서 그대로 읽어온다 — 여기서 바꾸는 값은 command의
-# 경로 표현 하나뿐(이중 정본화 금지 유지, script §머리말 참고).
+# How it was fixed: (a) bundle the five hook scripts themselves into the same directory as
+# hooks.json, removing the relative-path problem entirely, and (b) rewrite each command as an
+# absolute reference based on the plugin install root. The policy (matcher/timeout/event order)
+# is still read straight from Phillip's SSOT (.codex/hooks.json) — the only value changed here
+# is the path expression inside command (still no second canonical copy; see the header).
 #
-# 절대 참조 방식(⚠️ 라이브 미확정 — 근거 있는 최선안): Caleb 조사
-# (02-market-analysis/codex-mechanisms.md §4.1, 2026-07-23 공식 문서 확인)에
-# 따르면 Codex는 훅 프로세스에 **환경변수** `PLUGIN_ROOT`(+ 레거시 호환
-# `CLAUDE_PLUGIN_ROOT`)를 주입한다. 이 값이 command 문자열 안에서 자동
-# 치환(셸 경유 실행)되는지는 미확정이므로, 그 가정에 기대지 않고 우리가 직접
-# `/bin/bash -c '...'`로 감싸 **bash 자신의 환경변수 치환**을 쓴다 — 이렇게
-# 하면 바깥 실행기가 이 command를 셸로 돌리든 execve로 바로 돌리든(따옴표만
-# 보존하면) 안쪽 `${PLUGIN_ROOT:-$CLAUDE_PLUGIN_ROOT}`는 항상 bash -c 시점에
-# 그 프로세스의 실제 환경변수로 치환된다 — 바깥 실행 방식에 대한 가정이 필요
-# 없다. 이 가정이 틀렸다면(env var 이름이 다르거나 문서와 실제가 다르면)
-# 사용자 라이브 재테스트로 드러나며, 그 경우 probe.sh류 실측으로 이름을
-# 확정한 뒤 이 스크립트만 고치면 된다(스크립트 본체는 무수정).
+# The absolute-reference scheme (⚠️ not confirmed live — the best evidence-backed option):
+# per Caleb's research (02-market-analysis/codex-mechanisms.md §4.1, official docs checked
+# 2026-07-23), Codex injects the **environment variables** `PLUGIN_ROOT` (plus the legacy
+# `CLAUDE_PLUGIN_ROOT`) into the hook process. Whether that value is expanded inside the
+# command string (i.e. run through a shell) is unconfirmed, so rather than relying on that
+# assumption we wrap the command in `/bin/bash -c '...'` ourselves and use **bash's own**
+# variable expansion — that way, whether the outer runner executes this command through a
+# shell or straight via execve (as long as the quotes survive), the inner
+# `${PLUGIN_ROOT:-$CLAUDE_PLUGIN_ROOT}` is always expanded at `bash -c` time from that
+# process's real environment, so no assumption about the outer execution model is needed.
+# If the assumption is wrong (a different env var name, or docs diverging from reality), a
+# live retest by the user will reveal it; then the name can be pinned by a probe.sh-style
+# measurement and only this script needs changing (its body stays untouched).
 # ---------------------------------------------------------------------------
 if [ -f "$SRC_HOOKS" ]; then
   nhook=0
@@ -122,7 +132,7 @@ if [ -f "$SRC_HOOKS" ]; then
     [ -f "$h" ] || continue
     base="$(basename "$h")"
     case "$base" in
-      _test-*) continue ;;  # 테스트 스크립트는 배포 자산이 아님(codex-adapter 내부 전용)
+      _test-*) continue ;;  # test scripts are not distribution assets (codex-adapter internal)
     esac
     cp -p "$h" "$DST/hooks/$base"
     chmod +x "$DST/hooks/$base"
@@ -130,10 +140,10 @@ if [ -f "$SRC_HOOKS" ]; then
   done
   say "[hooks/*.sh] $nhook 개 → $DST/hooks/**(실행권한 유지)"
 
-  # hooks.json은 구조적으로 읽어 command 필드만 재작성(python3 — 이 파일의
-  # plugin.json 검증에도 이미 쓰는 도구, jq 비의존 원칙과 무관하게 이 스크립트는
-  # 빌드타임 전용이라 python3 사용이 무해함). matcher/timeout/이벤트 순서는
-  # SRC_HOOKS 그대로 보존된다.
+  # hooks.json is parsed structurally and only its command fields are rewritten (python3 — the
+  # same tool already used to validate this file's plugin.json; the no-jq-dependency rule does
+  # not apply here because this script is build-time only, so python3 is harmless).
+  # matcher/timeout/event order are preserved exactly as they appear in SRC_HOOKS.
   python3 - "$SRC_HOOKS" "$DST/hooks/hooks.json" <<'PYEOF'
 import json, re, sys
 

--- a/scripts/check-rule-copies.sh
+++ b/scripts/check-rule-copies.sh
@@ -2,34 +2,38 @@
 # =============================================================================
 # BATHOS Dynamis — check-rule-copies.sh
 #
-# 두 가지 모드를 지원한다(둘 다 CF-B1/B3 뒷받침):
+# Supports two modes (both back CF-B1/B3):
 #
-#   --dup-scan      (기본)  risk-log A-4 필수 조치 — B1/B2 AC1 "무중복" 즉시 검증.
-#                    canonical 소스(역할/스킬/커맨드 산문)의 유의미한 줄이
-#                    dist/**·docs/** 안에 통째로 재복제되지 않았는지 grep 검사.
-#                    B3 CI 승격 전 수동 실행 가능하도록 지금 도입한다(A-4 지시).
+#   --dup-scan      (default) risk-log A-4 required action — verifies B1/B2 AC1 "no
+#                    duplication" on the spot. greps whether meaningful lines of the
+#                    canonical sources (role/skill/command prose) have been re-copied
+#                    wholesale into dist/** or docs/**. Introduced now so it can be run
+#                    by hand before the B3 CI promotion (per A-4).
 #
-#   --check-copies          CF-B3 AC1 본체 — instruction-only 계층으로 "의도적으로"
-#                    복제된 규칙 텍스트(dist/copies-manifest.json에 등록된 항목만)의
-#                    drift를 검사한다. 짧은 복제=byte diff, 긴 본문=invariant 부분문자열.
-#                    등록된 복제가 0건이면 통과+안내(실패 아님 — B3 CONCERNS 명시 처리).
+#   --check-copies          The body of CF-B3 AC1 — checks drift in rule text that was
+#                    *deliberately* copied into the instruction-only layer (only entries
+#                    registered in dist/copies-manifest.json). Short copies=byte diff,
+#                    long bodies=invariant substrings. Zero registered copies means
+#                    pass + notice (not a failure — B3 CONCERNS, handled explicitly).
 #
-# 공통 관례: 기존 훅 5칙(project-context-kr.md §4-2) 중 ①②③ 계승
-#   ① SCRIPT_DIR -> BATHOS_ROOT 경로 해석
-#   ② jq 있으면 파싱, 없으면 보수적 grep 폴백
-#   ③ fail-safe: 검사 대상 자체가 없으면(디렉터리 부재 등) 통과 + 안내(과차단 금지)
+# Shared conventions: inherits (1)(2)(3) of the five hook rules (project-context-kr.md §4-2)
+#   (1) SCRIPT_DIR -> BATHOS_ROOT path resolution
+#   (2) parse with jq when available, else a conservative grep fallback
+#   (3) fail-safe: when there is nothing to check at all (missing directory, etc.), pass +
+#       notice (never over-block)
 #
-# exit: 0=문제 없음, 1=드리프트/중복 발견(무엇이 어디서 발견됐는지 + 다음 행동 포함)
+# exit: 0=no problem, 1=drift/duplication found (says what was found where + the next action)
 # =============================================================================
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BATHOS_ROOT="${BATHOS_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 
-# 두 모드가 함께 쓰는 제외 목록 파일 — 모드 블록 밖(공용)에 둔다.
-# 주의: 이전에는 --check-copies 블록 안에서만 정의돼 있었다. --dup-scan 이 이 값을
-# 참조하게 되면서 그 위치로는 빈 값이 되어 제외가 조용히 무력화된다(set -u 로도
-# 안 잡히는 침묵 실패). 새 모드가 추가되어도 같은 함정에 빠지지 않도록 공용화한다.
+# The exclusions file both modes use — kept outside the mode blocks (shared).
+# Note: this used to be defined only inside the --check-copies block. Once --dup-scan began
+# referencing it, that placement left it empty and silently disabled the exclusions (a silent
+# failure that `set -u` does not catch either). Shared here so a new mode cannot fall into
+# the same trap.
 EXCLUSIONS_FILE="${BATHOS_DRIFT_EXCLUSIONS:-$SCRIPT_DIR/drift-exclusions.json}"
 
 MODE="dup-scan"
@@ -55,11 +59,11 @@ warn()  { printf '[bathos check-rule-copies] ! %s\n' "$*"; }
 error() { printf '[bathos check-rule-copies] ✗ %s\n' "$*"; FAIL=1; }
 ok()    { printf '[bathos check-rule-copies] ✓ %s\n' "$*"; }
 
-# --- canonical 소스 루트 해석 (제품 트리 우선, 없으면 원본 bathos/ 폴백) --------
-# LD-5: 최종 조립(Paul)이 끝나기 전에는 제품 트리에 .claude/agents 등이 아직
-# 존재하지 않을 수 있다(구현자는 변경분만 커밋). 이 경우 원본 bathos/를
-# read-only 참조로 폴백해 "포인터가 가리킬 대상이 결국 무엇인지" 검증한다.
-# 이 폴백은 임시이며 최종 조립 후에는 자동으로 제품 트리 경로가 우선된다.
+# --- Canonical source root (product tree first, else fall back to the original bathos/) ---
+# LD-5: before Paul's final assembly the product tree may not have .claude/agents yet
+# (implementers commit only their diffs). In that case fall back to the original bathos/ as a
+# read-only reference, to verify "what the pointers will ultimately resolve to".
+# This fallback is temporary; after final assembly the product-tree path automatically wins.
 resolve_canon_root() {
   if [[ -d "$BATHOS_ROOT/.claude/agents" ]]; then
     printf '%s\n' "$BATHOS_ROOT/.claude"
@@ -67,8 +71,8 @@ resolve_canon_root() {
   fi
   local orig="$BATHOS_ROOT/../../bathos/.claude"
   if [[ -d "$orig" ]]; then
-    # 주의: 이 함수는 $(...) 로 호출되므로 stdout은 오직 "경로 한 줄"만 담아야
-    # 한다. 진단 메시지는 반드시 stderr로 보낸다(stdout 오염 시 경로가 깨짐).
+    # Note: this function is called via $(...), so stdout must carry exactly one line — the
+    # path. Diagnostics must go to stderr (polluting stdout corrupts the path).
     printf '[bathos check-rule-copies] ! 제품 트리에 .claude/agents 없음 — 원본 bathos/.claude 폴백 검사 중(LD-5 최종 조립 전 임시 동작)\n' >&2
     printf '%s\n' "$(cd "$orig" && pwd)"
     return
@@ -83,10 +87,10 @@ if [[ "$MODE" == "dup-scan" ]]; then
     exit 0
   fi
 
-  # 스캔 대상 산문 파일: 역할(agents) · 스킬(skills/*/SKILL.md) · 커맨드(commands)
-  # 셋 다 존재를 보장하지 않는다(예: 원본 bathos/.claude엔 skills/가 아직 없음
-  # — bathos-debt 등은 이번 Dynamis에서 신설되는 스킬). 존재하는 디렉터리만 검사.
-  # 주의: mapfile은 bash4+ 전용(기존 훅 호환 관례상 bash 3.2/macOS 기본 지원 유지).
+  # Prose files to scan: roles (agents), skills (skills/*/SKILL.md), commands (commands).
+  # None of the three is guaranteed to exist (e.g. the original bathos/.claude has no skills/
+  # yet — bathos-debt and friends are new in Dynamis). Only existing directories are checked.
+  # Note: mapfile is bash 4+ only (hook-compat convention keeps bash 3.2/macOS working).
   CANON_DIRS=()
   for d in "$CANON_CLAUDE/agents" "$CANON_CLAUDE/skills" "$CANON_CLAUDE/commands"; do
     [[ -d "$d" ]] && CANON_DIRS+=("$d")
@@ -104,8 +108,9 @@ if [[ "$MODE" == "dup-scan" ]]; then
     exit 0
   fi
 
-  # 검사 표면: dist/, docs/ (매니페스트 JSON·본 표 자체의 짧은 인용구는 제외 —
-  # 아래 MIN_LEN 이상만 비교하므로 "짧은 인용/기호 설명"은 자연히 걸러진다)
+  # Surfaces to check: dist/, docs/ (short quotations in manifest JSON or in the tables
+  # themselves are out — only lines at or above MIN_LEN below are compared, so "short
+  # quotes / symbol glossaries" fall out naturally)
   SEARCH_DIRS=()
   [[ -d "$BATHOS_ROOT/dist" ]] && SEARCH_DIRS+=("$BATHOS_ROOT/dist")
   [[ -d "$BATHOS_ROOT/docs" ]] && SEARCH_DIRS+=("$BATHOS_ROOT/docs")
@@ -115,17 +120,18 @@ if [[ "$MODE" == "dup-scan" ]]; then
     exit 0
   fi
 
-  MIN_LEN=60   # 이 길이 미만 줄은 우연 일치 가능성이 높아 비교 제외(오탐 방지)
+  MIN_LEN=60   # Shorter lines match by coincidence too easily — excluded (avoids false positives)
   LINES_SCANNED=0
   DUPES_FOUND=0
 
-  # --- 제외 디렉터리 로드(암묵 제외 금지 — 파일로 명시, 사유 필수) -------------
-  # drift-exclusions.json 의 `dup_scan_excluded_dirs[]` 는 "검색 표면에서 통째로
-  # 뺄 디렉터리 접두사"다(같은 파일의 `exclusions[]` 와 의미가 다름 — 그쪽은
-  # --check-copies 가 쓰는 '등록된 복제본' 파일 경로다).
-  # 왜 필요한가: 포인터를 따라갈 수 없는 호스트(Codex)의 배포 번들은 산문을
-  # 자체 보유해야 하므로, CF-B1 의 "배포 표면은 포인터만" 전제가 성립하지 않는다(#33).
-  # jq 가 없으면 제외를 적용하지 않는다 — 검사가 더 엄격해지는 방향이므로 안전하다.
+  # --- Load excluded directories (no implicit exclusions — declared in a file, reason required)
+  # `dup_scan_excluded_dirs[]` in drift-exclusions.json holds "directory prefixes to drop
+  # from the search surface entirely" (a different meaning from `exclusions[]` in the same
+  # file — those are the 'registered copy' file paths used by --check-copies).
+  # Why it is needed: a distribution bundle for a host that cannot follow pointers (Codex)
+  # has to carry the prose itself, so CF-B1's "distribution surfaces hold pointers only"
+  # premise does not hold (#33).
+  # Without jq no exclusions are applied — that only makes the check stricter, so it is safe.
   DUP_EXCLUDED_DIRS=()
   if [[ -f "$EXCLUSIONS_FILE" ]] && command -v jq >/dev/null 2>&1; then
     while IFS= read -r p; do
@@ -136,7 +142,7 @@ if [[ "$MODE" == "dup-scan" ]]; then
     info "제외 디렉터리 ${#DUP_EXCLUDED_DIRS[@]}건 적용(사유는 $(basename "$EXCLUSIONS_FILE") 참조): ${DUP_EXCLUDED_DIRS[*]}"
   fi
 
-  # 히트 경로가 제외 접두사 아래인지 판정(BATHOS_ROOT 상대경로로 비교).
+  # Decides whether a hit path sits under an excluded prefix (compared BATHOS_ROOT-relative).
   _hit_excluded() {
     local hit_rel="${1#"$BATHOS_ROOT"/}"
     local d
@@ -147,7 +153,8 @@ if [[ "$MODE" == "dup-scan" ]]; then
   }
 
   for f in "${CANON_FILES[@]}"; do
-    # frontmatter(---)·헤딩(#)·표 구분선·공백줄 제외, MIN_LEN 이상 줄만 후보로.
+    # Skips frontmatter (---), headings (#), table rules and blank lines; only lines at or
+    # above MIN_LEN become candidates.
     while IFS= read -r line; do
       [[ -z "$line" ]] && continue
       [[ "$line" =~ ^#+[[:space:]] ]] && continue
@@ -155,10 +162,11 @@ if [[ "$MODE" == "dup-scan" ]]; then
       [[ "${#line}" -lt "$MIN_LEN" ]] && continue
       LINES_SCANNED=$((LINES_SCANNED + 1))
       for d in "${SEARCH_DIRS[@]}"; do
-        # -F(고정문자열) -r(재귀) -l(파일명만): 정본 그대로의 산문 블록이
-        # 배포 표면에 그대로 박혀 있는지만 본다(부분 인용/의역은 오탐 방지 위해 무시).
+        # -F (fixed string) -r (recursive) -l (names only): looks only for a prose block
+        # embedded verbatim from the canonical file into a distribution surface (partial
+        # quotes/paraphrases are ignored to avoid false positives).
         hit="$(grep -F -r -l -- "$line" "$d" 2>/dev/null || true)"
-        # 제외 디렉터리 아래 히트는 버린다 — 남은 것이 없으면 위반이 아니다.
+        # Hits under an excluded directory are dropped — if none remain, it is no violation.
         if [[ -n "$hit" && "${#DUP_EXCLUDED_DIRS[@]}" -gt 0 ]]; then
           kept=""
           while IFS= read -r h; do
@@ -188,7 +196,7 @@ fi
 
 if [[ "$MODE" == "check-copies" ]]; then
   COPIES_MANIFEST="${BATHOS_COPIES_MANIFEST:-$BATHOS_ROOT/dist/copies-manifest.json}"
-  # EXCLUSIONS_FILE 은 스크립트 상단에서 공용으로 정의된다(두 모드가 공유).
+  # EXCLUSIONS_FILE is defined once at the top of the script (shared by both modes).
 
   if [[ ! -f "$COPIES_MANIFEST" ]]; then
     ok "copies-manifest.json 없음 — 검사 대상 0건(통과). 다음 행동: instruction-only 어댑터 추가 시 dist/copies-manifest.json에 등록하세요."
@@ -206,7 +214,7 @@ if [[ "$MODE" == "check-copies" ]]; then
     exit 0
   fi
 
-  # 제외 목록 로드(암묵 제외 금지 — 파일로 명시)
+  # Load the exclusions list (no implicit exclusions — declared in a file)
   is_excluded() {
     local rel="$1"
     [[ -f "$EXCLUSIONS_FILE" ]] || return 1
@@ -214,9 +222,10 @@ if [[ "$MODE" == "check-copies" ]]; then
   }
 
   norm() {
-    # fingerprint 정규화(간이판): 후행공백 제거 + CRLF->LF.
-    # 주의(CONCERNS): bathos-state의 단일 정규화 함수(Rust, Phillip 소유)와
-    # 별도 구현이다 — 언어 경계상 재사용 불가. 규칙만 동일하게 맞춤.
+    # fingerprint normalization (simplified): strip trailing whitespace + CRLF->LF.
+    # Note (CONCERNS): a separate implementation from bathos-state's single normalization
+    # function (Rust, owned by Phillip) — not reusable across the language boundary. Only
+    # the rules are kept identical.
     sed -e 's/\r$//' -e 's/[[:space:]]*$//' "$1"
   }
 

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -1,26 +1,27 @@
 #!/usr/bin/env bash
 # =============================================================================
 # BATHOS Dynamis — check-versions.sh
-# CF-B3 / US7 AC2 — 전 배포 매니페스트가 단일 semver에 핀 되었는지 검사한다.
-# ponytail 교훈: 무언 버전 노후화를 changelog 각주가 아니라 CI 실패로 만든다.
+# CF-B3 / US7 AC2 — verifies that every distribution manifest is pinned to a single semver.
+# ponytail lesson: turn silent version rot into a CI failure, not a changelog footnote.
 # =============================================================================
 #
-# 검사 대상: dist/**/plugin.json , dist/**/manifest.json
-#   (marketplace.json은 검사 제외 — 자체 버전 필드를 갖지 않는 설계, plugin.json을
-#    포인터로만 참조하므로 version 드리프트 대상이 아니다.)
+# Targets: dist/**/plugin.json , dist/**/manifest.json
+#   (marketplace.json is excluded — by design it carries no version field of its own and
+#    references plugin.json only as a pointer, so it cannot drift.)
 #
-# 기준(SSOT): dist/VERSION 1줄(semver). 이 파일이 축 B 배포 레이어의 단일 버전
-#   핀이다. (주의: core/crates의 Rust 엔진 버전(Phillip 소유, VERSION 파일 별도)과
-#   *의도적으로 분리*된 축이다 — 배포 패키징 버전과 엔진 크레이트 버전은 다른 축.
-#   통합이 필요하면 Paul 확인 후 재설계.)
+# Reference (SSOT): dist/VERSION, a single semver line. This file is the one version pin for
+#   the axis-B distribution layer. (Note: it is *deliberately separate* from the Rust engine
+#   version under core/crates (owned by Phillip, its own VERSION file) — packaging version and
+#   engine crate version are different axes. Unifying them needs Paul's sign-off and a redesign.)
 #
-# 부가: git 태그가 존재하면(예: v0.2.0) 태그-버전 정합도 검사(US7 AC2 후단).
+# Extra: when a git tag exists (e.g. v0.2.0), tag/version consistency is checked too
+#   (US7 AC2, latter half).
 #
-# exit: 0=전부 정합, 1=불일치 발견(어떤 파일의 어떤 값이 다른지 명시 + 다음 행동)
+# exit: 0=all consistent, 1=mismatch found (names the file, the differing value, next action)
 # =============================================================================
 set -uo pipefail
 
-# --- 경로 해석 (기존 훅 관례 ① 계승: SCRIPT_DIR -> BATHOS_ROOT) --------------
+# --- Path resolution (inherits hook convention (1): SCRIPT_DIR -> BATHOS_ROOT) ------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BATHOS_ROOT="${BATHOS_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 DIST_DIR="$BATHOS_ROOT/dist"
@@ -45,27 +46,27 @@ if [[ -z "$CANON_VERSION" ]]; then
 fi
 info "기준 버전(dist/VERSION): $CANON_VERSION"
 
-# --- jq 유무에 따른 필드 추출 (기존 훅 관례 ②: jq 있으면 파싱, 없으면 grep 폴백) --
+# --- Field extraction, jq-aware (hook convention (2): parse with jq, else grep fallback) --
 extract_version() {
   local file="$1"
   if command -v jq >/dev/null 2>&1; then
     jq -r '.version // empty' "$file" 2>/dev/null
   else
-    # 보수적 grep 폴백: "version": "x.y.z" 패턴만 인식
+    # Conservative grep fallback: recognizes only the "version": "x.y.z" pattern
     grep -oE '"version"[[:space:]]*:[[:space:]]*"[^"]+"' "$file" | head -1 | sed -E 's/.*"([^"]+)"$/\1/'
   fi
 }
 
-# --- 검사 대상 수집 ----------------------------------------------------------
-# 주의: mapfile/readarray는 bash4+ 전용 — 기존 훅과 동일하게 bash 3.2(macOS 기본)
-# 호환을 위해 while-read + process substitution 패턴을 쓴다.
+# --- Collect targets ---------------------------------------------------------
+# Note: mapfile/readarray are bash 4+ only — like the existing hooks, this uses the
+# while-read + process-substitution pattern to stay compatible with bash 3.2 (macOS default).
 TARGETS=()
 while IFS= read -r -d '' f; do
   TARGETS+=("$f")
 done < <(find "$DIST_DIR" -type f \( -name 'plugin.json' -o -name 'manifest.json' \) -print0 2>/dev/null)
 
 if [[ "${#TARGETS[@]}" -eq 0 ]]; then
-  # B3 CONCERNS 명시 처리: 검사 대상 0건 = 통과 + 안내(실패로 오인 금지)
+  # B3 CONCERNS, handled explicitly: zero targets = pass + notice (must not read as a failure)
   ok "검사 대상 0건 (dist/**/{plugin,manifest}.json 없음) — 통과. 다음 행동: 매니페스트 추가 시 자동으로 검사됩니다."
   exit 0
 fi
@@ -74,11 +75,11 @@ CHECKED=0
 for f in "${TARGETS[@]}"; do
   rel="${f#"$BATHOS_ROOT"/}"
 
-  # 폐지(deprecated) 매니페스트는 버전 핀 검사에서 제외한다 — #35 에서
-  # dist/tests/test-manifests.sh 에 넣은 것과 같은 관례. 스스로
-  # `"deprecated": true` 를 선언하고 후속 정본을 가리키며 삭제 계획(`_removal`)까지
-  # 적어 둔 스켈레톤에 버전 핀을 요구하면 오탐이 된다.
-  # 암묵 제외 금지 — 건너뛴 사실을 로그로 남긴다(조용히 통과시키지 않음).
+  # Deprecated manifests are excluded from the version-pin check — the same convention added
+  # to dist/tests/test-manifests.sh in #35. Demanding a version pin from a skeleton that
+  # declares `"deprecated": true`, points at its replacement, and even records a removal
+  # plan (`_removal`) produces a false positive.
+  # No implicit exclusions — the skip is logged (never a silent pass).
   if command -v jq >/dev/null 2>&1 && [[ "$(jq -r '.deprecated // false' "$f" 2>/dev/null)" == "true" ]]; then
     info "$rel — deprecated=true → 버전 핀 검사 제외(정본으로 대체된 스켈레톤). 파일 삭제는 해당 매니페스트의 _removal 계획을 따른다"
     continue
@@ -95,7 +96,7 @@ for f in "${TARGETS[@]}"; do
   fi
 done
 
-# --- git 태그 정합(태그가 있을 때만, 없으면 스킵 — fail-open) -------------------
+# --- git tag consistency (only when a tag exists; otherwise skipped — fail-open) ----------
 if command -v git >/dev/null 2>&1 && git -C "$BATHOS_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
   LATEST_TAG="$(git -C "$BATHOS_ROOT" tag --points-at HEAD 2>/dev/null | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)"
   if [[ -n "$LATEST_TAG" ]]; then

--- a/scripts/glm-smoke-test.sh
+++ b/scripts/glm-smoke-test.sh
@@ -1,32 +1,33 @@
 #!/usr/bin/env bash
 # =============================================================================
 # BATHOS P4 — scripts/glm-smoke-test.sh
-# GLM(Z.ai) 실연결 스모크 테스트: Claude Code를 띄우지 않고 curl로 직접
-# Z.ai의 Anthropic 호환 엔드포인트(`POST /v1/messages`)를 두드려 연결·인증·
-# 응답 형태를 검증하는 읽기성(read-only) 테스트다.
+# GLM (Z.ai) live-connection smoke test: without starting Claude Code, curl hits Z.ai's
+# Anthropic-compatible endpoint (`POST /v1/messages`) directly to verify connectivity,
+# authentication and response shape. A read-only test.
 #
-# 설계 원본: .agent-team/04-architecture/w2-runtime-p4-design-kr.md §A (James, 2026-07-16)
-# 상태 변경 없음(라이브 모드는 소량 토큰을 소비함 — max_tokens<=64, 0은 아님).
+# Design source: .agent-team/04-architecture/w2-runtime-p4-design-kr.md §A (James, 2026-07-16)
+# Changes no state (live mode does spend a few tokens — max_tokens<=64, not 0).
 #
-# 사용법:
-#   scripts/glm-smoke-test.sh --dry-run                 # 키 불요, 요청 구성만 출력
-#   Z_AI_API_KEY=<키> scripts/glm-smoke-test.sh          # 라이브 텍스트 검증
-#   Z_AI_API_KEY=<키> scripts/glm-smoke-test.sh --tool-use
+# Usage:
+#   scripts/glm-smoke-test.sh --dry-run                 # no key needed, prints the request only
+#   Z_AI_API_KEY=<key> scripts/glm-smoke-test.sh         # live text verification
+#   Z_AI_API_KEY=<key> scripts/glm-smoke-test.sh --tool-use
 #
-# 종료 코드 규약(설계 §A4 — 서로 겹치지 않게 유지, CI 원인 분기용):
-#   0 = 통과(dry-run 포함)      1 = HTTP 200이나 응답 검증 실패
-#   2 = HTTP 비-200             3 = 키 없음(라이브 모드)
-#   4 = 네트워크/전송 오류       5 = curl 미설치
+# Exit-code contract (design §A4 — kept mutually exclusive so CI can branch on the cause):
+#   0 = pass (including dry-run)   1 = HTTP 200 but response verification failed
+#   2 = non-200 HTTP               3 = no key (live mode)
+#   4 = network/transport error    5 = curl not installed
 # =============================================================================
 set -uo pipefail
-# `set -e`는 쓰지 않는다 — curl 비-0 종료(exit 4 분기)를 우리가 직접 처리해야
-# 하고, set -e 하에서는 `HTTP="$(curl ...)"` 같은 명령 치환의 실패가 스크립트를
-# 조기 종료시켜 원인별 메시지를 낼 기회를 잃는다(기존 훅과 동일한 이유).
+# `set -e` is deliberately not used — we must handle curl's non-zero exit ourselves (the exit-4
+# branch), and under `set -e` a failing command substitution such as `HTTP="$(curl ...)"` would
+# end the script early and cost us the chance to report a cause-specific message (the same
+# reason as in the existing hooks).
 
 PROG="glm-smoke-test.sh"
 
 # --------------------------------------------------------------------------
-# 0. 옵션 기본값 + 인자 파싱
+# 0. Option defaults + argument parsing
 # --------------------------------------------------------------------------
 OPT_DRY_RUN=0
 OPT_TOOL_USE=0
@@ -74,7 +75,7 @@ while [ $# -gt 0 ]; do
 done
 
 # --------------------------------------------------------------------------
-# 1. curl 존재 확인 (exit 5)
+# 1. Check that curl exists (exit 5)
 # --------------------------------------------------------------------------
 if ! command -v curl >/dev/null 2>&1; then
   printf '[%s] curl이 설치되어 있지 않습니다. RESULT: FAIL (curl 미설치)\n' "$PROG" >&2
@@ -82,19 +83,19 @@ if ! command -v curl >/dev/null 2>&1; then
 fi
 
 # --------------------------------------------------------------------------
-# 2. 설정 해석 (옵션 > 환경 > 기본값)
+# 2. Resolve configuration (flag > environment > default)
 # --------------------------------------------------------------------------
 BASE_URL="${OPT_BASE_URL:-${ANTHROPIC_BASE_URL:-https://api.z.ai/api/anthropic}}"
 # ponytail: hardcoded latest model id goes stale each time Z.ai ships a new one, override with
 # GLM_SMOKE_MODEL or --model; revisit when a docs.z.ai check shows a newer flagship than glm-5.3
 MODEL="${OPT_MODEL:-${GLM_SMOKE_MODEL:-glm-5.3}}"
 TIMEOUT="${OPT_TIMEOUT:-60}"
-# 정규화: trailing slash 제거 후 /v1/messages를 붙인다(E-A1 — "//v1/messages" 방지).
+# Normalization: strip a trailing slash before appending /v1/messages (E-A1 — avoids "//v1/messages").
 URL="${BASE_URL%/}/v1/messages"
 
-# 모델 값 검증(A-10): 인젝션 표면을 없애기 위해 안전 문자만 허용.
-# printf 조립 시 유일한 변수 삽입 지점이 이 값이므로, 여기를 통과하면 본문
-# 조립은 안전하다고 간주할 수 있다(그 외 필드는 고정 리터럴).
+# Model-value validation (A-10): only safe characters are allowed, to remove the injection
+# surface. This value is the single variable interpolated during printf assembly, so once it
+# passes here the body assembly can be considered safe (every other field is a fixed literal).
 if ! printf '%s' "$MODEL" | grep -Eq '^[A-Za-z0-9._-]+$'; then
   printf '[%s] 모델 ID에 허용되지 않은 문자가 포함되어 있습니다: %s\n' "$PROG" "$MODEL" >&2
   printf '[%s] 허용 문자: A-Z a-z 0-9 . _ -\n' "$PROG" >&2
@@ -102,10 +103,10 @@ if ! printf '%s' "$MODEL" | grep -Eq '^[A-Za-z0-9._-]+$'; then
   exit 1
 fi
 
-# 키 우선순위: ANTHROPIC_AUTH_TOKEN(Claude Code가 실제 export하는 변수) > Z_AI_API_KEY.
+# Key precedence: ANTHROPIC_AUTH_TOKEN (the variable Claude Code actually exports) > Z_AI_API_KEY.
 KEY="${ANTHROPIC_AUTH_TOKEN:-${Z_AI_API_KEY:-}}"
 
-# 키 마스킹 헬퍼(로그에 실키가 절대 노출되지 않도록 --verbose에서도 사용).
+# Key-masking helper (used even under --verbose so a real key is never exposed in logs).
 _mask_key() {
   local k="$1"
   if [ -z "$k" ]; then
@@ -116,7 +117,7 @@ _mask_key() {
 }
 
 # --------------------------------------------------------------------------
-# 3. 요청 본문 조립 (printf, heredoc 미사용 — 변수 삽입 지점은 MODEL 하나뿐)
+# 3. Assemble the request body (printf, no heredoc — MODEL is the only interpolation point)
 # --------------------------------------------------------------------------
 build_text_request() {
   printf '{"model":"%s","max_tokens":64,"messages":[{"role":"user","content":"Reply with exactly this token and nothing else: BATHOS-GLM-OK"}]}' "$1"
@@ -129,7 +130,7 @@ build_tool_request() {
 REQ_JSON="$(build_text_request "$MODEL")"
 
 # --------------------------------------------------------------------------
-# 4. --dry-run: 키 없이도 동작. 구성 결과만 출력하고 exit 0.
+# 4. --dry-run: works without a key. Prints the composed request and exits 0.
 # --------------------------------------------------------------------------
 if [ "$OPT_DRY_RUN" = "1" ]; then
   printf '[%s] --- dry-run: 요청 구성만 출력합니다(전송하지 않음) ---\n' "$PROG"
@@ -147,7 +148,7 @@ if [ "$OPT_DRY_RUN" = "1" ]; then
 fi
 
 # --------------------------------------------------------------------------
-# 5. 라이브 모드: 키 확인 (exit 3)
+# 5. Live mode: require a key (exit 3)
 # --------------------------------------------------------------------------
 if [ -z "$KEY" ]; then
   printf '[%s] ANTHROPIC_AUTH_TOKEN 또는 Z_AI_API_KEY 필요.\n' "$PROG" >&2
@@ -158,7 +159,7 @@ if [ -z "$KEY" ]; then
 fi
 
 # --------------------------------------------------------------------------
-# 6. 임시 파일 + 정리 트랩 (§A7)
+# 6. Temp files + cleanup trap (§A7)
 # --------------------------------------------------------------------------
 BODY_FILE="$(mktemp)"
 ERR_FILE="$(mktemp)"
@@ -167,10 +168,10 @@ ERR_FILE2="$(mktemp)"
 trap 'rm -f "$BODY_FILE" "$ERR_FILE" "$BODY_FILE2" "$ERR_FILE2"' EXIT INT TERM
 
 # --------------------------------------------------------------------------
-# 7. curl 실행 헬퍼 — auth_style: bearer | x-api-key
+# 7. curl execution helper — auth_style: bearer | x-api-key
 # --------------------------------------------------------------------------
-# $1=auth_style  $2=요청 본문 JSON  $3=본문 저장 파일  $4=stderr 저장 파일
-# stdout으로 "HTTP_CODE CURL_EXIT"를 출력(공백 구분, 두 값 모두 항상 존재).
+# $1=auth_style  $2=request body JSON  $3=body output file  $4=stderr output file
+# Prints "HTTP_CODE CURL_EXIT" on stdout (space-separated; both values are always present).
 do_request() {
   local auth_style="$1" body="$2" body_file="$3" err_file="$4"
   local auth_header http_code curl_exit
@@ -190,7 +191,7 @@ do_request() {
   printf '%s %s' "${http_code:-}" "$curl_exit"
 }
 
-# curl exit code -> 사람이 읽는 원인 메시지 (§A4 exit 4 분기)
+# curl exit code -> human-readable cause (the §A4 exit-4 branch)
 _curl_exit_reason() {
   case "$1" in
     6) echo "DNS 해석 실패(오프라인?)" ;;
@@ -202,7 +203,7 @@ _curl_exit_reason() {
 }
 
 # --------------------------------------------------------------------------
-# 8. 2단 인증 전략 (ADR-P4-3): Bearer 1차 -> 401/403 시 x-api-key 1회 재시도
+# 8. Two-step auth strategy (ADR-P4-3): Bearer first -> on 401/403, retry once with x-api-key
 # --------------------------------------------------------------------------
 if [ "$OPT_VERBOSE" = "1" ]; then
   printf '[%s] 요청 URL: %s\n' "$PROG" "$URL" >&2
@@ -239,14 +240,14 @@ if [ "$HTTP_CODE" = "401" ] || [ "$HTTP_CODE" = "403" ]; then
     BODY_FILE="$BODY_FILE2"
     AUTH_USED="x-api-key"
   else
-    # 재시도도 실패 — 최종 상태코드/본문은 재시도(x-api-key) 응답 기준으로 보고.
+    # The retry failed too — report the final status code/body from the x-api-key response.
     HTTP_CODE="$HTTP_CODE2"
     BODY_FILE="$BODY_FILE2"
   fi
 fi
 
 # --------------------------------------------------------------------------
-# 9. HTTP 상태코드 판정 (문자열 비교 — 산술 강제 금지, §A5 지시)
+# 9. HTTP status-code decision (string comparison — never coerce to arithmetic, per §A5)
 # --------------------------------------------------------------------------
 if [ "$HTTP_CODE" != "200" ]; then
   BODY_EXCERPT="$(head -c 300 "$BODY_FILE" 2>/dev/null || true)"
@@ -277,30 +278,30 @@ if [ "$HTTP_CODE" != "200" ]; then
 fi
 
 # --------------------------------------------------------------------------
-# 10. 응답 검증 V2~V5 (jq 없이 grep/sed — §A3)
+# 10. Response verification V2-V5 (grep/sed, no jq — §A3)
 # --------------------------------------------------------------------------
 RESP_BODY="$(cat "$BODY_FILE" 2>/dev/null || true)"
 RESP_FLAT="$(printf '%s' "$RESP_BODY" | tr '\n\r' '  ')"
 
 _die_v() {
-  # $1=검증 실패 사유
+  # $1=reason the verification failed
   printf '[%s] 응답 검증 실패: %s\n' "$PROG" "$1" >&2
   printf '[%s] 응답 본문(앞 300자): %s\n' "$PROG" "$(printf '%s' "$RESP_BODY" | head -c 300)" >&2
   printf 'RESULT: FAIL (%s)\n' "$1"
   exit 1
 }
 
-# E-A3: 강제 스트리밍 감지 — SSE 'event:' 라인이 보이면 비지원으로 처리.
+# E-A3: detect forced streaming — an SSE 'event:' line means unsupported, so bail out.
 if printf '%s' "$RESP_FLAT" | grep -Eq '^event:|"event:"'; then
   _die_v "스트리밍 응답 감지 — 비지원(단일 JSON 응답 가정)"
 fi
 
-# V2: 에러 본문 아님
+# V2: not an error body
 if printf '%s' "$RESP_FLAT" | grep -Eq '"type"[[:space:]]*:[[:space:]]*"error"'; then
   _die_v "V2 실패 — 응답이 에러 본문(\"type\":\"error\")"
 fi
 
-# V3: content 존재 + text 블록 존재
+# V3: content present + a text block present
 if ! printf '%s' "$RESP_FLAT" | grep -Eq '"content"'; then
   _die_v "V3 실패 — content 키 없음"
 fi
@@ -308,14 +309,15 @@ if ! printf '%s' "$RESP_FLAT" | grep -Eq '"type"[[:space:]]*:[[:space:]]*"text"'
   _die_v "V3 실패 — text 타입 블록 없음"
 fi
 
-# V4: 텍스트 비어있지 않음 (표시용 best-effort 추출 — E-A4: 이스케이프 포함 시 잘릴 수 있음, 판정은 "존재 여부"만)
+# V4: the text is non-empty (best-effort extraction for display — E-A4: it can be truncated when
+# escapes are present, so the decision rests on presence alone)
 TEXT_MATCH="$(printf '%s' "$RESP_FLAT" | grep -o '"text":"[^"]*"' | head -1)"
 if [ -z "$TEXT_MATCH" ]; then
   _die_v "V4 실패 — 비어있지 않은 text 값 없음"
 fi
 TEXT_VALUE="$(printf '%s' "$TEXT_MATCH" | sed 's/^"text":"\(.*\)"$/\1/')"
 
-# V5: 모델 echo (경고만, 비차단)
+# V5: model echo (warning only, non-blocking)
 RESP_MODEL="$(printf '%s' "$RESP_FLAT" | grep -o '"model"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*:[[:space:]]*"\([^"]*\)"$/\1/')"
 if [ -n "$RESP_MODEL" ] && [ "$RESP_MODEL" != "$MODEL" ]; then
   printf '[%s] 참고(V5, 비차단): 요청 모델 "%s" != 응답 모델 "%s" — Z.ai 내부 재매핑일 수 있음\n' "$PROG" "$MODEL" "$RESP_MODEL" >&2
@@ -323,7 +325,8 @@ fi
 
 printf '[%s] V1~V4 통과: HTTP 200, 정상 응답 본문, text 블록 존재.\n' "$PROG"
 printf '[%s] 응답 텍스트(표시용, 이스케이프 포함 시 잘릴 수 있음): %s\n' "$PROG" "$TEXT_VALUE"
-# 날조 금지 원칙: "연결 성공"과 "지시 이행"은 별개다 — 참고 출력만, 판정에 미사용.
+# No-fabrication rule: "the connection worked" and "the instruction was followed" are separate
+# things — printed for information only, never used in the verdict.
 if printf '%s' "$TEXT_VALUE" | grep -q 'BATHOS-GLM-OK'; then
   printf '[%s] 참고: 모델이 지시된 토큰(BATHOS-GLM-OK)을 포함해 응답함(참고용, 판정 기준 아님)\n' "$PROG"
 else
@@ -334,7 +337,7 @@ if [ "$AUTH_USED" = "x-api-key" ]; then
 fi
 
 # --------------------------------------------------------------------------
-# 11. --tool-use: 2차 요청(같은 auth_style 재사용) -> V6, V7
+# 11. --tool-use: a second request (reusing the same auth_style) -> V6, V7
 # --------------------------------------------------------------------------
 if [ "$OPT_TOOL_USE" = "1" ]; then
   TOOL_REQ_JSON="$(build_tool_request "$MODEL")"
@@ -363,7 +366,7 @@ if [ "$OPT_TOOL_USE" = "1" ]; then
   fi
 
   TOOL_RESP_FLAT="$(cat "$BODY_FILE3" 2>/dev/null | tr '\n\r' '  ' || true)"
-  # V6: tool_use 블록 + echo_token 이름 존재
+  # V6: a tool_use block plus the echo_token name are present
   if printf '%s' "$TOOL_RESP_FLAT" | grep -Eq '"type"[[:space:]]*:[[:space:]]*"tool_use"' \
      && printf '%s' "$TOOL_RESP_FLAT" | grep -Eq '"name"[[:space:]]*:[[:space:]]*"echo_token"'; then
     printf '[%s] V6 통과 — tool_use 블록(echo_token) 존재\n' "$PROG"
@@ -372,7 +375,7 @@ if [ "$OPT_TOOL_USE" = "1" ]; then
     printf 'RESULT: FAIL (V6 — tool_use 블록 없음)\n'
     exit 1
   fi
-  # V7: stop_reason 참고(경고만, 비차단 — 호환 레이어별 편차 가능 ⚠️[추정])
+  # V7: stop_reason for reference (warning only, non-blocking — may vary by compatibility layer ⚠️[assumed])
   if printf '%s' "$TOOL_RESP_FLAT" | grep -Eq '"stop_reason"[[:space:]]*:[[:space:]]*"tool_use"'; then
     printf '[%s] V7 참고 — stop_reason=tool_use\n' "$PROG"
   else
@@ -381,7 +384,7 @@ if [ "$OPT_TOOL_USE" = "1" ]; then
 fi
 
 # --------------------------------------------------------------------------
-# 12. 최종 결과
+# 12. Final result
 # --------------------------------------------------------------------------
 printf 'RESULT: PASS — GLM 백엔드 실연결 확인 (model: %s -> %s)\n' "$MODEL" "${RESP_MODEL:-$MODEL}"
 exit 0


### PR DESCRIPTION
## 무엇을·왜

명문화된 규칙 **"모든 코드 주석은 영어로 작성한다"**(각 구현자 역할 base의 "코드 주석 표준" + `ponytail-inject-kr.md` §언어)를 **오늘 커밋된 코드가 위반**한 것을 정정한다. 규칙은 오늘 신설된 것이 아니라 기존 규칙이며, PR #28·#30·#34·#36의 구현이 이를 지키지 못했다.

## 범위 — 오늘 만진 코드 파일 10개, 주석 207줄

| 대상 | 한글 주석 |
|---|---|
| Rust 구현 주석(`//`) | 4 |
| Rust 비노출 rustdoc(`///`, clap 밖) | 16 |
| 셸 5개(`#`) | 205 (+ 행끝 인라인 2) |
| `drift-guard.yml` | 11 |
| `.gitignore` | 2 |

## 보존한 것 — 주석이 아니라 "동작·출력"

한글이라도 **프로그램 출력**인 것은 그대로 두었다. 이건 주석 정리가 아니라 제품 UX 변경이기 때문이다.

- **`main.rs` clap `///` 151줄** = `bathos --help` 실제 출력(릴리스 바이너리로 실측 확인). `signoff.md` 후속액션 #4의 *"clap 도움말 영어화 = 미결정, 사용자 결정 대기"* 상태를 유지한다.
- 셸 `printf`/`info`/`error` 메시지, **히어독 본문 19줄**(생성되는 `plugin.json` 내용·`--help` 텍스트)
- **YAML `name:` 값 11개** = GitHub Actions UI 표시명
- **JSON `_comment`/`reason`** = 실행 시 CI 로그로 출력되는 데이터

한글 설계문서 인용구는 `§` 앵커를 남기고 인용 내용만 영어로 옮겨 추적성을 보존했다.

## 검증 (전부 실측)

- **diff 전수 기계 검증** — 추가·삭제 줄이 전부 주석임을 확인, **코드 줄 변경 0건**
- `cargo fmt --check` / `build` / `test` / `clippy --all-targets -D warnings` 전부 통과
- **drift-guard 8종 검사 전부 exit 0**, YAML 파서로 **job 3개·step 14개** 확인(#32 재발 방지 — 눈으로 안 보고 파서로 셌다)
- `check-codex-drift` 0건 · 훅 테스트 3종 통과 · `build-codex-plugin.sh` 멱등(재실행 후 추가 diff 0)

## 안전 절차

`.github/workflows/`는 freeze-guard 위험 경로 → `fingerprint approve --actor Paul --scope ci` **3건 정식 승인 후** 편집(Bash 우회 없음).

## 후속 과제

`scripts/`·`dist/tests` **형제 셸 11개(한글 주석 245줄)** 는 이번 범위 밖이다. 규칙을 저장소 전체로 확장할지는 별도 결정 필요 — 공개 저장소이고 외부 기여자가 있으므로 확장에 근거는 있다.
