### PR TITLE
형제 셸 11개 코드 주석 영어화 — 1차 PR(#37/#38)의 잔여 범위 완결

### DIFF
--- a/dist/tests/test-check-rule-copies.sh
+++ b/dist/tests/test-check-rule-copies.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 # =============================================================================
 # BATHOS Dynamis — dist/tests/test-check-rule-copies.sh
-# Story B3 §5 픽스처 4종(자기검증) — --check-copies 모드의 세 분기(byte/invariant/
-# 제외 목록)를 전부 격리된 임시 디렉터리에서 검증한다. 실제
-# scripts/drift-exclusions.json·dist/copies-manifest.json은 건드리지 않는다
-# (BATHOS_ROOT·BATHOS_COPIES_MANIFEST·BATHOS_DRIFT_EXCLUSIONS 환경변수로 격리).
+# Story B3 §5 — four self-verifying fixtures covering all three branches of
+# --check-copies (byte / invariant / exclusions), each in an isolated temp dir.
+# The real scripts/drift-exclusions.json and dist/copies-manifest.json are never
+# touched: env vars BATHOS_ROOT, BATHOS_COPIES_MANIFEST, BATHOS_DRIFT_EXCLUSIONS isolate them.
 #
-#   ① 일부러 드리프트시킨 복제본(byte 모드) -> 실패
-#   ② 정합 상태(byte 모드) -> 통과
-#   ③ invariant 문구 누락 -> 실패
-#   ④ 제외 목록 항목의 드리프트 -> 통과(제외 동작 확인)
+#   (1) copy drifted on purpose (byte mode) -> must fail
+#   (2) copy in sync (byte mode)            -> must pass
+#   (3) invariant phrase missing            -> must fail
+#   (4) drift in an excluded path           -> must pass (exclusion works)
 # =============================================================================
 set -uo pipefail
 
@@ -35,7 +35,7 @@ setup_root() {
   printf '%s\n' "$root"
 }
 
-# --- ① byte 모드 드리프트 -> 실패 -------------------------------------------
+# --- (1) byte-mode drift -> fail --------------------------------------------
 root="$(setup_root)"
 echo "canonical content line one" > "$root/canon/rule.md"
 echo "DRIFTED content line one" > "$root/copy/rule.md"
@@ -50,7 +50,7 @@ else
 fi
 rm -rf "$root" /tmp/out1.$$
 
-# --- ② byte 모드 정합 -> 통과 -----------------------------------------------
+# --- (2) byte mode in sync -> pass ------------------------------------------
 root="$(setup_root)"
 echo "canonical content line one" > "$root/canon/rule.md"
 cp "$root/canon/rule.md" "$root/copy/rule.md"
@@ -65,7 +65,7 @@ else
 fi
 rm -rf "$root" /tmp/out2.$$
 
-# --- ③ invariant 문구 누락 -> 실패 ------------------------------------------
+# --- (3) invariant phrase missing -> fail -----------------------------------
 root="$(setup_root)"
 echo "some skill body without the required phrase" > "$root/copy/skill.md"
 cat > "$root/dist/copies-manifest.json" <<EOF
@@ -79,7 +79,7 @@ else
 fi
 rm -rf "$root" /tmp/out3.$$
 
-# --- ④ 제외 목록 항목의 드리프트 -> 통과(제외 동작) --------------------------
+# --- (4) drift in an excluded path -> pass (exclusion) -----------------------
 root="$(setup_root)"
 echo "canonical content line one" > "$root/canon/rule.md"
 echo "DRIFTED but excluded" > "$root/copy/rule-es.md"

--- a/dist/tests/test-host-detect.sh
+++ b/dist/tests/test-host-detect.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 # =============================================================================
 # BATHOS — dist/tests/test-host-detect.sh
-# Story B5 §5 스모크 테스트 → story-13(실키 구현) 갱신.
+# Story B5 §5 smoke test, updated for story-13 (the real-key implementation).
 #
-# 이 파일은 story-13의 명시 소유 목록 밖이지만(File Structure Requirements는
-# dist/lib/host-detect.sh만 지정), .github/workflows/drift-guard.yml이 이
-# 스크립트를 CI에서 직접 실행한다 — host-detect.sh의 판정 로직을 실키로
-# 갱신하면서 이 파일을 그대로 두면 CI가 깨진다(구 스텁 가정: 기본값=claude,
-# codex=미구현 exit 2). 소유자가 없는 결합 파일이라 함께 갱신했다(리드 보고
-# 사항 — .agent-team/08-impl-notes/phillip-w5-impl-notes.md 참고).
+# This file sits outside story-13's explicit ownership list (File Structure Requirements
+# names only dist/lib/host-detect.sh), yet .github/workflows/drift-guard.yml runs this
+# script directly in CI — updating host-detect.sh's detection logic to the real keys
+# while leaving this file untouched would break CI (the old stub assumed default=claude,
+# codex=unimplemented exit 2). Being a coupled file with no owner, it was updated along
+# with it (reported to the lead — see .agent-team/08-impl-notes/phillip-w5-impl-notes.md).
 # =============================================================================
 set -uo pipefail
 
@@ -27,53 +27,53 @@ assert_eq() {
   fi
 }
 
-# 매 테스트가 이전 테스트의 env 잔재에 영향받지 않도록 판별 관련 키를 전부 비운다.
+# Clear every detection-related key so no test is affected by env residue from a previous one.
 _clear_detect_env() {
   unset PLUGIN_ROOT PLUGIN_DATA COPILOT_PLUGIN_DATA CLAUDE_PROJECT_DIR \
         CLAUDE_PLUGIN_ROOT CLAUDE_PLUGIN_DATA BATHOS_FORCE_HOST 2>/dev/null || true
 }
 
-# 1) 기본값(환경변수 없음) -> unknown (story-13 AC#1 — 과거엔 claude였다)
+# 1) default (no env vars) -> unknown (story-13 AC#1 — it used to be claude)
 _clear_detect_env
 got="$(bathos_detect_host)"
 assert_eq "기본 호스트 판별(전부 부재)" "unknown" "$got"
 
-# 2) PLUGIN_ROOT 존재 -> codex ([문서확정] 승격 + PLUGIN_ROOT 신규)
+# 2) PLUGIN_ROOT present -> codex ([doc-confirmed] promotion + PLUGIN_ROOT is new)
 _clear_detect_env
 got="$(PLUGIN_ROOT=/some/plugin bathos_detect_host)"
 assert_eq "PLUGIN_ROOT 존재 -> codex" "codex" "$got"
 
-# 3) PLUGIN_DATA 존재 -> codex
+# 3) PLUGIN_DATA present -> codex
 _clear_detect_env
 got="$(PLUGIN_DATA=/some/data bathos_detect_host)"
 assert_eq "PLUGIN_DATA 존재 -> codex" "codex" "$got"
 
-# 4) CLAUDE_PROJECT_DIR 존재 -> claude
+# 4) CLAUDE_PROJECT_DIR present -> claude
 _clear_detect_env
 got="$(CLAUDE_PROJECT_DIR=/some/project bathos_detect_host)"
 assert_eq "CLAUDE_PROJECT_DIR 존재 -> claude" "claude" "$got"
 
-# 5) CLAUDE_PLUGIN_ROOT만 존재(2순위 unprefixed 부재) -> claude
+# 5) only CLAUDE_PLUGIN_ROOT present (no 2nd-priority unprefixed var) -> claude
 _clear_detect_env
 got="$(CLAUDE_PLUGIN_ROOT=/some/plugin bathos_detect_host)"
 assert_eq "레거시 CLAUDE_PLUGIN_ROOT만 존재 -> claude" "claude" "$got"
 
-# 6) PLUGIN_ROOT와 CLAUDE_PLUGIN_ROOT 동시 존재 -> codex (2순위가 4순위보다 우선)
+# 6) PLUGIN_ROOT and CLAUDE_PLUGIN_ROOT both present -> codex (priority 2 beats priority 4)
 _clear_detect_env
 got="$(PLUGIN_ROOT=/p CLAUDE_PLUGIN_ROOT=/p bathos_detect_host)"
 assert_eq "PLUGIN_ROOT+CLAUDE_PLUGIN_ROOT 동시 -> codex(우선순위)" "codex" "$got"
 
-# 7) COPILOT_PLUGIN_DATA 존재 -> copilot(스코프 밖 — 원 동작 유지)
+# 7) COPILOT_PLUGIN_DATA present -> copilot (out of scope — original behaviour kept)
 _clear_detect_env
 got="$(COPILOT_PLUGIN_DATA=/x bathos_detect_host)"
 assert_eq "COPILOT_PLUGIN_DATA 존재 -> copilot(변경 없음)" "copilot" "$got"
 
-# 8) BATHOS_FORCE_HOST 유효값 오버라이드 -> 그 값(다른 신호가 있어도 우선)
+# 8) BATHOS_FORCE_HOST override with a valid value -> that value (wins over any other signal)
 _clear_detect_env
 got="$(BATHOS_FORCE_HOST=codex CLAUDE_PROJECT_DIR=/some/project bathos_detect_host)"
 assert_eq "강제 오버라이드(유효값 codex) 우선" "codex" "$got"
 
-# 9) BATHOS_FORCE_HOST 무효값 -> 경고 후 무시하고 실감지로 폴백(story-13 AC#1)
+# 9) BATHOS_FORCE_HOST with an invalid value -> warn, ignore it, fall back to real detection (story-13 AC#1)
 _clear_detect_env
 got="$(BATHOS_FORCE_HOST=bogus-typo CLAUDE_PROJECT_DIR=/some/project bathos_detect_host 2>/dev/null)"
 assert_eq "강제 오버라이드(무효값) -> 무시하고 실감지 폴백" "claude" "$got"
@@ -85,15 +85,15 @@ else
   FAIL=1
 fi
 
-# 10) claude/codex/unknown 출력분기는 payload를 그대로 통과(story-13 §5 — 포맷
-#     차이가 실제로 구현된 적이 없으므로 claude-형 기본을 공유한다)
+# 10) the claude/codex/unknown output branches pass the payload straight through (story-13 §5 —
+#     the format difference was never actually implemented, so they share the claude-style default)
 for h in claude codex unknown; do
   out="$(bathos_write_hook_output "$h" '{"decision":"allow"}')"; rc=$?
   assert_eq "$h 출력 통과(exit)" "0" "$rc"
   assert_eq "$h 출력 내용" '{"decision":"allow"}' "$out"
 done
 
-# 11) copilot은 여전히 미구현 -> exit 2, stdout 비어있음(오출력 금지)
+# 11) copilot is still unimplemented -> exit 2, empty stdout (no stray output)
 out="$(bathos_write_hook_output copilot '{"decision":"allow"}' 2>/dev/null)"
 rc=$?
 assert_eq "copilot 미구현 exit code(변경 없음)" "2" "$rc"

--- a/dist/tests/test-uninstall.sh
+++ b/dist/tests/test-uninstall.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 # =============================================================================
 # BATHOS Dynamis — dist/tests/test-uninstall.sh
-# Story B4 §5 "dry-run 모드가 곧 테스트 하니스다" — 픽스처 4종.
-#   ① 픽스처 외부 상태 생성 -> dry-run 출력이 전 대상을 나열
-#   ② --yes 실행 -> 실제 제거 + [removed] 로그
-#   ③ 대상 없음 -> 빈 상태 안내
-#   ④ 쓰기 불가 파일 1개 -> 부분 실패 분리 표기
+# Story B4 §5 "dry-run mode is the test harness" — four fixtures.
+#   (1) fixture creates external state -> dry-run output lists every target
+#   (2) run with --yes                 -> really removes + [removed] log
+#   (3) nothing to remove              -> reports the empty state
+#   (4) one unwritable file            -> partial failure reported separately
 #
-# 실제 $HOME/_state를 절대 건드리지 않는다 — 전부 격리된 임시 디렉터리로
-# BATHOS_ROOT/BATHOS_STATE_DIR/BATHOS_HOME/BATHOS_CONFIG_DIR를 오버라이드한다.
+# The real $HOME/_state is never touched — BATHOS_ROOT/BATHOS_STATE_DIR/
+# BATHOS_HOME/BATHOS_CONFIG_DIR are all overridden to isolated temp directories.
 # =============================================================================
 set -uo pipefail
 
@@ -24,7 +24,7 @@ new_fixture_root() {
 }
 
 # ---------------------------------------------------------------------------
-# ① dry-run: 외부 상태가 있으면 전 대상을 나열하고 아무것도 지우지 않는다
+# (1) dry-run: when external state exists, list every target and delete nothing
 # ---------------------------------------------------------------------------
 test_dry_run_lists_all() {
   local root state home
@@ -54,7 +54,7 @@ test_dry_run_lists_all() {
 }
 
 # ---------------------------------------------------------------------------
-# ② --yes 실행: 실제 제거 + [removed] 로그
+# (2) run with --yes: really removes, and logs [removed]
 # ---------------------------------------------------------------------------
 test_yes_actually_removes() {
   local root state home
@@ -83,7 +83,7 @@ test_yes_actually_removes() {
 }
 
 # ---------------------------------------------------------------------------
-# ③ 대상 없음: 빈 상태 안내
+# (3) nothing to remove: reports the empty state
 # ---------------------------------------------------------------------------
 test_empty_state_message() {
   local root state home
@@ -105,7 +105,7 @@ test_empty_state_message() {
 }
 
 # ---------------------------------------------------------------------------
-# ④ 쓰기 불가 파일: 부분 실패 분리 표기(성공/실패 카운트 분리)
+# (4) unwritable file: partial failure reported separately (success/fail counts split)
 # ---------------------------------------------------------------------------
 test_partial_failure_reported() {
   local root state home
@@ -113,15 +113,15 @@ test_partial_failure_reported() {
   state="$root/_state"; mkdir -p "$state"
   home="$root/home"; mkdir -p "$home/.claude"
   echo '{"plan_mode": true}' > "$state/session-flags.json"
-  # 쓰기 불가 디렉터리를 만들어 두 번째 대상(설정 statusLine 편집)에서 실패를 유도.
+  # Make the directory unwritable so the second target (editing the statusLine setting) fails.
   echo '{"statusLine": {"command": "bathos statusline"}}' > "$home/.claude/settings.json"
-  chmod 555 "$home/.claude"   # 디렉터리 쓰기 금지 -> 백업 파일(.bak) 생성 실패 유도
+  chmod 555 "$home/.claude"   # no writes allowed in the dir -> forces the .bak backup to fail
 
   local out
   out="$(BATHOS_ROOT="$root" BATHOS_STATE_DIR="$state" BATHOS_HOME="$home" bash "$UNINSTALL" --yes 2>&1)"
   local rc=$?
 
-  chmod 755 "$home/.claude"   # 정리 전 복구(rm -rf 위해)
+  chmod 755 "$home/.claude"   # restore before cleanup (so the recursive remove can succeed)
 
   if echo "$out" | grep -q "\[fail" && echo "$out" | grep -q "\[removed\]"; then
     pass "④ 부분 실패가 성공/실패 분리 표기됨"

--- a/scripts/_test-bathos-panes.sh
+++ b/scripts/_test-bathos-panes.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 # =============================================================================
-# BATHOS  scripts/_test-bathos-panes.sh  —  tmux 헤드리스 스모크 테스트 (T7)
+# BATHOS  scripts/_test-bathos-panes.sh  —  headless tmux smoke test (T7)
 #
-# 실제 사용자 없이 `bathos-panes.sh`의 핵심 계약만 검증한다:
-#   1) __control 서브커맨드가 "confirm <W> <VERDICT> <사유>" 입력을 받아
-#      inbox/confirm-<W>-*.txt 파일을 실제로 생성하는가(내용까지)
-#   2) __input 서브커맨드도 동일 계약을 지키는가(웨이브별 입력 pane)
-#   3) 자유서술 입력은 feedback-*.md로 떨어지는가
-#   4) up의 프리플라이트(E-TMUX-ABSENT/E-BATHOS-ABSENT)가 실제로 정확한 exit code를 내는가
+# Verifies only the core contracts of `bathos-panes.sh`, with no real user present:
+#   1) does the __control subcommand take a "confirm <W> <VERDICT> <reason>" input
+#      and really create inbox/confirm-<W>-*.txt (contents included)?
+#   2) does the __input subcommand honour the same contract (per-wave input pane)?
+#   3) does free-form input land in feedback-*.md?
+#   4) does up's preflight (E-TMUX-ABSENT/E-BATHOS-ABSENT) really return the exact exit code?
 #
-# tmux가 없는 CI 환경에서도 죽지 않도록 SKIP(exit 0)한다 — 이 프로젝트의 fail-safe 관례
-# (codex-adapter/hooks/_test-codex-hooks.sh와 동일 원칙: 도구 부재는 실패가 아니다).
+# SKIPs (exit 0) instead of dying in CI environments without tmux — this project's
+# fail-safe convention (like codex-adapter/hooks/_test-codex-hooks.sh: an absent tool is not a failure).
 #
-# 실행: bash scripts/_test-bathos-panes.sh
+# Run: bash scripts/_test-bathos-panes.sh
 # =============================================================================
 set -uo pipefail
 
@@ -127,8 +127,8 @@ tmux kill-session -t "$SESSION3" >/dev/null 2>&1 || true
 printf '\n== T8-lite: up 프리플라이트 — E-BATHOS-ABSENT(exit 4) ==\n'
 EMPTY_PROJECT="$WORK/empty-project"
 mkdir -p "$EMPTY_PROJECT"
-# tmux가 있는 디렉터리는 남기되(E-TMUX-ABSENT 아닌 E-BATHOS-ABSENT를 유도해야 하므로),
-# bathos 바이너리는 어디서도 못 찾도록 PATH를 좁힌다(BATHOS_BIN도 비움).
+# Keep tmux's directory on PATH (we must trigger E-BATHOS-ABSENT, not E-TMUX-ABSENT),
+# but narrow PATH so the bathos binary is nowhere to be found (BATHOS_BIN cleared too).
 TMUX_DIR="$(dirname "$(command -v tmux)")"
 if env -i PATH="/usr/bin:/bin:$TMUX_DIR" BATHOS_PANES_NO_ATTACH=1 \
      "$PANES_SH" up --project "$EMPTY_PROJECT" >/tmp/bathos-panes-preflight.$$ 2>&1; then

--- a/scripts/bathos-panes.sh
+++ b/scripts/bathos-panes.sh
@@ -1,28 +1,28 @@
 #!/usr/bin/env bash
 # =============================================================================
-# BATHOS  scripts/bathos-panes.sh  —  tmux Wave 패널 프론트엔드 (B3, ADR-D-0007/0009)
+# BATHOS  scripts/bathos-panes.sh  —  tmux Wave panel frontend (B3, ADR-D-0007/0009)
 #
-# 사용:
-#   bathos-panes.sh up      [--project <절대경로>] [--waves "W2 W5"] [--interval 2]
-#   bathos-panes.sh attach  [--project <절대경로>]
-#   bathos-panes.sh down    [--project <절대경로>]
-#   bathos-panes.sh status  [--project <절대경로>]
+# Usage:
+#   bathos-panes.sh up      [--project <abs-path>] [--waves "W2 W5"] [--interval 2]
+#   bathos-panes.sh attach  [--project <abs-path>]
+#   bathos-panes.sh down    [--project <abs-path>]
+#   bathos-panes.sh status  [--project <abs-path>]
 #
-# exit 0=성공 / 1=실행 실패 / 3=E-TMUX-ABSENT / 4=E-BATHOS-ABSENT
+# exit 0=success / 1=run failure / 3=E-TMUX-ABSENT / 4=E-BATHOS-ABSENT
 #
-# 무엇을 하는가: `bathos inspect vm --format lines`(bathos-inspect DashboardVM, ADR-D-0007)
-# 하나의 데이터원을 tmux 분할 패널에 2초 간격으로 렌더링하고, 패널에서 입력한
-# confirm/feedback/answer를 `_state/panes/inbox/`에 파일로 흘린다(ADR-D-0009). 게이트
-# 정본 기록은 여전히 `bathos gate`(웨이브 흐름) — 이 패널의 confirm은 "제안 채널"이다.
+# What it does: takes one single data source, `bathos inspect vm --format lines`
+# (bathos-inspect DashboardVM, ADR-D-0007), renders it into split tmux panes every 2s, and
+# streams the confirm/feedback/answer typed in a pane into `_state/panes/inbox/` as files
+# (ADR-D-0009). The canonical gate record is still `bathos gate` (the wave flow) — this panel's confirm is a "proposal channel".
 #
-# 왜 파일 기반 입력인가: 팀원(Claude Code 서브에이전트)에는 TTY가 없다 — 이 스크립트는
-# **사람이 여는 두 번째 터미널**의 관측/입력 도구다(F9). Paul(리드) 자신의 세션이 이
-# 스크립트를 자동 기동하지 않는 이유도 같다(자기 TTY를 이미 점유 중).
+# Why file-based input: teammates (Claude Code subagents) have no TTY — this script is the
+# observe/input tool for **a second terminal that a human opens** (F9). It is also why Paul's
+# (the lead's) own session does not auto-start this script: it already occupies its own TTY.
 #
-# 이식성: bash 3.2(macOS 기본) 호환 — mapfile/연관배열(`declare -A`)/`${var,,}`/`&>` 금지.
-# jq 금지 — `bathos inspect vm --format lines`의 TSV를 awk/grep/cut/read로만 소비한다.
-# Windows 네이티브는 tmux가 없어 미지원 — WSL(`scripts/wsl-setup.sh`) 또는
-# `bathos panes --mode tui`(§B4, crossterm)를 대신 쓴다.
+# Portability: bash 3.2 compatible (the macOS default) — mapfile / associative arrays (`declare -A`) / `${var,,}` / `&>` are banned.
+# No jq — the TSV from `bathos inspect vm --format lines` is consumed with awk/grep/cut/read only.
+# Native Windows is unsupported because it has no tmux — use WSL (`scripts/wsl-setup.sh`) or
+# `bathos panes --mode tui` (§B4, crossterm) instead.
 # =============================================================================
 set -uo pipefail
 
@@ -110,7 +110,7 @@ EOF
 }
 
 # --------------------------------------------------------------------------
-# 0. bathos 바이너리 탐색 (codex-adapter/hooks/pretooluse-gate.sh와 동일 순서)
+# 0. locate the bathos binary (same order as codex-adapter/hooks/pretooluse-gate.sh)
 # --------------------------------------------------------------------------
 find_bathos_bin() {
   local project="$1"
@@ -324,7 +324,7 @@ case "$CMD" in
 esac
 
 # --------------------------------------------------------------------------
-# 2. 공통 인자 파싱 (up/attach/down/status)
+# 2. shared argument parsing (up/attach/down/status)
 # --------------------------------------------------------------------------
 PROJECT="$(pwd)"
 WAVES_ARG=""
@@ -357,7 +357,7 @@ AGENT_TEAM="$PROJECT/.agent-team"
 PANES_DIR="$AGENT_TEAM/_state/panes"
 
 # --------------------------------------------------------------------------
-# 3. 프리플라이트 — tmux · bathos 바이너리
+# 3. preflight — tmux · the bathos binary
 # --------------------------------------------------------------------------
 if ! command -v tmux >/dev/null 2>&1; then
   err "tmux가 설치돼 있지 않습니다(E-TMUX-ABSENT)."
@@ -375,7 +375,7 @@ BATHOS_BIN_RESOLVED="$(find_bathos_bin "$PROJECT")" || {
 }
 
 # --------------------------------------------------------------------------
-# 4. 세션명 — bathos-<project_id> (jq 금지: grep으로 manifest.json에서 직접 추출)
+# 4. session name — bathos-<project_id> (no jq: grep it straight out of manifest.json)
 # --------------------------------------------------------------------------
 MANIFEST="$AGENT_TEAM/_state/manifest.json"
 PROJECT_ID=""
@@ -390,13 +390,13 @@ mkdir -p "$PANES_DIR/inbox" "$PANES_DIR/processed"
 
 session_exists() { tmux has-session -t "$SESSION" 2>/dev/null; }
 
-# stale session.info 정리(has-session과 불일치하면 재생성 대상 — E8/멱등성)
+# Clear a stale session.info (if it disagrees with has-session it must be recreated — E8/idempotency)
 if [ -f "$PANES_DIR/session.info" ] && ! session_exists; then
   rm -f "$PANES_DIR/session.info"
 fi
 
 # --------------------------------------------------------------------------
-# 5. 웨이브 자동 선택 (--waves 미지정 시)
+# 5. automatic wave selection (when --waves is not given)
 # --------------------------------------------------------------------------
 select_waves() {
   if [ -n "$WAVES_ARG" ]; then
@@ -423,7 +423,7 @@ select_waves() {
 }
 
 # --------------------------------------------------------------------------
-# 6. 커맨드 구현
+# 6. command implementations
 # --------------------------------------------------------------------------
 case "$CMD" in
   up)
@@ -487,7 +487,7 @@ case "$CMD" in
       say "이미 종료 상태: $SESSION"
     fi
     rm -f "$PANES_DIR/session.info"
-    # wave-log.md는 리드 소유 — 종료 스탬프는 별도 파일에만 남긴다(소유권 침범 금지).
+    # wave-log.md belongs to the lead — the close stamp goes into a separate file only (no ownership trespass).
     printf 'closed %s session=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SESSION" \
       >> "$PANES_DIR/session.info.last" 2>/dev/null || true
     # PANES-004: this file accumulates across every `down` invocation via append (`>>`, not a

--- a/scripts/check-codex-drift.sh
+++ b/scripts/check-codex-drift.sh
@@ -1,23 +1,23 @@
 #!/usr/bin/env bash
 # ---------------------------------------------------------------------------
-# BATHOS  scripts/check-codex-drift.sh  —  Codex 방출물 drift 검사(US13-AC2)
+# BATHOS  scripts/check-codex-drift.sh  —  drift check for the Codex emissions (US13-AC2)
 #
-# 무엇을·왜: `.agents/skills/**`의 generated 파일(scripts/to-codex.sh 산출)이 정본
-# (`.claude/commands/*.md`)과 어긋나 있지 않은지 — 즉 "누군가 방출물을 직접 손으로 고쳐서
-# 재방출과 달라지지 않았는지"를 검사한다(E-EMIT-DRIFT, exceptions.md#5 "정본 수정 후 재방출이
-# 유일 경로"). 검사 방법은 to-codex.sh를 임시 디렉터리(`--skills-root`)에 다시 돌려 실물과
-# diff하는 것뿐이다 — 이 스크립트 자체는 별도 렌더링 로직을 갖지 않는다(멱등 파이프라인의
-# 유일 진실원은 to-codex.sh, 재발명 금지).
+# What & why: checks that the generated files under `.agents/skills/**` (emitted by scripts/to-codex.sh) have
+# not drifted from the canonical source (`.claude/commands/*.md`) — i.e. "did someone hand-edit an emission so
+# that it no longer matches a re-emission?" (E-EMIT-DRIFT, exceptions.md#5 "editing the canonical file and
+# re-emitting is the only path"). The only method used is re-running to-codex.sh into a temp directory
+# (`--skills-root`) and diffing against the real files — this script has no rendering logic of its own (the sole
+# source of truth for the idempotent pipeline is to-codex.sh; do not reinvent it).
 #
-# 검사 대상: generated 헤더 파일만(15개 — story-04 §4). hand-authored 15개(팀 스폰형)는
-# scripts/codex-skills-drift-exclusions.json에 등재된 이름이라 자동 제외한다(파일명 충돌 경위는
-# andrew-command-classification.md#8 참고 — story 원문의 "drift-exclusions.json"이 아니다).
+# Scope: only the generated-header files (15 of them — story-04 §4). The 15 hand-authored ones (team-spawning)
+# are auto-excluded because their names are registered in scripts/codex-skills-drift-exclusions.json (for how the
+# filename clash came about see andrew-command-classification.md#8 — it is NOT the story's "drift-exclusions.json").
 #
-# 사용:
-#   bash scripts/check-codex-drift.sh            # 검사만(비파괴), 그린이면 exit 0
-#   bash scripts/check-codex-drift.sh --verbose   # diff 상세 출력
+# Usage:
+#   bash scripts/check-codex-drift.sh            # check only (non-destructive); exit 0 when green
+#   bash scripts/check-codex-drift.sh --verbose   # print the diff in full
 #
-# CI 배선은 Phillip 소유(.github/workflows/ci.yml, build-plan.md#1) — 이 스크립트는 "호출되는 쪽"만.
+# CI wiring is Phillip's (.github/workflows/ci.yml, build-plan.md#1) — this script is only "the callee".
 # ---------------------------------------------------------------------------
 set -euo pipefail
 
@@ -31,7 +31,7 @@ EXCLUSIONS_FILE="$SCRIPT_DIR/codex-skills-drift-exclusions.json"
 TMPROOT="$(mktemp -d "${TMPDIR:-/tmp}/bathos-codex-drift.XXXXXX")"
 trap 'rm -rf "$TMPROOT"' EXIT
 
-# hand-authored 제외 목록 추출(jq 금지 — awk/grep만, project-context-kr.md#1)
+# Extract the hand-authored exclusion list (no jq — awk/grep only, project-context-kr.md#1)
 hand_authored(){
   awk '/"hand_authored_skills"[[:space:]]*:[[:space:]]*\[/{f=1;next} f&&/\]/{f=0} f' "$EXCLUSIONS_FILE" \
     | grep -oE '"[a-zA-Z0-9_-]+"' | tr -d '"'
@@ -47,8 +47,8 @@ echo "== check-codex-drift: $EXCLUSIONS_FILE 기준 재생성 비교 =="
 [ -f "$EXCLUSIONS_FILE" ] || { echo "오류: $EXCLUSIONS_FILE 없음" >&2; exit 1; }
 [ -d "$REAL_SKILLS" ] || { echo "오류: $REAL_SKILLS 없음 — 먼저 'bash scripts/to-codex.sh --write' 실행" >&2; exit 1; }
 
-# to-codex.sh를 임시 root로 재실행(실물은 건드리지 않음 — 순수 비교용 사본 생성).
-# to-codex.sh는 skills 외에도 agents를 방출하므로 agents-root도 tmp로 격리한다.
+# Re-run to-codex.sh into a temp root (the real files stay untouched — the copy is purely for comparison).
+# to-codex.sh emits agents as well as skills, so isolate agents-root into tmp too.
 bash "$SCRIPT_DIR/to-codex.sh" --write --skills-root "$TMPROOT/skills" --agents-root "$TMPROOT/agents" >/dev/null
 
 fail=0
@@ -74,7 +74,7 @@ for d in "$REAL_SKILLS"/*/; do
     [ "$VERBOSE" = "1" ] && diff -u "$regen" "$real" >&2
     fail=$((fail+1))
   fi
-  # openai.yaml도 있으면 동일 비교(인자형 4개)
+  # Compare openai.yaml the same way when it exists (the 4 argument-taking skills)
   if [ -f "$REAL_SKILLS/$name/agents/openai.yaml" ]; then
     real_y="$REAL_SKILLS/$name/agents/openai.yaml"
     regen_y="$TMPROOT/skills/$name/agents/openai.yaml"

--- a/scripts/codex-glm/verify-relay.sh
+++ b/scripts/codex-glm/verify-relay.sh
@@ -13,7 +13,7 @@
 # liveness check", not "connection verified". What this script checks:
 #   1. codex-relay binary is on PATH (or a path was given).
 #   2. relay-config.toml.example has the required TOML keys (grep, no jq —
-#      this repo's bash-3.2/no-jq convention, code-structure.md#레이어경계).
+#      this repo's bash-3.2/no-jq convention, code-structure.md §layer boundaries).
 #   3. IF a relay happens to already be running locally, its /v1/models
 #      endpoint is reachable — this only proves "a proxy is listening", not
 #      "GLM behind it is reachable/authenticated". No API key is read, sent,

--- a/scripts/glm-env.sh
+++ b/scripts/glm-env.sh
@@ -1,22 +1,22 @@
 #!/usr/bin/env bash
 # ---------------------------------------------------------------------------
-# BATHOS  scripts/glm-env.sh  —  GLM(Z.ai) 백엔드로 Claude Code/BATHOS 구동
-# 사용:  Z_AI_API_KEY=<키> source scripts/glm-env.sh
-#        (반드시 `source` — 현재 셸에 export 되어야 함. 실행만 하면 효과 없음.)
-# 되돌리기:  scripts/glm-env.sh --unset  (또는 새 셸)
+# BATHOS  scripts/glm-env.sh  —  run Claude Code/BATHOS on the GLM (Z.ai) backend
+# Usage:  Z_AI_API_KEY=<key> source scripts/glm-env.sh
+#        (must be `source`d — the exports have to land in the current shell. Merely running it does nothing.)
+# Revert:  scripts/glm-env.sh --unset  (or just open a new shell)
 #
-# 철칙: 이 파일에 키를 하드코딩하지 말 것(커밋 사고 방지). 키는 Z_AI_API_KEY 로 주입.
-# 근거: docs/glm-backend-kr.md · https://docs.z.ai/scenario-example/develop-tools/claude
+# Hard rule: never hardcode the key in this file (guards against committing it by accident). Inject it via Z_AI_API_KEY.
+# Reference: docs/glm-backend-kr.md · https://docs.z.ai/scenario-example/develop-tools/claude
 # ---------------------------------------------------------------------------
 
-# --unset: GLM 설정 해제 → Claude(Anthropic) 복귀
+# --unset: drop the GLM settings and fall back to Claude (Anthropic)
 if [ "${1:-}" = "--unset" ]; then
   unset ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN API_TIMEOUT_MS
   echo "[glm-env] 해제됨 — Claude(Anthropic) 기본 백엔드로 복귀."
   return 0 2>/dev/null || exit 0
 fi
 
-# source 여부 감지(실행만 하면 export가 무의미)
+# Detect whether we were sourced (without it the exports are meaningless)
 _sourced=0
 if [ -n "${BASH_SOURCE:-}" ] && [ "${BASH_SOURCE[0]}" != "$0" ]; then _sourced=1; fi
 if [ -n "${ZSH_EVAL_CONTEXT:-}" ] && case "$ZSH_EVAL_CONTEXT" in *:file) true;; *) false;; esac; then _sourced=1; fi

--- a/scripts/to-codex.sh
+++ b/scripts/to-codex.sh
@@ -1,63 +1,63 @@
 #!/usr/bin/env bash
 # ---------------------------------------------------------------------------
-# BATHOS  scripts/to-codex.sh  —  Claude Code 자산 → OpenAI Codex CLI dual-emit
+# BATHOS  scripts/to-codex.sh  —  Claude Code assets -> OpenAI Codex CLI dual-emit
 #
-# 무엇을·왜 (intro):
-#   정본은 항상 `.claude/commands/*.md`·`.claude/agents/_base/*.md`이고, 이 스크립트는
-#   그 정본을 **읽기만** 한다(project-context-kr.md#2.6 "Claude 경로 회귀 0" — W5 동결).
-#   출력은 네 타깃으로 나뉜다:
-#     1) 레거시 스캐폴드(하위호환, story-05 AC#6): <dest>/prompts/*.md, <dest>/agents/*.toml
-#        — 기존 동작 그대로(기본 dest=./.codex-out), TOML만 리터럴 `'''`+spawnable 필터 적용(§3).
-#        model 필드는 여기선 계속 `# TODO` 주석(레거시는 미리보기 스캐폴드일 뿐 정본 배포 경로가 아님).
-#     2) skills 정본(D6 — `.codex/skills` 아님): $REPO_ROOT/.agents/skills/<name>/SKILL.md
-#        `--write` 시 자동 방출(레포 내부 경로라 추가 동의 불필요).
-#     3) prompts 과도기: ~/.codex/prompts/<name>.md — `--emit-prompts` 명시 시에만(홈 디렉터리
-#        쓰기는 사용자 승인 사안 — story-05 하위작업 1항).
-#     4) agents 정본(CT-SUBAGENT, story-11 — Stephen 요청 §8): <repo>/.codex/agents/<slug>.toml
-#        `--write` 시 자동 방출(레포 내부). skills 정본과 같은 D6류 이중경로 패턴(legacy+canonical) —
-#        레거시(1)와 달리 여기는 **model 필드에 실값을 기입**한다(stephen-model-mapping.md §1 룩업,
-#        리드 v0.145.0+ 채택 확정) + story-09 오케스트레이션 표준 문구(블록 A+B, stephen-orchestration.md
-#        §"TOML/skills 삽입 위치" 지정대로 A+B만)를 developer_instructions 말미에 append한다. 두 텍스트는
-#        전부 정본 문서에서 그대로 복사한 상수다(재작문 금지 — 표현 드리프트가 곧 정본 붕괴, 두 문서
-#        모두 명시).
+# What & why (intro):
+#   The canonical sources are always `.claude/commands/*.md` and `.claude/agents/_base/*.md`, and this
+#   script **only reads** them (project-context-kr.md#2.6 "zero regression on the Claude path" — W5 freeze).
+#   The output splits into four targets:
+#     1) legacy scaffold (backwards compat, story-05 AC#6): <dest>/prompts/*.md, <dest>/agents/*.toml
+#        — behaviour unchanged (default dest=./.codex-out); only the TOML gets the literal `'''` + spawnable filter (§3).
+#        here the model field stays a `# TODO` comment (legacy is only a preview scaffold, not a release path).
+#     2) canonical skills (D6 — NOT `.codex/skills`): $REPO_ROOT/.agents/skills/<name>/SKILL.md
+#        emitted automatically on `--write` (an in-repo path, so no extra consent is needed).
+#     3) transitional prompts: ~/.codex/prompts/<name>.md — only with an explicit `--emit-prompts` (writing to
+#        the home directory is a matter of user consent — story-05, subtask 1).
+#     4) canonical agents (CT-SUBAGENT, story-11 — Stephen's request §8): <repo>/.codex/agents/<slug>.toml
+#        emitted automatically on `--write` (in-repo). Same D6-style dual-path pattern as the canonical skills (legacy+canonical) —
+#        unlike legacy (1), this one **writes a real value into the model field** (stephen-model-mapping.md §1 lookup,
+#        the lead's confirmed v0.145.0+ adoption) plus the story-09 standard orchestration text (blocks A+B, stephen-orchestration.md
+#        §"TOML/skills insertion points" specifies A+B only), appended at the end of developer_instructions. Both texts are
+#        constants copied verbatim from the canonical documents (do not rewrite — wording drift is canon collapse; both
+#        documents state this explicitly).
 #
-#   방출 대상 3분류(근거: .agent-team/08-impl-notes/andrew-command-classification.md, story-04 SS5):
-#     - 팀 스폰형 15개(Task 툴 사용) → 이 스크립트가 만들지 않는다. story-10에서 수기(hand-authored)
-#       SKILL.md를 직접 쓰고 scripts/codex-skills-drift-exclusions.json에 등재해 재생성 대상에서 뺀다.
-#       (주의: `scripts/drift-exclusions.json`은 **이미 존재**하는 별개 파일 — docs i18n drift-guard
-#       `check-rule-copies.sh`가 소유·소비 중이라 이름 충돌을 피해 새 파일명을 쓴다. 상세 근거는
+#   Three emission classes (rationale: .agent-team/08-impl-notes/andrew-command-classification.md, story-04 SS5):
+#     - the 15 team-spawning ones (they use the Task tool) -> this script does not create them. story-10 writes their
+#       SKILL.md by hand (hand-authored) and registers them in scripts/codex-skills-drift-exclusions.json, out of regeneration.
+#       (Careful: `scripts/drift-exclusions.json` is a separate file that **already exists** — the docs i18n drift-guard
+#       `check-rule-copies.sh` owns and consumes it, so a new filename avoids the clash. Detailed rationale in
 #       andrew-command-classification.md#8.)
-#     - 별칭 4개(save/resume/context-save/context-restore) → skills 타깃에서는 정본(save-session/
-#       cold-start)으로 병합(중복 skill 노출 방지, US8-AC1). prompts 타깃(레거시+과도기 둘 다)에는
-#       그대로 포함 — 결정론 폴백은 별칭까지 살아 있어야 의미가 있다.
-#     - remote-dev 1개 → Claude 전용 기능(Remote Control) 가이드라 Codex 대응 기능이 없다. skills
-#       타깃에서 제외(과장 방지, project-context-kr.md#2.5). prompts 타깃엔 AC#1 문언대로 포함.
-#     → skills 최종 노출 수 = 15(수기) + 15(이 스크립트 generated) = 30 (분류표 §5 확정치).
+#     - the 4 aliases (save/resume/context-save/context-restore) -> in the skills target they merge into the canonical
+#       names (save-session/cold-start) so no duplicate skill is exposed (US8-AC1). In the prompts target (both legacy
+#       and transitional) they are kept — a deterministic fallback only means something if the aliases live too.
+#     - remote-dev (1) -> it is a guide to a Claude-only feature (Remote Control), which Codex has no counterpart for.
+#       Excluded from the skills target (no overclaiming, project-context-kr.md#2.5); included in prompts per AC#1's wording.
+#     -> final number of exposed skills = 15 (hand-authored) + 15 (generated here) = 30 (the classification table's §5 figure).
 #
-#   description 3부(요약/TRIGGER/NOT, CT-SKILL §7)는 `.claude/commands`를 건드리지 않고 이 스크립트가
-#   **결정론적으로 합성**한다(trigger_for/not_for 표, 아래). 출처 없는 자연어 트리거는 날조하지 않는다 —
-#   CLAUDE.md §8/§8.1 또는 각 커맨드 자체 "자연어 트리거" 각주가 없으면 "명시 멘션만"으로 정직 표기한다
-#   (project-context-kr.md#2.5). 이 합성이 매 실행 동일 출력을 내므로(비결정 요소 없음) "generated" 자격은
-#   유지된다 — 멱등(AC#4)은 "정본과 바이트가 같다"가 아니라 "이 스크립트를 다시 돌리면 같은 결과"다.
+#   The 3-part description (summary/TRIGGER/NOT, CT-SKILL §7) is synthesised **deterministically** by this script
+#   without touching `.claude/commands` (the trigger_for/not_for tables, below). Unsourced natural-language triggers are
+#   never invented — without a CLAUDE.md §8/§8.1 entry or the command's own "natural-language trigger" footnote, we
+#   honestly write "explicit mention only" (project-context-kr.md#2.5). Since the synthesis emits the same output every
+#   run (nothing nondeterministic), it keeps the "generated" status — idempotence (AC#4) is not "byte-equal to canon" but "re-run this script, same result".
 #
-#   프로젝트 경로 인자 처리: 원본 커맨드는 대부분 `$1`(프로젝트 절대경로, 대개 선택)을 받지만 Codex
-#   skills에는 인자 치환이 없다(L4, 이슈 #15316). 그래서 skills 본문에는 매번 동일한 안내 배너를
-#   앞머리에 붙여, 본문에 남은 `$1` 토큰을 "항상 현재 작업 디렉터리(cwd)"로 읽도록 명시한다(F1: Codex는
-#   레포 루트에서 실행되는 것이 기본 전제). 문장 단위로 `$1`을 치환하지 않는 이유: 조사·어미가 붙은
-#   한국어 문장을 정규식으로 재작문하면 의미가 깨질 위험이 실익보다 크다 — 배너 1회 고지가 더 정직하다.
+#   Handling the project-path argument: most original commands accept `$1` (the project's absolute path, usually
+#   optional), but Codex skills have no argument substitution (L4, issue #15316). So every skill body gets the same
+#   banner prepended, stating that any `$1` token left in the body must be read as "always the current working
+#   directory (cwd)" (F1: the base assumption is that Codex runs from the repo root). Why `$1` is not substituted
+#   sentence by sentence: rewriting Korean prose (with its particles and endings) by regex risks breaking the meaning more than it gains — one banner notice is more honest.
 #
-# 사용:
-#   bash scripts/to-codex.sh                              # dry-run(미리보기, 전체)
-#   bash scripts/to-codex.sh --write                       # 레거시 스캐폴드 + skills 정본 실제 생성
-#   bash scripts/to-codex.sh --write --emit-prompts        # + ~/.codex/prompts 과도기 방출(홈 쓰기 동의)
-#   bash scripts/to-codex.sh --write --dest ~/.codex-out2  # 레거시 스캐폴드 위치 지정
-#   bash scripts/to-codex.sh --write --skills-root <dir>   # skills 출력 위치 재지정(주로 drift 검사용)
-#   bash scripts/to-codex.sh --write --agents-root <dir>   # agents 정본 출력 위치 재지정(기본 .codex/agents)
+# Usage:
+#   bash scripts/to-codex.sh                              # dry-run (preview, everything)
+#   bash scripts/to-codex.sh --write                       # really create the legacy scaffold + canonical skills
+#   bash scripts/to-codex.sh --write --emit-prompts        # + transitional ~/.codex/prompts emission (consent to write to home)
+#   bash scripts/to-codex.sh --write --dest ~/.codex-out2  # choose where the legacy scaffold goes
+#   bash scripts/to-codex.sh --write --skills-root <dir>   # redirect the skills output (mainly for the drift check)
+#   bash scripts/to-codex.sh --write --agents-root <dir>   # redirect the canonical agents output (default .codex/agents)
 #
-# 철칙: 날조 금지. model 은 원본(claude-*)을 주석으로 보존하고, Codex 모델은
-#       사용자가 지정하도록 비워 둔다(임의 모델명 삽입 금지 — SS10 매핑표 확정 전 공란).
-#       멱등: `--write` 2회 연속 실행 시 방출물 diff 0(US13-AC1 — 타임스탬프 등 비결정 요소 금지).
-#       bash 3.2 호환(macOS 기본) — jq 금지, grep/sed/awk 네이티브 파싱만(project-context-kr.md#1).
+# Hard rule: no fabrication. The model field preserves the original (claude-*) as a comment, and the
+#       Codex model is left blank for the user to fill in (never insert an arbitrary model name — blank until the SS10 mapping table is settled).
+#       Idempotence: two `--write` runs back to back yield a zero diff (US13-AC1 — no timestamps or other nondeterminism).
+#       bash 3.2 compatible (the macOS default) — no jq, native grep/sed/awk parsing only (project-context-kr.md#1).
 # ---------------------------------------------------------------------------
 set -euo pipefail
 
@@ -92,15 +92,15 @@ say(){ printf '%s\n' "$*"; }
 [ "$WRITE" = "1" ] && say "== 실제 생성 → $DEST (+ skills: $SKILLS_ROOT) ==" || say "== DRY-RUN(미리보기) — 실제 생성하려면 --write =="
 
 # ---------------------------------------------------------------------------
-# §1. frontmatter/본문 파서 (기존 헬퍼 재사용 — 재발명 금지)
+# §1. frontmatter/body parser (reuse the existing helpers — do not reinvent)
 # ---------------------------------------------------------------------------
-# frontmatter 값 추출(첫 --- 블록에서 key: value, 인라인 주석 제거)
+# Extract a frontmatter value (key: value from the first --- block, inline comments stripped)
 fm_val(){ # $1=file $2=key
   awk -v k="$2" '
     NR==1 && $0 ~ /^---[[:space:]]*$/ {inf=1; next}
     inf && $0 ~ /^---[[:space:]]*$/ {exit}
     inf {
-      line=$0; sub(/#.*/,"",line)                       # 인라인 주석 제거
+      line=$0; sub(/#.*/,"",line)                       # strip the inline comment
       if (line ~ "^[[:space:]]*" k "[[:space:]]*:") {
         sub("^[[:space:]]*" k "[[:space:]]*:[[:space:]]*","",line)
         gsub(/^[[:space:]]+|[[:space:]]+$/,"",line)
@@ -109,7 +109,7 @@ fm_val(){ # $1=file $2=key
       }
     }' "$1"
 }
-# 본문(두 번째 --- 이후) 추출
+# Extract the body (everything after the second ---)
 body_after_fm(){ awk 'p{print} /^---[[:space:]]*$/{c++; if(c==2)p=1}' "$1"; }
 first_body_description(){
   awk '
@@ -119,7 +119,7 @@ first_body_description(){
 }
 
 # ---------------------------------------------------------------------------
-# §2. 분류 데이터 (andrew-command-classification.md §1~4 그대로 — .claude 미접촉)
+# §2. classification data (andrew-command-classification.md §1~4 verbatim — .claude untouched)
 # ---------------------------------------------------------------------------
 TEAM_SPAWN="autoplan cso investigate lecture plan-design-review plan-devex-review plan-eng-review review wave0-analysis wave1-discovery wave2-design wave3-story-gate wave4-ip-research wave5-implement wave6-verify-report"
 ARG_SKILLS="route recall guard team-kickoff"
@@ -129,7 +129,7 @@ is_in(){ # $1=needle $2=space-separated haystack
   case " $2 " in *" $1 "*) return 0 ;; *) return 1 ;; esac
 }
 
-# 별칭 → 정본 매핑(skills 타깃 병합용). 대상 아니면 빈 문자열.
+# Alias -> canonical mapping (for merging in the skills target). Empty string when it does not apply.
 alias_canonical(){
   case "$1" in
     save|context-save) printf 'save-session' ;;
@@ -138,7 +138,7 @@ alias_canonical(){
   esac
 }
 
-# skills 타깃 방출 대상인가(= 팀 스폰형도 별칭도 remote-dev도 아닌 나머지 20)
+# Is this an emission target for skills? (= the other 20: not team-spawning, not an alias, not remote-dev)
 is_skill_target(){
   is_in "$1" "$TEAM_SPAWN" && return 1
   [ -n "$(alias_canonical "$1")" ] && return 1
@@ -147,7 +147,7 @@ is_skill_target(){
 }
 
 # ---------------------------------------------------------------------------
-# §3. TRIGGER/NOT 3부 description 합성 (날조 금지 — 출처 있는 표현만)
+# §3. synthesise the 3-part TRIGGER/NOT description (no fabrication — only sourced wording)
 # ---------------------------------------------------------------------------
 trigger_for(){
   case "$1" in
@@ -181,7 +181,7 @@ not_for(){
   esac
 }
 
-# 인자형 4개 전용 — 산문 인자 규약 블록(CT-SKILL argument_convention, story-07)
+# For the 4 argument-taking skills only — the prose argument-convention block (CT-SKILL argument_convention, story-07)
 arg_prose_for(){
   case "$1" in
     route)
@@ -226,7 +226,7 @@ BLOCK
 }
 
 # ---------------------------------------------------------------------------
-# §4. 경로 배너 + generated 헤더 (모든 skills 방출물 공통, AC#2)
+# §4. path banner + generated header (common to every emitted skill, AC#2)
 # ---------------------------------------------------------------------------
 GENERATED_HEADER_SKILL(){ printf '# generated by scripts/to-codex.sh — 정본: .claude/commands/%s.md (직접 수정 금지)\n' "$1"; }
 GENERATED_HEADER_TOML(){ printf '# generated by scripts/to-codex.sh — 정본: .claude/agents/_base/%s (직접 수정 금지)\n' "$1"; }
@@ -240,7 +240,7 @@ PATH_BANNER(){
 BANNER
 }
 
-# story-16 L1/L2 고지 — save-session/cold-start/taskreport 전용(ux-parity-limits.md §3)
+# story-16 L1/L2 disclosure — only for save-session/cold-start/taskreport (ux-parity-limits.md §3)
 codex_notice_for(){
   case "$1" in
     save-session)
@@ -268,7 +268,7 @@ BLOCK
 }
 
 # ---------------------------------------------------------------------------
-# §5. skills 정본 방출 (.agents/skills/<name>/SKILL.md — D6)
+# §5. emit the canonical skills (.agents/skills/<name>/SKILL.md — D6)
 # ---------------------------------------------------------------------------
 nskill=0
 if [ -d "$CMD_SRC" ]; then
@@ -324,8 +324,8 @@ if [ -d "$CMD_SRC" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# §6. 레거시 스캐폴드(하위호환, AC#6) — <dest>/prompts, <dest>/agents
-#     + ~/.codex/prompts 과도기(--emit-prompts, story-05 AC#1: 팀 스폰형 15개만 제외)
+# §6. legacy scaffold (backwards compat, AC#6) — <dest>/prompts, <dest>/agents
+#     + transitional ~/.codex/prompts (--emit-prompts, story-05 AC#1: only the 15 team-spawning ones excluded)
 # ---------------------------------------------------------------------------
 ncmd=0
 if [ -d "$CMD_SRC" ]; then
@@ -346,7 +346,7 @@ if [ -d "$CMD_SRC" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# §7. 에이전트 → agents/*.toml (레거시 스캐폴드) — literal ''' + spawnable 필터(AC#3)
+# §7. agents -> agents/*.toml (legacy scaffold) — literal ''' + spawnable filter (AC#3)
 # ---------------------------------------------------------------------------
 nagt=0
 nagt_skipped=0
@@ -359,23 +359,23 @@ if [ -d "$AGT_SRC" ]; then
     model="$(fm_val "$f" model)"
     spawnable="$(fm_val "$f" spawnable)"
 
-    # spawnable:false(현재 00-paul-team-lead.md 1건) → TOML 방출 제외(story-05 AC#3 — 18파일 방출
-    # 버그 수정: Paul은 팀원으로 스폰되지 않으므로 서브에이전트 TOML 자체가 성립하지 않는다).
+    # spawnable:false (currently one file, 00-paul-team-lead.md) -> excluded from TOML emission (story-05 AC#3 — fixes
+    # the 18-file emission bug: Paul is never spawned as a teammate, so a subagent TOML makes no sense for him).
     if [ "$spawnable" = "false" ]; then
       nagt_skipped=$((nagt_skipped+1))
       [ "$WRITE" != "1" ] && say "  [agent]  $slug.toml  SKIP(spawnable:false)"
       continue
     fi
 
-    # description = 본문 첫 비어있지 않은 non-heading 줄
+    # description = the body's first non-empty, non-heading line
     desc="$(first_body_description "$f")"
     [ -z "$desc" ] && desc="BATHOS role $slug"
     nagt=$((nagt+1))
 
     if [ "$WRITE" = "1" ]; then
       body="$(body_after_fm "$f")"
-      # AC#3: developer_instructions 본문에 리터럴 ''' 이 등장하면 TOML로 안전 표현이 불가하다
-      # (TOML엔 문자열 연결 연산자가 없어 "분할"이 실질적으로 불가능 — 정직 오류로 중단).
+      # AC#3: if a literal ''' appears in the developer_instructions body, TOML cannot express it safely
+      # (TOML has no string-concatenation operator, so "splitting" is effectively impossible — stop with an honest error).
       if printf '%s' "$body" | grep -qF "'''"; then
         echo "오류: $slug — developer_instructions 본문에 literal ''' 등장, TOML 리터럴 문자열로 안전 표현 불가(AC#3 정직 오류)" >&2
         exit 1
@@ -399,16 +399,16 @@ if [ -d "$AGT_SRC" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# §8. 에이전트 → .codex/agents/*.toml (정본, CT-SUBAGENT — story-11/Stephen 요청)
-#     레거시(§7)와 같은 소스·같은 spawnable 필터·같은 literal ''' 규율이지만, 여기는 배포 정본이라
-#     model 필드에 실값을 채우고 오케스트레이션 표준 문구를 붙인다. 두 절이 거의 같은 루프를 반복하는
-#     이유: §7은 "미리보기 스캐폴드"(레거시 --dest 하위호환, story-05 AC#6)이고 §8은 "story-11 배포
-#     정본"이라 목적이 달라 여기서 억지로 합치면 각 절의 변경 이유가 서로 얽힌다(단일 책임 유지).
+# §8. agents -> .codex/agents/*.toml (canonical, CT-SUBAGENT — story-11/Stephen's request)
+#     Same source, same spawnable filter and same literal ''' discipline as legacy (§7), but this is the release
+#     canon, so the model field gets a real value and the standard orchestration text is appended. Why the two
+#     sections repeat an almost identical loop: §7 is a "preview scaffold" (legacy --dest backwards compat, story-05
+#     AC#6) while §8 is the "story-11 release canon" — different purposes, and force-merging them would entangle each section's reason to change (single responsibility kept).
 # ---------------------------------------------------------------------------
 
-# model 매핑(story-11/SS10 정본 — stephen-model-mapping.md §1, 리드 v0.145.0+ 채택 확정 반영).
-# 이 두 함수만 룩업이고, 나머지 텍스트(주석·오케스트레이션 문구)는 정본 문서에서 그대로 복사한 상수다.
-model_for(){ # $1 = base frontmatter model 값(claude-fable-5|claude-sonnet-5)
+# The model mapping (story-11/SS10 canon — stephen-model-mapping.md §1, reflecting the lead's confirmed v0.145.0+ adoption).
+# Only these two functions are lookups; every other text (comments, orchestration wording) is a constant copied verbatim from the canonical documents.
+model_for(){ # $1 = the base frontmatter model value (claude-fable-5|claude-sonnet-5)
   case "$1" in
     claude-fable-5) printf 'gpt-5.6-sol' ;;
     claude-sonnet-5) printf 'gpt-5.5' ;;
@@ -423,7 +423,7 @@ effort_for(){
   esac
 }
 
-# 잔존 제약 주석 — stephen-model-mapping.md §4 정본 텍스트 그대로(재작문 금지, 날조/과장 리스크 회피).
+# Residual-constraint note — stephen-model-mapping.md §4 canonical text verbatim (no rewriting; avoids fabrication/overclaiming risk).
 MODEL_CONSTRAINT_NOTE(){
   cat <<'BLOCK'
 # ⚠️ 잔존 제약(2026-07-23 확인, [실측]/[문서확정] 아님 — 커뮤니티 재현 수준, 상세: stephen-model-mapping.md#3):
@@ -435,9 +435,9 @@ MODEL_CONSTRAINT_NOTE(){
 BLOCK
 }
 
-# 오케스트레이션 표준 블록 A+B — stephen-orchestration.md 정본 텍스트 그대로(재작문 금지).
-# "TOML/skills 삽입 위치" 절 지정: 개별 role TOML엔 A+B만(C·D는 세션 전역/스폰 의미론이라 페르소나
-# 파일엔 불필요 — AGENTS.md·wave skills 전용).
+# Standard orchestration blocks A+B — stephen-orchestration.md canonical text verbatim (no rewriting).
+# As the "TOML/skills insertion points" section specifies: A+B only in an individual role TOML (C and D carry
+# session-global/spawn semantics, unnecessary in a persona file — they are for AGENTS.md and the wave skills).
 ORCH_BLOCK_AB(){
   cat <<'BLOCK'
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,40 +1,40 @@
 #!/usr/bin/env bash
 # =============================================================================
 # BATHOS Dynamis — scripts/uninstall.sh
-# CF-B4 / SS11 (Should) — 플러그인 폴더 "밖" 외부 상태 정리 1급 스크립트.
+# CF-B4 / SS11 (Should) — first-class script for cleaning up external state "outside" the plugin folder.
 #
-# ★★★ 실행순서 계약(핵심 엣지케이스, ponytail 확인 사실) ★★★
-#   호스트의 플러그인 제거 명령은 이 스크립트 파일 자체를 먼저 지운다.
-#   반드시 "호스트 제거 명령보다 먼저" 이 스크립트를 실행해야 한다.
-#   (스크립트가 이미 사라진 뒤라면 아래 §README "수동 정리 경로"를 따를 것 —
-#    docs/uninstall-kr.md 참조)
+# ★★★ Execution-order contract (the key edge case, confirmed on ponytail) ★★★
+#   The host's plugin-removal command deletes this script file itself first.
+#   So this script must always be run "before the host removal command".
+#   (If the script is already gone, follow §README "manual cleanup path" below —
+#    see docs/uninstall-kr.md)
 #
-# 정리 대상(명시적 목록 — 암묵 글롭 삭제 금지, careful 정신 계승):
-#   1. ${BATHOS_STATE_DIR}/session-flags.json   (plan_mode/intensity 세션 플래그)
-#   2. ${BATHOS_HOME}/.claude/settings.json 의 statusLine 엔트리
-#      (bathos 관련 엔트리만 정밀 제거 — 파일 전체 재작성 금지, .bak 백업 후 수정)
-#   3. ${BATHOS_CONFIG_DIR}/*                   (존재 시에만 — 전역 설정 잔여물)
+# Cleanup targets (an explicit list — no implicit glob deletion, inheriting the careful spirit):
+#   1. ${BATHOS_STATE_DIR}/session-flags.json   (plan_mode/intensity session flags)
+#   2. the statusLine entry inside ${BATHOS_HOME}/.claude/settings.json
+#      (surgically remove only bathos-related entries — never rewrite the whole file; edit after a .bak backup)
+#   3. ${BATHOS_CONFIG_DIR}/*                   (only when it exists — global-config leftovers)
 #
-# 명시적으로 건드리지 않는 것(SSOT 보호):
-#   - _state/manifest.json (프로젝트 SSOT, 삭제 대상 아님)
-#   - _state/audit-log.jsonl (append-only 감사 이력, 삭제 대상 아님)
+# Explicitly never touched (protecting the SSOT):
+#   - _state/manifest.json (the project SSOT, not a deletion target)
+#   - _state/audit-log.jsonl (append-only audit history, not a deletion target)
 #
-# UX 규약(ux-flow-map Flow C, design-handoff §2-4 그대로 구현):
-#   - dry-run 기본(인자 없으면 계획만 출력)
-#   - 파괴적 실행 앞단 강한 경고 + 항목별 결과 로그
-#   - `y/N`(기본 N) 또는 `--yes`
-#   - 부분 실패는 성공/실패를 분리 표기(전체를 죽이지 않음)
-#   - 완료 후 "다음 행동" 안내(막다른 골목 금지)
+# UX contract (implements ux-flow-map Flow C and design-handoff §2-4 as written):
+#   - dry-run by default (with no arguments it only prints the plan)
+#   - a strong warning ahead of the destructive run + a per-item result log
+#   - `y/N` (defaults to N) or `--yes`
+#   - partial failure is reported as separate success/failure counts (it does not kill the whole run)
+#   - a "next action" hint once finished (no dead ends)
 #
-# exit: 0=정상 완료(dry-run 포함), 1=사용자 취소 또는 부분 실패 존재
+# exit: 0=finished normally (dry-run included), 1=user cancelled, or partial failures exist
 # =============================================================================
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BATHOS_ROOT="${BATHOS_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 
-# 테스트 가능성을 위해 전부 환경변수로 오버라이드 가능(기존 훅 관례 계승 —
-# 실제 $HOME을 건드리지 않고 픽스처로 검증할 수 있어야 한다).
+# All of these are overridable by env var for testability (inheriting the existing hook
+# convention — it has to be verifiable with fixtures without touching the real $HOME).
 BATHOS_STATE_DIR="${BATHOS_STATE_DIR:-$BATHOS_ROOT/_state}"
 BATHOS_HOME="${BATHOS_HOME:-$HOME}"
 BATHOS_CONFIG_DIR="${BATHOS_CONFIG_DIR:-$BATHOS_HOME/.config/bathos}"
@@ -68,7 +68,7 @@ failmsg(){ printf '%s ✗ %s\n' "$PREFIX" "$*"; }
 warn "되돌릴 수 없음 — 호스트의 플러그인 제거 명령보다 먼저 이 스크립트를 실행하세요."
 warn "  (호스트 제거가 먼저 실행되면 이 스크립트 파일 자체가 함께 삭제됩니다.)"
 
-# --- 대상 계획 수립 ----------------------------------------------------------
+# --- Build the target plan ---------------------------------------------------
 declare -a PLAN_DESC=()
 declare -a PLAN_KIND=()   # file | jsonkey | dircontents
 declare -a PLAN_PATH=()
@@ -122,7 +122,7 @@ if [[ "$ASSUME_YES" -ne 1 ]]; then
   esac
 fi
 
-# --- 실제 삭제 실행 -----------------------------------------------------------
+# --- Perform the actual deletion ----------------------------------------------
 SUCCESS=0
 FAILED=0
 
@@ -140,8 +140,8 @@ remove_file() {
 remove_dir_contents() {
   local dir="$1"
   local any_fail=0
-  # 암묵 글롭 전체삭제(rm -rf) 대신 항목 단위로 순회(careful 정신 — 개별 실패가
-  # 전체를 죽이지 않도록, 그리고 careful-guard의 광범위 삭제 차단과도 정합).
+  # Walk entry by entry instead of an implicit whole-glob delete (rm -rf) — the careful spirit:
+  # a single failure must not kill the rest, and it matches careful-guard's block on broad deletes.
   local entry
   for entry in "$dir"/* "$dir"/.[!.]*; do
     [[ -e "$entry" ]] || continue
@@ -164,7 +164,7 @@ remove_statusline_key() {
     return
   fi
 
-  # bathos 관련 엔트리인지 확인(무관한 statusLine 설정을 실수로 지우지 않기 위함).
+  # Confirm the entry really is bathos-related (so an unrelated statusLine setting is never wiped by mistake).
   local is_bathos
   is_bathos="$(jq -r '(.statusLine.command // "") | test("bathos"; "i")' "$path" 2>/dev/null || echo false)"
   if [[ "$is_bathos" != "true" ]]; then

--- a/scripts/wsl-setup.sh
+++ b/scripts/wsl-setup.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 # =============================================================================
-# BATHOS — wsl-setup.sh   (WSL 프리플라이트 · 복구)
-# WSL(Windows Subsystem for Linux)에서 BATHOS를 쓰기 전에 한 번 실행한다.
+# BATHOS — wsl-setup.sh   (WSL preflight · repair)
+# Run this once before using BATHOS on WSL (Windows Subsystem for Linux).
 #
-#   ./scripts/wsl-setup.sh            점검 + 복구(줄바꿈 LF 정규화·실행비트)
-#   ./scripts/wsl-setup.sh --check    점검만(수정하지 않음)
+#   ./scripts/wsl-setup.sh            check + repair (normalize line endings to LF, exec bit)
+#   ./scripts/wsl-setup.sh --check    check only (changes nothing)
 #
-# 배경: WSL은 리눅스 환경이므로 BATHOS의 **bash 버전(.sh 훅 + 리눅스 `bathos`
-# 바이너리)** 을 그대로 쓴다(Windows PowerShell 포트 .ps1은 WSL에서 불필요).
-# 유일한 함정은 저장소를 **Windows에서 CRLF로 클론**한 경우 — `.sh`의 shebang이
-# `#!/usr/bin/env bash^M`이 되어 `bad interpreter` 오류가 난다. `.gitattributes`가
-# 앞으로는 이를 막지만, 이미 CRLF로 받은 트리를 이 스크립트가 LF로 복구한다.
+# Background: WSL is a Linux environment, so it uses BATHOS's **bash edition (.sh hooks
+# plus the Linux `bathos` binary)** as-is (the Windows PowerShell port .ps1 is not needed here).
+# The one trap is a repo **cloned with CRLF on Windows** — the shebang of a `.sh` becomes
+# `#!/usr/bin/env bash^M` and you get a `bad interpreter` error. `.gitattributes` prevents
+# that from now on, but a tree that already arrived as CRLF is repaired to LF by this script.
 #
-# 안전: 아무것도 삭제하지 않는다. .sh 파일의 CR 제거 + 실행비트 부여만 한다(멱등).
-# 이식성: bash 3.2+(macOS 기본) 호환 — mapfile/연관배열 미사용.
+# Safety: deletes nothing. It only strips CR from .sh files and grants the exec bit (idempotent).
+# Portability: bash 3.2+ compatible (the macOS default) — no mapfile, no associative arrays.
 # =============================================================================
 set -uo pipefail
 
@@ -25,7 +25,7 @@ say()  { printf '\033[0;36m[bathos-wsl]\033[0m %s\n' "$*"; }
 warn() { printf '\033[0;33m[bathos-wsl] ⚠ %s\033[0m\n' "$*" >&2; }
 ok()   { printf '\033[0;32m[bathos-wsl] ✓ %s\033[0m\n' "$*"; }
 
-# 제품 트리의 .sh 파일을 나열(core/target·.git·node_modules 제외).
+# List the .sh files in the product tree (excluding core/target, .git, node_modules).
 list_sh() {
   find "$PKG_ROOT" -type f -name '*.sh' \
     -not -path '*/core/target/*' \
@@ -33,7 +33,7 @@ list_sh() {
     -not -path '*/node_modules/*' 2>/dev/null | sort
 }
 
-# --- 1. WSL 여부 안내 (강제는 아님 — 리눅스/macOS에서도 무해하게 동작) -----------
+# --- 1. Report whether this is WSL (not enforced — harmless on Linux/macOS too) --
 if grep -qiE '(microsoft|wsl)' /proc/version 2>/dev/null; then
   say "WSL 환경 감지됨 — BATHOS는 여기서 bash(.sh) 버전으로 동작합니다."
 else
@@ -43,7 +43,7 @@ fi
 TOTAL_SH="$(list_sh | wc -l | tr -d ' ')"
 say "검사 대상 .sh: ${TOTAL_SH}개"
 
-# --- 2. CRLF 탐지 + (복구 모드면) LF 정규화 --------------------------------------
+# --- 2. Detect CRLF and, in repair mode, normalize to LF -------------------------
 crlf_count=0
 fixed_count=0
 while IFS= read -r f; do
@@ -74,7 +74,7 @@ else
   say "$fixed_count개 파일을 LF로 정규화했습니다."
 fi
 
-# --- 3. 실행비트 부여 (복구 모드) ------------------------------------------------
+# --- 3. Set the exec bit (repair mode) -------------------------------------------
 if [ "$CHECK_ONLY" -eq 0 ]; then
   while IFS= read -r f; do
     [ -n "$f" ] || continue
@@ -83,15 +83,15 @@ if [ "$CHECK_ONLY" -eq 0 ]; then
   ok ".sh 실행비트 확인/부여 완료."
 fi
 
-# --- 4. 의존성 점검 (WSL=리눅스 → apt 안내) --------------------------------------
+# --- 4. Dependency check (WSL is Linux -> apt hints) -----------------------------
 say "의존성 점검:"
 if command -v cargo >/dev/null 2>&1; then ok "cargo 있음 ($(cargo --version 2>/dev/null | awk '{print $2}'))"; else warn "Rust 미설치 — https://rustup.rs (WSL 안에서 설치). 엔진 빌드에 필요."; fi
 if command -v jq >/dev/null 2>&1; then ok "jq 있음"; else warn "jq 미설치 — 'sudo apt-get update && sudo apt-get install -y jq' (bash 훅의 JSON 파싱에 필요)."; fi
 if command -v claude >/dev/null 2>&1; then ok "claude CLI 있음"; else warn "Claude Code CLI 미발견 — WSL 안에 설치된 Claude Code로 실행하세요(v2.1.32+)."; fi
 
-# --- 5. 엔진 바이너리 상태 -------------------------------------------------------
-# WSL은 리눅스이므로 네이티브 바이너리는 `bathos`(ELF)다. 실수의 핵심은 Windows에서
-# 빌드한 `bathos.exe`(PE)를 WSL로 들고 오는 것 — OS 무관하게 그 경우만 경고한다.
+# --- 5. Engine binary status -----------------------------------------------------
+# WSL is Linux, so the native binary is `bathos` (ELF). The classic mistake is carrying a
+# `bathos.exe` (PE) built on Windows into WSL — we warn about exactly that case, on any OS.
 LINUX_BIN="$PKG_ROOT/core/target/release/bathos"
 if [ -x "$LINUX_BIN" ]; then
   btype="$(file "$LINUX_BIN" 2>/dev/null || true)"
@@ -104,7 +104,7 @@ else
   say "엔진 미빌드 — WSL 안에서: cd core && cargo build --release  (→ core/target/release/bathos)"
 fi
 
-# --- 6. 다음 단계 ----------------------------------------------------------------
+# --- 6. Next steps ---------------------------------------------------------------
 printf '\n'
 say "다음 단계(WSL):"
 printf '  1) 엔진 빌드:   cd core && cargo build --release && cd ..\n'


### PR DESCRIPTION
## 무엇을

s13에서 "오늘 커밋분"만 1차 정정하고(PR #37→#38, prod 반영 완료) 남겨 둔 **형제 셸 파일 11개**를 같은 규칙으로 정리한다. 이로써 저장소의 셸 주석 영어화가 완결된다.

규칙 출처는 신설이 아니라 **기존 명문 규칙**이다 — `.claude/agents/_base/{08,09,10,13,14}.md` "코드 주석 표준" + `.claude/agents/_preamble/ponytail-inject-kr.md` §언어(2026-07-21 `e33e13d`부터 존재).

## 범위 — 주석 전용, 코드 줄 변경 0건

`dist/tests/{test-check-rule-copies,test-host-detect,test-uninstall}.sh`
`scripts/{_test-bathos-panes,bathos-panes,check-codex-drift,glm-env,to-codex,uninstall,wsl-setup}.sh`
`scripts/codex-glm/verify-relay.sh`

**보존(출력이므로 한글 유지 — 288줄):** `printf`/`echo`/`say`/`err`/`warn` 메시지, 히어독 본문(생성 파일 내용·TOML 블록), 테스트 assertion 라벨, YAML/JSON 데이터 문자열.

## ⚠️ User 결정 — `--help` 영어화 수용

`scripts/to-codex.sh:79` 와 `scripts/codex-glm/verify-relay.sh:45` 는 자기 헤더 주석을 `grep '^#' "$0" | sed` 로 렌더해 **그대로 `--help` 출력으로 쓴다.** 즉 이 두 파일에서는 주석이 곧 사용자 노출 출력이며, 주석 영어화가 `--help` 를 영어로 바꾼다(to-codex 196줄, verify-relay 1줄).

s13 락인 결정 "사용자 노출 출력은 한글 유지"와 정면 충돌하므로 커밋을 보류했고, **User 가 규칙 일관성을 우선해 "그대로 수용"으로 확정**했다. 나머지 9파일의 출력 문자열은 종전대로 한글 유지다.

## 예외 1건(기록)

`scripts/bathos-panes.sh:143` 은 152행이 출력하는 한글 리터럴 `"[로드 실패] …"` 을 인용하는 주석이라, 번역하면 주석이 거짓이 된다 — 영어 주석 안에 그 리터럴만 원문으로 남겼다.

## 검증 (전부 실측)

| 검사 | 결과 |
|---|---|
| diff 전수 기계 검증 | 변경 484줄 중 비순수주석 8줄 = "코드+행끝주석" 4쌍. 코드 부분만 추출 비교 → **완전 동일 = 코드 줄 변경 0건 증명** |
| 파일별 행수 | HEAD 대비 **11/11 불변** |
| `bash -n` 구문검사 | **11/11 통과** |
| 한글 잔존 재탐지 | 히어독 구간 제외 후 진짜 셸 주석 중 한글 **1줄**(위 예외)뿐 |
| `check-codex-drift.sh` | **drift 0건, exit 0** (to-codex.sh 생성물 바이트 동일) |
