### PR TITLE
fix(hooks): careful-guard 의 git 플래그 검사를 대소문자 구분으로 분리 (#39)

### DIFF
--- a/.claude/hooks/_test-hooks.sh
+++ b/.claude/hooks/_test-hooks.sh
@@ -133,6 +133,40 @@ JSON='{"tool_name":"Bash","tool_input":{"command":"psql -c \"TRUNCATE TABLE sess
 EC=$(run_hook "careful-guard.sh" "$JSON")
 assert_exit "[L-4] TRUNCATE TABLE sessions → 차단" 2 "$EC"
 
+# --- #39 케이스: git 플래그는 대소문자를 구분한다 (DANGER_PATTERNS_CS) ---
+# 종전에는 grep -Ei 가 배열 전체에 걸려 -b/-d 같은 안전 플래그까지 차단했다.
+
+# 1-16. git checkout -b (새 브랜치 생성) → 통과(exit 0)
+JSON='{"tool_name":"Bash","tool_input":{"command":"git checkout -b feature/login"}}'
+EC=$(run_hook "careful-guard.sh" "$JSON")
+assert_exit "[#39] git checkout -b (새 브랜치) → 통과" 0 "$EC"
+
+# 1-17. git checkout -B (기존 브랜치 강제 덮어쓰기) → 차단(exit 2)
+JSON='{"tool_name":"Bash","tool_input":{"command":"git checkout -B feature/login"}}'
+EC=$(run_hook "careful-guard.sh" "$JSON")
+assert_exit "[#39] git checkout -B (강제 덮어쓰기) → 차단" 2 "$EC"
+
+# 1-18. git branch -d (머지된 브랜치만 안전 삭제) → 통과(exit 0)
+JSON='{"tool_name":"Bash","tool_input":{"command":"git branch -d feature/login"}}'
+EC=$(run_hook "careful-guard.sh" "$JSON")
+assert_exit "[#39] git branch -d (안전 삭제) → 통과" 0 "$EC"
+
+# 1-19. git branch -D (강제 삭제) → 차단(exit 2)
+JSON='{"tool_name":"Bash","tool_input":{"command":"git branch -D feature/login"}}'
+EC=$(run_hook "careful-guard.sh" "$JSON")
+assert_exit "[#39] git branch -D (강제 삭제) → 차단" 2 "$EC"
+
+# 1-20. git clean -f → 여전히 차단(exit 2) [CS 배열 이전 후 회귀 확인]
+JSON='{"tool_name":"Bash","tool_input":{"command":"git clean -f"}}'
+EC=$(run_hook "careful-guard.sh" "$JSON")
+assert_exit "[#39] git clean -f → 차단(CS 이전 회귀)" 2 "$EC"
+
+# 1-21. 소문자 SQL → 여전히 차단(exit 2)
+#   CS 분리의 핵심 제약: -i 를 전역으로 빼면 이 케이스를 놓친다. SQL 은 -i 를 유지해야 한다.
+JSON='{"tool_name":"Bash","tool_input":{"command":"psql -c \"drop table users\""}}'
+EC=$(run_hook "careful-guard.sh" "$JSON")
+assert_exit "[#39] 소문자 drop table → 차단(-i 유지 확인)" 2 "$EC"
+
 # --------------------------------------------------------------------------
 # 2. freeze-guard.sh 테스트
 # --------------------------------------------------------------------------

--- a/.claude/hooks/careful-guard.sh
+++ b/.claude/hooks/careful-guard.sh
@@ -56,7 +56,10 @@ fi
 # --------------------------------------------------------------------------
 # 3. 위험 패턴 목록
 # --------------------------------------------------------------------------
-# 각 원소: ERE(Extended Regular Expression), grep -Eiq 로 검사
+# 각 원소: ERE(Extended Regular Expression), grep -Eiq 로 검사 — **대소문자 무시**.
+# ⚠️ 대소문자가 의미를 갖는 패턴은 이 배열이 아니라 아래 DANGER_PATTERNS_CS 에 둔다.
+#    (예: `git branch -D`는 강제 삭제지만 `-d`는 머지된 브랜치만 지우는 안전 삭제다.
+#     여기에 두면 -i 탓에 안전한 쪽까지 차단된다 — #39)
 DANGER_PATTERNS=(
   # --- 파일시스템 파괴 ---
   'rm[[:space:]]+-[[:alpha:]]*r[[:alpha:]]*f([[:space:]]|$)'  # rm -rf, rm -fr, rm -Rf 등
@@ -77,14 +80,8 @@ DANGER_PATTERNS=(
   'TRUNCATE[[:space:]]+TABLE'                                  # TRUNCATE (전체 삭제, 롤백 불가)
   # DELETE without WHERE는 ERE 단일 패턴으로 정확히 표현 불가 → 섹션 4b에서 2단계 검사
 
-  # --- git 파괴적 명령 ---
-  'git[[:space:]]+push[[:space:]].*--force'                   # git push --force
-  'git[[:space:]]+push[[:space:]].*-f([[:space:]]|$)'         # git push -f
-  'git[[:space:]]+push[[:space:]].*-f[[:space:]]'             # git push -f <remote>
-  'git[[:space:]]+reset[[:space:]]+--hard'                    # git reset --hard
-  'git[[:space:]]+checkout[[:space:]]+-[Bf]'                  # git checkout -B/-f
-  'git[[:space:]]+clean[[:space:]]+-f'                        # git clean -f (미추적 파일 삭제)
-  'git[[:space:]]+branch[[:space:]]+-D'                       # git branch -D (강제 삭제)
+  # --- git 파괴적 명령 → DANGER_PATTERNS_CS 로 이전(#39) ---
+  #   git 플래그는 대소문자가 곧 의미라 -i 검사에 둘 수 없다.
 
   # --- 권한/소유권 위험 ---
   'chmod[[:space:]]+-R[[:space:]]+777'                         # chmod -R 777
@@ -114,6 +111,26 @@ DANGER_PATTERNS=(
 )
 
 # --------------------------------------------------------------------------
+# 3b. 대소문자 구분 패턴 (#39)
+# --------------------------------------------------------------------------
+# 위 DANGER_PATTERNS 는 SQL(`drop table`)을 잡으려고 -i 로 검사한다. 그런데 그 -i 가
+# 배열 전체에 걸려, 대소문자로 위험도가 갈리는 git 플래그까지 싸잡아 차단했다:
+#   git checkout -b (새 브랜치 생성)      ← -B(강제 덮어쓰기)로 오인
+#   git branch  -d (머지된 것만 안전 삭제) ← -D(강제 삭제)로 오인
+# `-d` 는 등가 대체가 없어, 안전 삭제를 하려면 더 위험한 `-D` 를 쓰라고 안내하게 된다 —
+# 가드 의도와 정반대다. 그래서 이 배열만 grep -Eq(대소문자 구분)로 따로 검사한다.
+#   판단 기준: 플래그의 대소문자가 위험도를 가르면 여기, 아니면 위.
+DANGER_PATTERNS_CS=(
+  'git[[:space:]]+push[[:space:]].*--force'                   # git push --force
+  'git[[:space:]]+push[[:space:]].*-f([[:space:]]|$)'         # git push -f
+  'git[[:space:]]+push[[:space:]].*-f[[:space:]]'             # git push -f <remote>
+  'git[[:space:]]+reset[[:space:]]+--hard'                    # git reset --hard
+  'git[[:space:]]+checkout[[:space:]]+-[Bf]'                  # git checkout -B/-f (-b 는 통과)
+  'git[[:space:]]+clean[[:space:]]+-f'                        # git clean -f (미추적 파일 삭제)
+  'git[[:space:]]+branch[[:space:]]+-D'                       # git branch -D (-d 는 통과)
+)
+
+# --------------------------------------------------------------------------
 # 4. 패턴 검사
 # --------------------------------------------------------------------------
 DETECTED_PATTERN=""
@@ -123,6 +140,16 @@ for PATTERN in "${DANGER_PATTERNS[@]}"; do
     break
   fi
 done
+
+# 4a. 대소문자 구분 검사 (#39) — -i 없음
+if [[ -z "$DETECTED_PATTERN" ]]; then
+  for PATTERN in "${DANGER_PATTERNS_CS[@]}"; do
+    if printf '%s' "$CMD" | grep -Eq "$PATTERN"; then
+      DETECTED_PATTERN="$PATTERN"
+      break
+    fi
+  done
+fi
 
 # --------------------------------------------------------------------------
 # 4b. WHERE 없는 DELETE 2단계 검사 (L-4 보강, 2026-06-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`careful-guard.sh` 가 안전한 git 플래그까지 차단하던 문제** (#39). 위험 패턴 검사가
+  `grep -Eiq` 로 배열 **전체**를 대소문자 무시로 검사하고 있었다. SQL(`drop table`)을 잡으려면
+  `-i` 가 필요하지만, git 플래그는 대소문자가 곧 위험도라 같은 검사에 둘 수 없었다.
+  그 결과 `git checkout -b`(새 브랜치 생성)가 `-B`(강제 덮어쓰기)로, `git branch -d`
+  (머지된 것만 지우는 안전 삭제)가 `-D`(강제 삭제)로 오인돼 차단됐다. `-d` 는 등가 대체가
+  없어 **안전 삭제를 하려면 더 위험한 `-D` 를 쓰라고 안내하게 되는** 역전이 생겼다.
+  - git 플래그 7개를 `DANGER_PATTERNS_CS` 로 분리해 `grep -Eq`(대소문자 구분)로 따로
+    검사한다. SQL·경로 우회 패턴은 `-i` 검사를 그대로 유지한다.
+  - 판단 기준을 주석에 명문화했다 — **플래그의 대소문자가 위험도를 가르면 CS 배열**.
+  - 훅 하네스에 회귀 케이스 6건 추가(`-b`/`-d` 통과 · `-B`/`-D`/`clean -f` 차단 ·
+    소문자 `drop table` 차단으로 `-i` 유지 확인).
+
 ## [0.4.0] — 2026-09-10
 
 Everything accumulated since 0.1.0 is released under this version. The 0.2.0 and


### PR DESCRIPTION
Fixes #39

## 문제

`careful-guard.sh:121` 이 `grep -Eiq` 로 `DANGER_PATTERNS` 배열 **전체**를 대소문자 무시로 검사한다. SQL(`drop table`)을 잡으려면 `-i` 가 필요하지만, git 플래그는 **대소문자가 곧 위험도**라 같은 검사에 둘 수 없다. 그래서 막으려던 대상이 아닌 쪽까지 차단됐다.

| 명령 | 실제 의미 | 오인된 대상 |
|:--|:--|:--|
| `git checkout -b` | 새 브랜치 생성 | `-B` (기존 브랜치 강제 덮어쓰기) |
| `git branch -d` | 머지된 브랜치만 지우는 안전 삭제 | `-D` (강제 삭제) |

`-b` 는 `git switch -c` 로 우회할 수 있지만 `-d` 에는 등가 대체가 없다. 결국 **안전 삭제를 하려면 더 위험한 `-D` 를 쓰라고 안내하게 되는** 역전이 생긴다 — 가드 의도와 정반대다. 실제 세션에서 그렇게 됐다(#39 에 로그 있음).

## `-i` 를 그냥 뺄 수는 없다

전역 제거는 소문자 SQL 을 놓친다. 실측:

```
── git 플래그: 대소문자가 의미를 가진다 ──
  git branch -d feature      현재(-Ei) 차단   -i제거(-E) 통과   <<< 오탐
  git branch -D feature      현재(-Ei) 차단   -i제거(-E) 차단
  git checkout -b feature    현재(-Ei) 차단   -i제거(-E) 통과   <<< 오탐
  git checkout -B feature    현재(-Ei) 차단   -i제거(-E) 차단

── SQL: 대소문자 무시가 반드시 필요하다 ──
  DROP TABLE users           현재(-Ei) 차단   -i제거(-E) 차단
  drop table users           현재(-Ei) 차단   -i제거(-E) 통과   <<< -i 필요
```

검사를 **둘로 가르는 것**이 유일한 해법이다.

## 변경

- git 플래그 7개를 `DANGER_PATTERNS_CS` 로 분리하고 섹션 4a 에서 `grep -Eq`(대소문자 구분)로 따로 검사한다. SQL·경로 우회 패턴은 `-i` 검사를 그대로 둔다.
- 두 배열 주석에 **판단 기준을 명문화**했다 — 플래그의 대소문자가 위험도를 가르면 CS 배열, 아니면 기존 배열. 다음 사람이 같은 실수를 반복하지 않도록.
- 기존 검사를 먼저 돌리고 미탐지일 때만 CS 검사를 돌린다. 탐지 우선순위와 `DETECTED_PATTERN` 출력 형식은 그대로다.

**가드가 약해지지 않는다.** 차단하던 것 중 빠지는 것은 없고, `-b`/`-d` 두 안전 플래그만 통과로 바뀐다. `--force`·`--hard` 는 원래 소문자 고정이라 CS 로 옮겨도 탐지가 같고, 옮겨두면 `--FORCE` 같은 무의미한 변형에 반응하지 않는다.

## 테스트

훅 하네스에 회귀 6건 추가(1-16 ~ 1-21):

| 케이스 | 기대 |
|:--|:--|
| `git checkout -b feature/login` | 통과 |
| `git checkout -B feature/login` | 차단 |
| `git branch -d feature/login` | 통과 |
| `git branch -D feature/login` | 차단 |
| `git clean -f` | 차단 (CS 이전 후 회귀 확인) |
| `psql -c "drop table users"` | 차단 (**SQL 쪽 `-i` 생존 확인** — 이 케이스가 전역 `-i` 제거를 막는 근거다) |

```
테스트 결과: 85 PASS / 0 FAIL (총 85)
```

79 → 85. `bash -n` 문법 검사도 통과. **Rust 코드 변경 없음**이라 fmt/clippy/test 영향 없음.

## 체크리스트

- [x] 이슈 선등록 (#39)
- [x] 동작 변경에 대한 테스트 추가
- [x] `CHANGELOG.md` *Unreleased* 갱신
- [x] 주변 코드 스타일 준수 (한국어 주석 + 영어 식별자)
- [x] 안전 훅을 약화시키지 않음 — 차단 범위 유지, 오탐만 제거

## 남긴 것 (별건)

같은 `-i` 전역 적용 때문에 **명령이 아니라 문자열 리터럴**도 잡힌다. 이 PR 을 만드는 동안 세 번 겪었다 — 테스트 스크립트 안의 테스트 데이터, #39 이슈 본문, 그리고 이슈 제목. `git commit -m "drop table 정리"` 같은 평범한 커밋도 막힌다.

이건 "명령 문자열 전체를 grep" 하는 설계상 한계(careful-guard.sh 17~20행이 이미 완전성 미주장으로 인정)라 판단이 필요해 보여 이 PR 범위에 넣지 않았다. #39 에 별도로 적어 두었다.
